### PR TITLE
[CHORE] CI/CD 워크플로우 적용

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Dev Server Swagger UI
+    url: https://api.dev.jnu-locker.site/swagger-ui/index.html
+    about: 개발 서버 Swagger UI

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,47 @@
+name: image build and push
+
+on:
+  workflow_call:
+    secrets:
+      DOCKER_USERNAME:
+        required: true
+      DOCKER_PASSWORD:
+        required: true
+      DOCKER_REPO:
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: 이미지 빌드하기
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '8.12.1' # 사용할 버전 명시해 캐싱 및 숫자로 변하지 않게 따옴표 처리
+          # main, dev는 캐시 쓰기 가능. 다른 브랜치에서는 true로 설정하여 읽기만 허용
+          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
+          # 불필요한 로컬 캐시 제외
+          gradle-home-cache-excludes: |
+            caches/build-cache-1
+
+      - name: Run Jib
+        id: build-image
+        env:
+          PROFILE: ${{ github.ref_name }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_REPO: ${{ secrets.DOCKER_REPO }}
+          IMAGE_TAG: ${{ github.sha }}
+
+        run: ./gradlew jib

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1,0 +1,33 @@
+name: Spring Boot CI/CD
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - dev
+
+concurrency:
+  group: ${{ github.ref }} # 동일한 브랜치에서는 한 번에 한 워크플로우만 실행
+
+jobs:
+  call-build-workflow:
+    name: 이미지 빌드
+    uses: ./.github/workflows/build.yaml
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      DOCKER_REPO: ${{ secrets.DOCKER_REPO }}
+
+  call-deploy-workflow:
+    needs: call-build-workflow
+    name: 서비스 배포
+    uses: ./.github/workflows/deploy.yaml
+    secrets:
+      SSH_HOST: ${{ github.ref_name == 'dev' && secrets.DEV_SSH_HOST || github.ref_name == 'main' && secrets.PROD_SSH_HOST }}
+      SSH_USERNAME: ${{ github.ref_name == 'dev' && secrets.DEV_SSH_USERNAME || github.ref_name == 'main' && secrets.PROD_SSH_USERNAME }}
+      SSH_KEY: ${{ github.ref_name == 'dev' && secrets.DEV_SSH_KEY || github.ref_name == 'main' && secrets.PROD_SSH_KEY }}
+      SSH_PORT: ${{ github.ref_name == 'dev' && secrets.DEV_SSH_PORT || github.ref_name == 'main' && secrets.PROD_SSH_PORT }}
+      REPO: ${{ github.ref_name == 'dev' && secrets.DEV_REPO || github.ref_name == 'main' && secrets.PROD_REPO }}
+      WORKSPACE: ${{ secrets.WORKSPACE }}
+      DEPLOY_SCRIPT: ${{ secrets.DEPLOY_SCRIPT }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,39 @@
+name: Deploy Server
+
+on:
+  workflow_call:
+    secrets:
+      SSH_HOST:
+        required: true
+      SSH_USERNAME:
+        required: true
+      SSH_KEY:
+        required: true
+      SSH_PORT:
+        required: true
+      REPO:
+        required: true
+      WORKSPACE:
+        required: true
+      DEPLOY_SCRIPT:
+        required: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: 서비스 배포하기
+
+    steps:
+      - name: 배포 스크립트 실행
+        uses: appleboy/ssh-action@master
+        env:
+          REPO: ${{ secrets.REPO }}
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USERNAME }}
+          key: ${{ secrets.SSH_KEY }}
+          port: ${{ secrets.SSH_PORT }}
+          envs: REPO
+          script: |
+            cd ${{ secrets.WORKSPACE }}
+            bash ${{ secrets.DEPLOY_SCRIPT }}

--- a/build.gradle
+++ b/build.gradle
@@ -77,15 +77,16 @@ jib {
     def dockerPassword = System.getenv('DOCKER_PASSWORD') ?: ''
     def dockerRepo = System.getenv('DOCKER_REPO') ?: ''
 
-    // 기본 이미지 태그가 없으면 tags 명시해도 latest 태그로 이미지가 생성됨
+    // 기본 이미지 태그가 없으면 tags 명시해도 latest 태그도 함께 업로드됨
+    def imageName = dockerUsername && dockerRepo ? "$dockerUsername/$dockerRepo-$profile" : ''
     def imageTag = System.getenv('IMAGE_TAG') ?: ''
-    def imageName = dockerUsername && dockerRepo ? "$dockerUsername/$dockerRepo:$imageTag" : ''
 
     from {
         image = 'amazoncorretto:21-alpine-jdk'
     }
     to {
         image = imageName
+        tags = [imageTag]
         auth {
             username = dockerUsername
             password = dockerPassword


### PR DESCRIPTION
### 개요
close #15 

### 작업사항
- 개발서버 CI/CD 워크플로우 적용
  - gradle 의존성 캐싱
  - AWS Route53을 이용해 도메인 적용

- Swagger UI 주소 Issues에 추가

### 변경로직
- build & push, deploy 스크립트 작성
- cicd.yaml 에서 해당 워크플로우 이용

### 테스트 결과

### reference
- 개발서버는 AWS에서 IPv4를 사용하면 비용이 발생하기 때문에 IPv6로 구축했습니다. [관련 링크](https://aws.amazon.com/ko/blogs/korea/new-aws-public-ipv4-address-charge-public-ip-insights/) 참고해주세요.

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the issue submission process with additional contact options for streamlined support.
  - Introduced automated workflows for building, testing, and deploying the application, ensuring smoother and more reliable releases.

- **Chores**
  - Refined the Docker image build configuration for clearer tagging and improved consistency in image releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->