### PR TITLE
[DOCS] Swagger 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
+
+    // p6spy
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.10.0'
 
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/jnulocker/common/response/ResponseEntityGenerator.java
+++ b/src/main/java/com/jnulocker/common/response/ResponseEntityGenerator.java
@@ -4,16 +4,18 @@ import com.jnulocker.common.exception.ErrorCode;
 import com.jnulocker.common.exception.ErrorResponse;
 import com.jnulocker.common.exception.ValidationError;
 import java.util.List;
+import lombok.experimental.UtilityClass;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+@UtilityClass
 public class ResponseEntityGenerator {
     public static <D> ResponseEntity<D> success(D data, HttpStatus status) {
-        return new ResponseEntity<>(data, status);
+        return ResponseEntity.status(status).body(data);
     }
 
     public static ResponseEntity<Void> success(HttpStatus status) {
-        return success(null, status);
+        return ResponseEntity.status(status).build();
     }
 
     public static ResponseEntity<ErrorResponse> fail(ErrorCode errorCode) {

--- a/src/main/java/com/jnulocker/common/swagger/ApiExceptionExamples.java
+++ b/src/main/java/com/jnulocker/common/swagger/ApiExceptionExamples.java
@@ -1,0 +1,36 @@
+package com.jnulocker.common.swagger;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * API 메서드의 예외 응답 예시를 Swagger 문서에 표시하기 위한 어노테이션
+ *
+ * <p>Controller의 메서드에 적용하여 {@link ExceptionDoc} 어노테이션으로 정의된 문서 내용을 Swagger에 표시합니다.
+ *
+ * <p>사용 예시:
+ *
+ * <pre>{@code
+ * @RestController
+ * public class CommentController {
+ *     // ...
+ *     @ApiExceptionExamples(DeleteCommentExceptionDocs.class)  // 예외 상황을 정의한 클래스를 지정
+ *     public ApiResponse<CustomBody<Void>> deleteComment(
+ *             // ...
+ *     ) {
+ *         // ...
+ *     }
+ * }
+ * }</pre>
+ *
+ * @see SwaggerExceptionDoc
+ * @see ExceptionDoc
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiExceptionExamples {
+    /** 해당 API에서 발생할 수 있는 예외들이 정의된 문서화 클래스를 지정합니다. */
+    Class<? extends SwaggerExceptionDoc> value();
+}

--- a/src/main/java/com/jnulocker/common/swagger/ExceptionDoc.java
+++ b/src/main/java/com/jnulocker/common/swagger/ExceptionDoc.java
@@ -1,0 +1,45 @@
+package com.jnulocker.common.swagger;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.stereotype.Component;
+
+/**
+ * 예외 문서화를 위한 클래스임을 나타내고 스프링 빈으로 등록하는 어노테이션
+ *
+ * <p>예외 예시들을 그룹화하고 관리하기 위한 클래스에 적용합니다. <br>
+ * 이 클래스들은 {@link SwaggerExceptionDoc} 인터페이스를 구현해야 합니다. 각 예외 케이스는 {@link ExplainError} 어노테이션이 붙은 필드로
+ * 정의됩니다.
+ *
+ * <p>사용 예시:
+ *
+ * <pre>{@code
+ * @ExceptionDoc    // 이 어노테이션을 붙여서 스프링 빈으로 등록
+ * @NoArgsConstructor(access = AccessLevel.PRIVATE)
+ * public class GetCommentExceptionDocs implements SwaggerExceptionDoc {
+ *
+ *     // ...
+ * }
+ * }</pre>
+ *
+ * @see SwaggerExceptionDoc
+ * @see ExplainError
+ * @see Component
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented // JavaDoc에 이 어노테이션의 정보를 표시하도록 지정
+@Component
+public @interface ExceptionDoc {
+    /**
+     * 스프링 빈의 이름을 지정합니다.
+     *
+     * <p>{@link Component} 어노테이션의 value 속성과 동일한 역할을 합니다. 지정하지 않을 경우 기본 빈 명명 규칙을 따릅니다.
+     */
+    @AliasFor(annotation = Component.class)
+    String value() default "";
+}

--- a/src/main/java/com/jnulocker/common/swagger/ExplainError.java
+++ b/src/main/java/com/jnulocker/common/swagger/ExplainError.java
@@ -1,0 +1,36 @@
+package com.jnulocker.common.swagger;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 예외 상황에 대한 설명을 제공하는 어노테이션 <br>
+ * ExceptionDoc 클래스의 필드에 적용하여 각 예외 상황에 대한 상세 설명을 Swagger 문서에 표시한다.
+ *
+ * <p>사용 예시:
+ *
+ * <pre>{@code
+ * @ExceptionDoc
+ * @NoArgsConstructor(access = AccessLevel.PRIVATE)
+ * public class GetCommentExceptionDocs implements SwaggerExceptionDoc {
+ *
+ *     @ExplainError("게시글이 존재하지 않을 때 발생하는 예외입니다.")
+ *     public static final BusinessException 게시글이_존재하지_않을_때 = PostNotFoundException.EXCEPTION;
+ *
+ *     // ...
+ * }
+ * }</pre>
+ *
+ * @see ExceptionDoc
+ * @see SwaggerExceptionDoc
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ExplainError {
+    /** 예외 상황에 대한 설명을 지정한다. */
+    String value() default "";
+}

--- a/src/main/java/com/jnulocker/common/swagger/SwaggerExampleHolder.java
+++ b/src/main/java/com/jnulocker/common/swagger/SwaggerExampleHolder.java
@@ -1,0 +1,7 @@
+package com.jnulocker.common.swagger;
+
+import io.swagger.v3.oas.models.examples.Example;
+import lombok.Builder;
+
+@Builder
+public record SwaggerExampleHolder(Example examplesItem, String name, int code) {}

--- a/src/main/java/com/jnulocker/common/swagger/SwaggerExceptionDoc.java
+++ b/src/main/java/com/jnulocker/common/swagger/SwaggerExceptionDoc.java
@@ -1,0 +1,35 @@
+package com.jnulocker.common.swagger;
+
+/**
+ * Swagger 문서에 표시될 예외 예시들을 정의하는 클래스들의 인터페이스
+ *
+ * <p>이 인터페이스를 구현하는 클래스는 {@link ExceptionDoc} 어노테이션과 함께 사용되어야 하며, {@link ExplainError} 어노테이션이 붙은
+ * 필드들로 각각의 예외 케이스를 정의해야 합니다.
+ *
+ * <p>사용 예시:
+ *
+ * <pre>{@code
+ * @ExceptionDoc
+ * @NoArgsConstructor(access = AccessLevel.PRIVATE)
+ * public class CreateCommentExceptionDocs implements SwaggerExceptionDoc {
+ *
+ *     @ExplainError("회원이 존재하지 않을 때 발생하는 예외입니다.")
+ *     public static final BusinessException 회원이_존재하지_않을_때 = MemberNotFoundException.EXCEPTION;
+ *
+ *     // 다른 예외 케이스들...
+ * }
+ * }</pre>
+ *
+ * <p>이 인터페이스를 구현한 클래스는 다음 규칙을 따라야 합니다:
+ *
+ * <ul>
+ *   <li>모든 예외 필드는 {@code static final}로 선언되어야 합니다
+ *   <li>각 예외 필드는 {@link ExplainError} 어노테이션으로 설명되어야 합니다
+ *   <li>예외 필드의 이름은 해당 예외 상황을 명확히 설명해야 합니다
+ * </ul>
+ *
+ * @see ExceptionDoc
+ * @see ExplainError
+ * @see ApiExceptionExamples
+ */
+public interface SwaggerExceptionDoc {}

--- a/src/main/java/com/jnulocker/common/swagger/exception/ExampleGenerationFailureException.java
+++ b/src/main/java/com/jnulocker/common/swagger/exception/ExampleGenerationFailureException.java
@@ -1,0 +1,12 @@
+package com.jnulocker.common.swagger.exception;
+
+import com.jnulocker.common.exception.BusinessException;
+
+public class ExampleGenerationFailureException extends BusinessException {
+
+    public static final BusinessException EXCEPTION = new ExampleGenerationFailureException();
+
+    private ExampleGenerationFailureException() {
+        super(SwaggerErrorCode.EXAMPLE_GENERATION_FAILURE);
+    }
+}

--- a/src/main/java/com/jnulocker/common/swagger/exception/SwaggerErrorCode.java
+++ b/src/main/java/com/jnulocker/common/swagger/exception/SwaggerErrorCode.java
@@ -1,0 +1,18 @@
+package com.jnulocker.common.swagger.exception;
+
+import com.jnulocker.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SwaggerErrorCode implements ErrorCode {
+    EXAMPLE_GENERATION_FAILURE(
+            "S001", HttpStatus.INTERNAL_SERVER_ERROR, "Swagger 예제 생성 중 오류가 발생했습니다."),
+    ;
+
+    private final String code;
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/jnulocker/config/SecurityConfig.java
+++ b/src/main/java/com/jnulocker/config/SecurityConfig.java
@@ -1,0 +1,32 @@
+package com.jnulocker.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsUtils;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable);
+
+        http.authorizeHttpRequests(
+                requestMatcherRegistry ->
+                        requestMatcherRegistry
+                                .requestMatchers(CorsUtils::isPreFlightRequest)
+                                .permitAll()
+                                .requestMatchers(
+                                        "/api-docs/**",
+                                        "/swagger-resources/**",
+                                        "/swagger-ui/**")
+                                .permitAll()
+                                .anyRequest()
+                                .authenticated());
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/jnulocker/config/SecurityConfig.java
+++ b/src/main/java/com/jnulocker/config/SecurityConfig.java
@@ -20,9 +20,7 @@ public class SecurityConfig {
                                 .requestMatchers(CorsUtils::isPreFlightRequest)
                                 .permitAll()
                                 .requestMatchers(
-                                        "/api-docs/**",
-                                        "/swagger-resources/**",
-                                        "/swagger-ui/**")
+                                        "/api-docs/**", "/swagger-resources/**", "/swagger-ui/**")
                                 .permitAll()
                                 .anyRequest()
                                 .authenticated());

--- a/src/main/java/com/jnulocker/config/SwaggerConfig.java
+++ b/src/main/java/com/jnulocker/config/SwaggerConfig.java
@@ -1,19 +1,44 @@
 package com.jnulocker.config;
 
+import static java.util.stream.Collectors.groupingBy;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import com.jnulocker.common.exception.BusinessException;
+import com.jnulocker.common.exception.ErrorCode;
+import com.jnulocker.common.exception.ErrorResponse;
+import com.jnulocker.common.swagger.ApiExceptionExamples;
+import com.jnulocker.common.swagger.ExplainError;
+import com.jnulocker.common.swagger.SwaggerExampleHolder;
+import com.jnulocker.common.swagger.exception.ExampleGenerationFailureException;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import jakarta.servlet.ServletContext;
+import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 
+@Slf4j
 @Configuration
+@RequiredArgsConstructor
 public class SwaggerConfig {
 
     private static final String SCHEME = "bearer"; // basic, bearer, oauth2
@@ -22,6 +47,8 @@ public class SwaggerConfig {
     private static final String PROJECT_NAME = "JNU-Locker";
     private static final String PROJECT_URL = "https://github.com/DDING-MIN-YEONG/JNU-LOCKER-BE";
     private static final String DOCUMENT_VERSION = "v0.0.1";
+
+    private final ApplicationContext applicationContext;
 
     @Bean
     public OpenAPI openAPI(ServletContext servletContext) {
@@ -59,5 +86,90 @@ public class SwaggerConfig {
                 .title(PROJECT_NAME + " API문서")
                 .description(PROJECT_NAME + "의 API 문서 입니다.")
                 .license(license);
+    }
+
+    @Bean
+    public OperationCustomizer customizer() {
+        return (operation, handlerMethod) -> {
+            ApiExceptionExamples apiExceptionExamples =
+                    handlerMethod.getMethodAnnotation(ApiExceptionExamples.class);
+
+            if (apiExceptionExamples != null) {
+                generateExceptionResponseExamples(
+                        operation, apiExceptionExamples.value()); // 예외 응답 예제 생성 및 Swagger에 추가
+            }
+
+            operation.addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME));
+            return operation;
+        };
+    }
+
+    public void generateExceptionResponseExamples(Operation operation, Class<?> type) {
+        ApiResponses responses = operation.getResponses();
+
+        Object bean = applicationContext.getBean(type);
+        Field[] declaredFields = bean.getClass().getDeclaredFields();
+
+        // 해당 엔드포인트에 대한 예외 응답들을 SwaggerExampleHolder로 만들고 HTTP 상태 코드별로 그룹화
+        Map<Integer, List<SwaggerExampleHolder>> statusWithExampleHolders =
+                Arrays.stream(declaredFields)
+                        .filter(field -> field.getAnnotation(ExplainError.class) != null)
+                        .filter(field -> BusinessException.class.isAssignableFrom(field.getType()))
+                        .map(
+                                field -> {
+                                    try {
+                                        BusinessException exception =
+                                                (BusinessException) field.get(bean);
+                                        ExplainError explainError =
+                                                field.getAnnotation(ExplainError.class);
+
+                                        ErrorCode errorCode = exception.getErrorCode();
+                                        String description = explainError.value();
+
+                                        return SwaggerExampleHolder.builder()
+                                                .examplesItem(
+                                                        getSwaggerExample(errorCode, description))
+                                                .name(field.getName().replace('_', ' '))
+                                                .code(errorCode.getHttpStatus().value())
+                                                .build();
+                                    } catch (IllegalAccessException e) {
+                                        // 문서가 생성되지 않는 예외 케이스
+                                        throw ExampleGenerationFailureException.EXCEPTION;
+                                    }
+                                })
+                        .collect(groupingBy(SwaggerExampleHolder::code));
+
+        addExamplesToResponses(responses, statusWithExampleHolders);
+    }
+
+    private Example getSwaggerExample(ErrorCode errorCode, String description) { // 예외 응답 예제 생성
+        ErrorResponse errorResponse = new ErrorResponse(errorCode);
+
+        Example example = new Example();
+        example.value(errorResponse); // Example Value에 표시될 내용
+        example.description(description); // Example Description에 표시될 내용
+
+        return example;
+    }
+
+    private void addExamplesToResponses( // 예외 응답 예제를 Swagger 문서에 추가
+            ApiResponses responses,
+            Map<Integer, List<SwaggerExampleHolder>> statusWithExampleHolders) {
+        statusWithExampleHolders.forEach(
+                (status, exampleHolders) -> {
+                    ApiResponse apiResponse = new ApiResponse();
+                    Content content = new Content();
+                    MediaType mediaType = new MediaType();
+
+                    exampleHolders.forEach(
+                            exampleHolder ->
+                                    mediaType.addExamples(
+                                            exampleHolder.name(), exampleHolder.examplesItem()));
+
+                    content.addMediaType(APPLICATION_JSON_VALUE, mediaType);
+                    apiResponse.setContent(content);
+
+                    responses.addApiResponse(status.toString(), apiResponse);
+                });
     }
 }

--- a/src/main/java/com/jnulocker/config/SwaggerConfig.java
+++ b/src/main/java/com/jnulocker/config/SwaggerConfig.java
@@ -1,0 +1,63 @@
+package com.jnulocker.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import jakarta.servlet.ServletContext;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+
+@Configuration
+public class SwaggerConfig {
+
+    private static final String SCHEME = "bearer"; // basic, bearer, oauth2
+    private static final String BEARER_FORMAT = "JWT";
+    private static final String SECURITY_SCHEME_NAME = "access-token";
+    private static final String PROJECT_NAME = "JNU-Locker";
+    private static final String PROJECT_URL = "https://github.com/DDING-MIN-YEONG/JNU-LOCKER-BE";
+    private static final String DOCUMENT_VERSION = "v0.0.1";
+
+    @Bean
+    public OpenAPI openAPI(ServletContext servletContext) {
+
+        String contextPath = servletContext.getContextPath();
+        Server server = new Server().url(contextPath);
+
+        // JWT 토큰을 위한 SecurityScheme 정의
+        SecurityScheme securityScheme =
+                new SecurityScheme()
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme(SCHEME)
+                        .bearerFormat(BEARER_FORMAT)
+                        .in(SecurityScheme.In.HEADER)
+                        .name(HttpHeaders.AUTHORIZATION);
+
+        SecurityRequirement securityRequirement =
+                new SecurityRequirement().addList(SECURITY_SCHEME_NAME);
+
+        return new OpenAPI()
+                .servers(List.of(server))
+                .info(swaggerInfo())
+                .components(
+                        new Components().addSecuritySchemes(SECURITY_SCHEME_NAME, securityScheme))
+                .addSecurityItem(securityRequirement);
+    }
+
+    private Info swaggerInfo() {
+        License license = new License();
+        license.setUrl(PROJECT_URL);
+        license.setName(PROJECT_NAME);
+
+        return new Info()
+                .version(DOCUMENT_VERSION)
+                .title(PROJECT_NAME + " API문서")
+                .description(PROJECT_NAME + "의 API 문서 입니다.")
+                .license(license);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,7 @@
+server:
+  servlet:
+    context-path: /api
+
 spring:
   application:
     name: jnu-locker
@@ -29,6 +33,10 @@ logging:
       max-file-size: 10MB   # default: 10MB
       total-size-cap: 5GB   # default: 제한 없음
       file-name-pattern: ${LOGGING_DIR}/${LOGGING_FILE_NAME_PATTERN} # 압축해서 보관 -> 디스크 절약
+
+springdoc:
+  api-docs:
+    path: /api-docs # default: /v3/api-docs
 
 # p6spy 로깅 활성화 (JDBC 이벤트 로깅)
 decorator:


### PR DESCRIPTION
### 개요
close #4 

### 작업사항
- Swagger 를 적용해 API 문서를 생성
- 예외 커스텀 응답을 위한 어노테이션 정의
- Swagger 커스터마이징 설정
- 엔드포인트에 `/api` prefix 적용
    ```yaml
    server:
      servlet:
        context-path: /api
    ```


### 변경로직

### 테스트 결과

- 정상 응답과 예외 응답 예시

  <img width="400" alt="image" src="https://github.com/user-attachments/assets/793cb535-d465-4b64-a597-6a5bb0a9db6a" />

  <img width="400" alt="image" src="https://github.com/user-attachments/assets/5bbc2883-a861-45e8-8a53-e800baddf7ef" />


- Swagger 문서 생성 중 예외가 발생한 경우

  <img width="400" alt="image" src="https://github.com/user-attachments/assets/c076e500-3b11-45c1-b65c-d552de3b3f02" />

  <img width="400" alt="image" src="https://github.com/user-attachments/assets/150fffea-922f-40b4-9816-31e4ca602514" />

### 적용 방법

1. `SwaggerExceptionDoc`을 구현하는 `~ExceptionDocs` 클래스를 만들고 `@ExceptionDoc` 어노테이션 적용

    문서화에 해당하는 코드입니다.
    여기에는 해당 엔드포인트에서 발생하는 비즈니스 예외들을 정의합니다. `throw`로 던져지는 예외를 넣어주세요.

    ```java
    @ExceptionDoc
    @NoArgsConstructor(access = AccessLevel.PRIVATE)
    public class TestExceptionDocs implements SwaggerExceptionDoc {
    
        @ExplainError("첫 번째 에러 상황입니다.")
        public static final BusinessException 첫_번째_에러 = ErrorCaseOneException.EXCEPTION;
    
        @ExplainError("두 번째 에러 상황입니다.")
        public static final BusinessException 두_번째_에러 = ErrorCaseTwoException.EXCEPTION;
    
        // ...
    }
    ```

2. `@ApiExceptionExamples` 어노테이션을 해당 엔드포인트에 적용하고 문서화 클래스(`~Docs`)를 값으로 넘김

    Swagger에 예제(`Example`)를 등록하기 위한 작업입니다.

    ```java
    @RestController
    public class TestController {
    
        @GetMapping("/hello")
        @ApiExceptionExamples(TestExceptionDocs.class)
        public ResponseEntity<String> get() {
            return ResponseEntity.ok("hello");
        }
    }
    ```

예시로 사용한 `test` 도메인 구조

```
test
├── controller
│   └── TestController.java
├── docs
│   └── TestExceptionDocs.java
└── exception
    ├── ErrorCaseOneException.java
    ├── ErrorCaseThreeException.java
    ├── ErrorCaseTwoException.java
    └── TestErrorCode.java
```

### reference
- 구현한 부분에 대한 이해를 위해 `JavaDoc`을 적용했습니다.

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인
