### PR TITLE
[FEAT] 예외처리 구현

### DIFF
--- a/src/main/java/com/jnulocker/common/exception/BusinessException.java
+++ b/src/main/java/com/jnulocker/common/exception/BusinessException.java
@@ -1,0 +1,14 @@
+package com.jnulocker.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/jnulocker/common/exception/CommonErrorCode.java
+++ b/src/main/java/com/jnulocker/common/exception/CommonErrorCode.java
@@ -1,0 +1,16 @@
+package com.jnulocker.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonErrorCode implements ErrorCode {
+    INVALID_INPUT_VALUE("C001", HttpStatus.BAD_REQUEST, "요청 값이 올바르지 않습니다."),
+    ;
+
+    private final String code;
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/jnulocker/common/exception/ErrorCode.java
+++ b/src/main/java/com/jnulocker/common/exception/ErrorCode.java
@@ -1,0 +1,13 @@
+package com.jnulocker.common.exception;
+
+import java.io.Serializable;
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode extends Serializable {
+
+    String getCode();
+
+    HttpStatus getHttpStatus();
+
+    String getMessage();
+}

--- a/src/main/java/com/jnulocker/common/exception/ErrorResponse.java
+++ b/src/main/java/com/jnulocker/common/exception/ErrorResponse.java
@@ -1,0 +1,23 @@
+package com.jnulocker.common.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+
+public record ErrorResponse(
+        String code,
+        Integer status,
+        String message,
+        @JsonInclude(JsonInclude.Include.NON_NULL) List<ValidationError> invalidParams) {
+
+    public ErrorResponse(ErrorCode errorCode) {
+        this(errorCode, null);
+    }
+
+    public ErrorResponse(ErrorCode errorCode, List<ValidationError> invalidParams) {
+        this(
+                errorCode.getCode(),
+                errorCode.getHttpStatus().value(),
+                errorCode.getMessage(),
+                invalidParams);
+    }
+}

--- a/src/main/java/com/jnulocker/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/jnulocker/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,42 @@
+package com.jnulocker.common.exception;
+
+import java.util.List;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.NonNull;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
+        ErrorResponse errorResponse = new ErrorResponse(errorCode);
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(errorResponse);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            @NonNull MethodArgumentNotValidException ex,
+            @NonNull HttpHeaders headers,
+            @NonNull HttpStatusCode status,
+            @NonNull WebRequest request) {
+        ErrorCode errorCode = CommonErrorCode.INVALID_INPUT_VALUE;
+        return makeErrorResponse(ex, errorCode);
+    }
+
+    private ResponseEntity<Object> makeErrorResponse(
+            MethodArgumentNotValidException ex, ErrorCode errorCode) {
+        List<ValidationError> invalidParams =
+                ex.getBindingResult().getFieldErrors().stream().map(ValidationError::of).toList();
+
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(new ErrorResponse(errorCode, invalidParams));
+    }
+}

--- a/src/main/java/com/jnulocker/common/exception/ValidationError.java
+++ b/src/main/java/com/jnulocker/common/exception/ValidationError.java
@@ -1,0 +1,10 @@
+package com.jnulocker.common.exception;
+
+import org.springframework.validation.FieldError;
+
+public record ValidationError(String field, String message) {
+
+    public static ValidationError of(final FieldError fieldError) {
+        return new ValidationError(fieldError.getField(), fieldError.getDefaultMessage());
+    }
+}


### PR DESCRIPTION
### 개요
close #3 

### 작업사항
- GlobalExceptionHandler를 이용한 예외처리 구현

  - 검증 예외의 경우 해당 필드를 포함해 응답 handleMethodArgumentNotValid
  - 최상위 비즈니스 예외 BusinessException를 두고 이를 상속하도록 구현

#### 예외처리 적용 방식

1. 자신이 적용할 도메인에 `exception` 패키지 생성
2. `도메인명ErrorCode`로 에러코드 열거형 생성 (`ErrorCode` 인터페이스 상속)
3. 에러코드 열거형에 예외들을 정의
4. 각 에러코드마다 1대1로 대응하는 비즈니스 예외 구현 (`BusinessException` 상속, 싱글톤으로 구현)
5. 싱글톤으로 구현하는 방식은, 생성자를 `private`으로 두고 `EXCEPTION`이라는 static 변수를 생성자 호출로 바로 초기화
6. 이때, 생성자에는 이에 대응하는 `ErrorCode` 열거형값을 넘겨주어야 함.
7. 구현한 예외를 `예외명.EXCEPTION`으로 throw

#### 코드 예시 - 인증 관련

- `ErrorCode`를 상속한 `AuthErrorCode` 열거형 정의
  ```java
  @Getter
  @RequiredArgsConstructor
  public enum AuthErrorCode implements ErrorCode {
      ACCESS_DENIED("A001", HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
      // 다른 예외 코드들...
      ;
  
      private final String code;
      private final HttpStatus httpStatus;
      private final String message;
  }
  ```

- 에러코드에 대응하는 비즈니스 예외클래스 정의
  ```java
  public class AccessDeniedException extends BusinessException {
  
      public static final BusinessException EXCEPTION = new AccessDeniedException();
  
      private AccessDeniedException() {
          super(AuthErrorCode.ACCESS_DENIED);
      }
  }
  ```

- 예외처리시 `EXCEPTION` 인스턴스 사용
  ```java
  private void checkUserRole(Long userId, Role[] roles) {
      User user = userService.getUserByIdOrThrow(userId);
      if (!List.of(roles).contains(user.getRole())) {
          throw AccessDeniedException.EXCEPTION;
      }
  }
  ```

### 변경로직

### 테스트 결과

### reference

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인
