### PR TITLE
[CHORE] Jib 및 docker compose 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.springframework.boot' version '3.4.3'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'com.diffplug.spotless' version '7.0.2'
+    id 'com.google.cloud.tools.jib' version '3.4.5'
 }
 
 group = 'com'
@@ -67,6 +68,36 @@ spotless {
         importOrder()               // import문 정렬
         trimTrailingWhitespace()    // 뒤에 공백 제거
         endWithNewline()            // 파일 끝에 개행 추가
+    }
+}
+
+jib {
+    def profile = System.getenv('PROFILE') ?: ''
+    def dockerUsername = System.getenv('DOCKER_USERNAME') ?: ''
+    def dockerPassword = System.getenv('DOCKER_PASSWORD') ?: ''
+    def dockerRepo = System.getenv('DOCKER_REPO') ?: ''
+
+    // 기본 이미지 태그가 없으면 tags 명시해도 latest 태그로 이미지가 생성됨
+    def imageTag = System.getenv('IMAGE_TAG') ?: ''
+    def imageName = dockerUsername && dockerRepo ? "$dockerUsername/$dockerRepo:$imageTag" : ''
+
+    from {
+        image = 'amazoncorretto:21-alpine-jdk'
+    }
+    to {
+        image = imageName
+        auth {
+            username = dockerUsername
+            password = dockerPassword
+        }
+    }
+    container {
+        jvmFlags = [
+            '-Dspring.profiles.active=' + profile,
+            '-Duser.timezone=Asia/Seoul',
+            '-Dfile.encoding=UTF-8',
+            '-XX:+UseContainerSupport'
+        ]
     }
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+services:
+  mysql:
+    container_name: mysql-jnu-locker
+    image: mysql:8.0
+    ports:
+      - "3306:3306"
+    environment:
+      TZ: Asia/Seoul
+      LC_ALL: C.UTF-8
+      MYSQL_ROOT_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USERNAME}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    healthcheck:
+      test: ["CMD", "mysql", "-u", "$MYSQL_USERNAME", "-p$MYSQL_PASSWORD", "-e", "SELECT 1;"]
+      start_period: 10s
+      start_interval: 3s
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    volumes:
+      - ${MYSQL_DATA_PATH}:/var/lib/mysql
+    networks:
+      - jnu-locker-network
+
+  was:
+    container_name: was-jnu-locker
+    image: ${DOCKER_USERNAME}/${DOCKER_REPO}:${IMAGE_TAG}
+    ports:
+      - "8080:8080"
+    env_file:
+      - .env
+    healthcheck:
+      test: [ "CMD-SHELL", "wget -q --spider http://localhost:8080$MANAGEMENT_BASE_PATH$HEALTH_CHECK_PATH || exit 1" ]
+      start_period: 20s
+      start_interval: 5s
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    depends_on:
+      mysql:
+        condition: service_healthy
+    volumes:
+      - ${WAS_LOG_PATH}:${LOGGING_DIR}
+    networks:
+      - jnu-locker-network
+
+networks:
+  jnu-locker-network:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     env_file:
       - .env
     healthcheck:
-      test: [ "CMD-SHELL", "wget -q --spider http://localhost:8080$MANAGEMENT_BASE_PATH$HEALTH_CHECK_PATH || exit 1" ]
+      test: [ "CMD-SHELL", "wget -q --spider http://localhost:8080$MANAGEMENT_BASE_PATH/health || exit 1" ]
       start_period: 20s
       start_interval: 5s
       interval: 10s

--- a/src/main/java/com/jnulocker/config/SecurityConfig.java
+++ b/src/main/java/com/jnulocker/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.jnulocker.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -10,6 +11,9 @@ import org.springframework.web.cors.CorsUtils;
 @Configuration
 public class SecurityConfig {
 
+    @Value(("${management.endpoints.web.base-path}"))
+    private String actuatorBasePath;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable);
@@ -19,8 +23,11 @@ public class SecurityConfig {
                         requestMatcherRegistry
                                 .requestMatchers(CorsUtils::isPreFlightRequest)
                                 .permitAll()
-                                .requestMatchers(
+                                .requestMatchers( // swagger
                                         "/api-docs/**", "/swagger-resources/**", "/swagger-ui/**")
+                                .permitAll()
+                                .requestMatchers( // actuator TODO: 접근 권한 설정 (ADMIN)
+                                        actuatorBasePath + "/health")
                                 .permitAll()
                                 .anyRequest()
                                 .authenticated());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,3 @@
-server:
-  servlet:
-    context-path: /api
-
 spring:
   application:
     name: jnu-locker
@@ -19,6 +15,16 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
+
+management:
+  endpoints:
+    web:
+      base-path: ${MANAGEMENT_BASE_PATH}
+    access:
+      default: none
+  endpoint:
+    health:
+      access: unrestricted
 
 logging:
   level:


### PR DESCRIPTION
### 개요
close #11 

### 작업사항
- Jib를 이용한 빌드 및 이미지 업로드 설정
- docker compose 설정
- `/api` context path 제거

### 변경로직
- `SecurityConfig` 에서 actuator 엔드포인트 요청 허용
- `build.gradle`에 `jib` 플러그인 추가 및 구성

### 테스트 결과
- `healthcheck` 및 `network` 적용된 모습

  <img width="264" alt="image" src="https://github.com/user-attachments/assets/69aefe50-001e-431a-8495-541786c57b8f" />

- `actuator`에서 기본적으로 제공하는 `healthcheck` 엔드포인트
  
  `dev` 및 `prod` 환경에서는 `.env` 파일에서 경로를 임의 값으로 수정해야 함

  <img width="400" alt="image" src="https://github.com/user-attachments/assets/8e43ed09-02c6-4199-8c12-1e533a5305cb" />



### reference
- actuator 엔드포인트의 경우 추후 `role` 등으로 허가된 사용자만 접근 가능하도록 수정해야 함
- `jib` 실행은 `Intellij`에서 `.env` 파일 내용을 주입해서 `IDE`로 실행해야 함

  `.env` 파일에 자신의 docker 계정 정보를 넣고 `docker hub`에서 이미지가 `IMAGE_TAG` 태그값으로 잘 올라가는지 확인하기

  ![image](https://github.com/user-attachments/assets/514dffdc-213d-4bfc-897d-2ffbc38439a8)
  <img width="974" alt="image" src="https://github.com/user-attachments/assets/73bc23ff-0d5e-4e03-a2c3-f0464d444a8d" />


### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인
