### PR TITLE
[FEAT] 소속대학 조회 API

### DIFF
--- a/src/main/java/com/jnulocker/config/SecurityConfig.java
+++ b/src/main/java/com/jnulocker/config/SecurityConfig.java
@@ -30,7 +30,8 @@ public class SecurityConfig {
                                         actuatorBasePath + "/health")
                                 .permitAll()
                                 .anyRequest()
-                                .authenticated());
+                                //                                .authenticated());
+                                .permitAll());
 
         return http.build();
     }

--- a/src/main/java/com/jnulocker/organization/adapter/in/OrganizationController.java
+++ b/src/main/java/com/jnulocker/organization/adapter/in/OrganizationController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class OrganizationController {
     private final OrganizationUseCase organizationUseCase;
 
-    @GetMapping("/affiliation")
+    @GetMapping("/affiliations")
     public ResponseEntity<Set<String>> getAffiliations() {
         Set<String> affiliations = organizationUseCase.findAffiliations();
         return new ResponseEntity<>(affiliations, HttpStatus.OK);

--- a/src/main/java/com/jnulocker/organization/adapter/in/OrganizationController.java
+++ b/src/main/java/com/jnulocker/organization/adapter/in/OrganizationController.java
@@ -1,0 +1,23 @@
+package com.jnulocker.organization.adapter.in;
+
+import com.jnulocker.organization.application.port.in.OrganizationUseCase;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class OrganizationController {
+    private final OrganizationUseCase organizationUseCase;
+
+    @GetMapping("/affiliation")
+    public ResponseEntity<Set<String>> getAffiliations() {
+        Set<String> affiliations = organizationUseCase.findAffiliations();
+        return new ResponseEntity<>(affiliations, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/jnulocker/organization/adapter/in/OrganizationController.java
+++ b/src/main/java/com/jnulocker/organization/adapter/in/OrganizationController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/v1")
+@RequestMapping("/v1/organizations")
 @RequiredArgsConstructor
 public class OrganizationController {
     private final OrganizationUseCase organizationUseCase;

--- a/src/main/java/com/jnulocker/organization/adapter/in/OrganizationController.java
+++ b/src/main/java/com/jnulocker/organization/adapter/in/OrganizationController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping("/v1")
 @RequiredArgsConstructor
 public class OrganizationController {
     private final OrganizationUseCase organizationUseCase;

--- a/src/main/java/com/jnulocker/organization/adapter/out/OrganizationPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/organization/adapter/out/OrganizationPersistenceAdapter.java
@@ -13,7 +13,6 @@ public class OrganizationPersistenceAdapter implements OrganizationLoadPort {
 
     @Override
     public List<Organization> findAll() {
-        List<Organization> organization = organizationRepository.findAll();
-        return organization;
+        return organizationRepository.findAll();
     }
 }

--- a/src/main/java/com/jnulocker/organization/adapter/out/OrganizationPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/organization/adapter/out/OrganizationPersistenceAdapter.java
@@ -1,0 +1,19 @@
+package com.jnulocker.organization.adapter.out;
+
+import com.jnulocker.organization.application.port.out.OrganizationLoadPort;
+import com.jnulocker.organization.domain.Organization;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OrganizationPersistenceAdapter implements OrganizationLoadPort {
+    private final OrganizationRepository organizationRepository;
+
+    @Override
+    public List<Organization> findAll() {
+        List<Organization> organization = organizationRepository.findAll();
+        return organization;
+    }
+}

--- a/src/main/java/com/jnulocker/organization/adapter/out/OrganizationRepository.java
+++ b/src/main/java/com/jnulocker/organization/adapter/out/OrganizationRepository.java
@@ -2,7 +2,5 @@ package com.jnulocker.organization.adapter.out;
 
 import com.jnulocker.organization.domain.Organization;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface OrganizationRepository extends JpaRepository<Organization, Long> {}

--- a/src/main/java/com/jnulocker/organization/adapter/out/OrganizationRepository.java
+++ b/src/main/java/com/jnulocker/organization/adapter/out/OrganizationRepository.java
@@ -1,0 +1,8 @@
+package com.jnulocker.organization.adapter.out;
+
+import com.jnulocker.organization.domain.Organization;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OrganizationRepository extends JpaRepository<Organization, Long> {}

--- a/src/main/java/com/jnulocker/organization/application/port/in/OrganizationUseCase.java
+++ b/src/main/java/com/jnulocker/organization/application/port/in/OrganizationUseCase.java
@@ -1,11 +1,7 @@
 package com.jnulocker.organization.application.port.in;
 
-import com.jnulocker.organization.domain.Organization;
-import java.util.List;
 import java.util.Set;
 
 public interface OrganizationUseCase {
-    List<Organization> findAll();
-
     Set<String> findAffiliations();
 }

--- a/src/main/java/com/jnulocker/organization/application/port/in/OrganizationUseCase.java
+++ b/src/main/java/com/jnulocker/organization/application/port/in/OrganizationUseCase.java
@@ -1,0 +1,11 @@
+package com.jnulocker.organization.application.port.in;
+
+import com.jnulocker.organization.domain.Organization;
+import java.util.List;
+import java.util.Set;
+
+public interface OrganizationUseCase {
+    List<Organization> findAll();
+
+    Set<String> findAffiliations();
+}

--- a/src/main/java/com/jnulocker/organization/application/port/out/OrganizationLoadPort.java
+++ b/src/main/java/com/jnulocker/organization/application/port/out/OrganizationLoadPort.java
@@ -1,0 +1,8 @@
+package com.jnulocker.organization.application.port.out;
+
+import com.jnulocker.organization.domain.Organization;
+import java.util.List;
+
+public interface OrganizationLoadPort {
+    List<Organization> findAll();
+}

--- a/src/main/java/com/jnulocker/organization/application/service/OrganizationService.java
+++ b/src/main/java/com/jnulocker/organization/application/service/OrganizationService.java
@@ -23,7 +23,7 @@ public class OrganizationService implements OrganizationUseCase {
     public Set<String> findAffiliations() {
         List<Organization> organizations = organizationLoadPort.findAll();
         return organizations.stream()
-                .map(Organization::getAffiliation) // Organization에서 affiliation 필드만 추출
-                .collect(Collectors.toSet()); //
+                .map(Organization::getAffiliation)
+                .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/com/jnulocker/organization/application/service/OrganizationService.java
+++ b/src/main/java/com/jnulocker/organization/application/service/OrganizationService.java
@@ -1,0 +1,29 @@
+package com.jnulocker.organization.application.service;
+
+import com.jnulocker.organization.application.port.in.OrganizationUseCase;
+import com.jnulocker.organization.application.port.out.OrganizationLoadPort;
+import com.jnulocker.organization.domain.Organization;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OrganizationService implements OrganizationUseCase {
+    private final OrganizationLoadPort organizationLoadPort;
+
+    @Override
+    public List<Organization> findAll() {
+        return organizationLoadPort.findAll();
+    }
+
+    @Override
+    public Set<String> findAffiliations() {
+        List<Organization> organizations = organizationLoadPort.findAll();
+        return organizations.stream()
+                .map(Organization::getAffiliation) // Organization에서 affiliation 필드만 추출
+                .collect(Collectors.toSet()); //
+    }
+}

--- a/src/main/java/com/jnulocker/organization/application/service/OrganizationService.java
+++ b/src/main/java/com/jnulocker/organization/application/service/OrganizationService.java
@@ -15,15 +15,8 @@ public class OrganizationService implements OrganizationUseCase {
     private final OrganizationLoadPort organizationLoadPort;
 
     @Override
-    public List<Organization> findAll() {
-        return organizationLoadPort.findAll();
-    }
-
-    @Override
     public Set<String> findAffiliations() {
         List<Organization> organizations = organizationLoadPort.findAll();
-        return organizations.stream()
-                .map(Organization::getAffiliation)
-                .collect(Collectors.toSet());
+        return organizations.stream().map(Organization::getAffiliation).collect(Collectors.toSet());
     }
 }


### PR DESCRIPTION
### 개요
close #18 

### 작업사항
- organization 테이블에 소속대학/소속학과 데이터를 저장
- 소속대학 조회 API 구현

### 변경로직
- SecurityConfig에서 `authenticated()`를 주석처리하고 `permitAll()`을 추가하였습니다.
- 추후 인증인가가 구현되면 해당 변경 사항을 복구하겠습니다.

### 테스트 결과
![image](https://github.com/user-attachments/assets/738e14fa-77bd-4fa9-823a-ba17f4dc25ba)

### 리뷰어에게

응답 DTO를 어떻게 해야할지 고민이 되어 소속대학 조회 API는 단순하게 사용하는 API여서 Set<String>으로 하였습니다.
주차권이나 리쿠르트를 보면 List<객체>인데 저 객체에 소속대학필드밖에 없고 굳이 객체로 감싸야하나 생각이 들고

```java
public record ResponseDto(List<String> affiliation) {}
```
도 생각해보았는데 어떤게 좋은 방법인지 말씀해주시면 감사드리겠습니다!

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- 조직 관련 정보를 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
	- 모든 서비스 엔드포인트에 대해 인증 절차 없이 접근할 수 있게 되어 사용자 접근성이 향상되었습니다.
	- 조직 데이터 로드를 위한 새로운 서비스 및 리포지토리 인터페이스가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->