### PR TITLE
[FEAT] 사물함 조회 API 구현

### DIFF
--- a/src/main/java/com/jnulocker/common/annotation/PersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/common/annotation/PersistenceAdapter.java
@@ -1,0 +1,19 @@
+package com.jnulocker.common.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.stereotype.Component;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Component
+public @interface PersistenceAdapter {
+
+    @AliasFor(annotation = Component.class)
+    String value() default "";
+}

--- a/src/main/java/com/jnulocker/events/adapter/in/EventController.java
+++ b/src/main/java/com/jnulocker/events/adapter/in/EventController.java
@@ -1,0 +1,27 @@
+package com.jnulocker.events.adapter.in;
+
+import com.jnulocker.events.adapter.in.docs.EventApi;
+import com.jnulocker.events.application.port.in.GetEventLockerQuery;
+import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/events")
+public class EventController implements EventApi {
+
+    private final GetEventLockerQuery getEventLockerQuery;
+
+    @Override
+    @GetMapping("/{event-id}/lockers")
+    public ResponseEntity<List<FloorWithLockersResponse>> getLockers(
+            @PathVariable("event-id") Long eventId) {
+        return ResponseEntity.ok(getEventLockerQuery.getLockersByEventId(eventId));
+    }
+}

--- a/src/main/java/com/jnulocker/events/adapter/in/docs/EventApi.java
+++ b/src/main/java/com/jnulocker/events/adapter/in/docs/EventApi.java
@@ -1,0 +1,18 @@
+package com.jnulocker.events.adapter.in.docs;
+
+import com.jnulocker.common.swagger.ApiExceptionExamples;
+import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "사물함 신청 이벤트", description = "사물함 신청 이벤트 관련 API")
+public interface EventApi {
+
+    @ApiExceptionExamples(GetLockerExceptionDocs.class)
+    @Operation(summary = "사물함 목록 조회", description = "사물함 신청 이벤트에 대한 사물함 목록을 조회합니다.")
+    ResponseEntity<List<FloorWithLockersResponse>> getLockers(
+            @PathVariable("event-id") Long eventId);
+}

--- a/src/main/java/com/jnulocker/events/adapter/in/docs/GetLockerExceptionDocs.java
+++ b/src/main/java/com/jnulocker/events/adapter/in/docs/GetLockerExceptionDocs.java
@@ -1,0 +1,17 @@
+package com.jnulocker.events.adapter.in.docs;
+
+import com.jnulocker.common.exception.BusinessException;
+import com.jnulocker.common.swagger.ExceptionDoc;
+import com.jnulocker.common.swagger.ExplainError;
+import com.jnulocker.common.swagger.SwaggerExceptionDoc;
+import com.jnulocker.events.exception.EventNotFoundException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@ExceptionDoc
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetLockerExceptionDocs implements SwaggerExceptionDoc {
+
+    @ExplainError("이벤트가 존재하지 않을 때 발생하는 예외입니다")
+    public static final BusinessException 이벤트가_존재하지_않을_때 = EventNotFoundException.EXCEPTION;
+}

--- a/src/main/java/com/jnulocker/events/adapter/out/EventPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/EventPersistenceAdapter.java
@@ -1,0 +1,17 @@
+package com.jnulocker.events.adapter.out;
+
+import com.jnulocker.common.annotation.PersistenceAdapter;
+import com.jnulocker.events.application.port.out.LoadEventPort;
+import lombok.RequiredArgsConstructor;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class EventPersistenceAdapter implements LoadEventPort {
+
+    private final EventRepository eventRepository;
+
+    @Override
+    public boolean existsById(Long eventId) {
+        return eventRepository.existsById(eventId);
+    }
+}

--- a/src/main/java/com/jnulocker/events/adapter/out/EventRepository.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/EventRepository.java
@@ -1,0 +1,6 @@
+package com.jnulocker.events.adapter.out;
+
+import com.jnulocker.events.domain.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventRepository extends JpaRepository<Event, Long> {}

--- a/src/main/java/com/jnulocker/events/adapter/out/FloorPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/FloorPersistenceAdapter.java
@@ -1,0 +1,19 @@
+package com.jnulocker.events.adapter.out;
+
+import com.jnulocker.common.annotation.PersistenceAdapter;
+import com.jnulocker.events.application.port.out.LoadFloorPort;
+import com.jnulocker.events.domain.Floor;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class FloorPersistenceAdapter implements LoadFloorPort {
+
+    private final FloorRepository floorRepository;
+
+    @Override
+    public List<Floor> getFloorsByEventId(Long eventId) {
+        return floorRepository.findAllByEventId(eventId);
+    }
+}

--- a/src/main/java/com/jnulocker/events/adapter/out/FloorRepository.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/FloorRepository.java
@@ -1,0 +1,10 @@
+package com.jnulocker.events.adapter.out;
+
+import com.jnulocker.events.domain.Floor;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FloorRepository extends JpaRepository<Floor, Long> {
+
+    List<Floor> findAllByEventId(Long eventId);
+}

--- a/src/main/java/com/jnulocker/events/adapter/out/LockerPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/LockerPersistenceAdapter.java
@@ -1,0 +1,19 @@
+package com.jnulocker.events.adapter.out;
+
+import com.jnulocker.common.annotation.PersistenceAdapter;
+import com.jnulocker.events.application.port.out.LoadLockerPort;
+import com.jnulocker.events.domain.Locker;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class LockerPersistenceAdapter implements LoadLockerPort {
+
+    private final LockerRepository lockerRepository;
+
+    @Override
+    public List<Locker> getLockersByFloorId(Long floorId) {
+        return lockerRepository.findAllByFloorId(floorId);
+    }
+}

--- a/src/main/java/com/jnulocker/events/adapter/out/LockerRepository.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/LockerRepository.java
@@ -1,0 +1,10 @@
+package com.jnulocker.events.adapter.out;
+
+import com.jnulocker.events.domain.Locker;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LockerRepository extends JpaRepository<Locker, Long> {
+
+    List<Locker> findAllByFloorId(Long floorId);
+}

--- a/src/main/java/com/jnulocker/events/application/port/in/GetEventLockerQuery.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/GetEventLockerQuery.java
@@ -1,0 +1,9 @@
+package com.jnulocker.events.application.port.in;
+
+import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
+import java.util.List;
+
+public interface GetEventLockerQuery {
+
+    List<FloorWithLockersResponse> getLockersByEventId(Long eventId);
+}

--- a/src/main/java/com/jnulocker/events/application/port/in/response/FloorWithLockersResponse.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/response/FloorWithLockersResponse.java
@@ -1,0 +1,12 @@
+package com.jnulocker.events.application.port.in.response;
+
+import java.util.List;
+
+public record FloorWithLockersResponse(
+        Long floorId, Integer floorNumber, List<LockerResponse> lockers) {
+
+    public static FloorWithLockersResponse of(
+            Long floorId, Integer floorNumber, List<LockerResponse> lockers) {
+        return new FloorWithLockersResponse(floorId, floorNumber, lockers);
+    }
+}

--- a/src/main/java/com/jnulocker/events/application/port/in/response/LockerResponse.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/response/LockerResponse.java
@@ -1,0 +1,10 @@
+package com.jnulocker.events.application.port.in.response;
+
+import com.jnulocker.events.domain.Locker;
+
+public record LockerResponse(Long lockerId, String code, Boolean available) {
+
+    public static LockerResponse from(Locker locker) {
+        return new LockerResponse(locker.getId(), locker.getCode(), locker.getAvailable());
+    }
+}

--- a/src/main/java/com/jnulocker/events/application/port/out/LoadEventPort.java
+++ b/src/main/java/com/jnulocker/events/application/port/out/LoadEventPort.java
@@ -1,0 +1,6 @@
+package com.jnulocker.events.application.port.out;
+
+public interface LoadEventPort {
+
+    boolean existsById(Long eventId);
+}

--- a/src/main/java/com/jnulocker/events/application/port/out/LoadFloorPort.java
+++ b/src/main/java/com/jnulocker/events/application/port/out/LoadFloorPort.java
@@ -1,0 +1,9 @@
+package com.jnulocker.events.application.port.out;
+
+import com.jnulocker.events.domain.Floor;
+import java.util.List;
+
+public interface LoadFloorPort {
+
+    List<Floor> getFloorsByEventId(Long eventId);
+}

--- a/src/main/java/com/jnulocker/events/application/port/out/LoadLockerPort.java
+++ b/src/main/java/com/jnulocker/events/application/port/out/LoadLockerPort.java
@@ -1,0 +1,9 @@
+package com.jnulocker.events.application.port.out;
+
+import com.jnulocker.events.domain.Locker;
+import java.util.List;
+
+public interface LoadLockerPort {
+
+    List<Locker> getLockersByFloorId(Long floorId);
+}

--- a/src/main/java/com/jnulocker/events/application/service/GetEventLockerService.java
+++ b/src/main/java/com/jnulocker/events/application/service/GetEventLockerService.java
@@ -1,0 +1,46 @@
+package com.jnulocker.events.application.service;
+
+import com.jnulocker.events.application.port.in.GetEventLockerQuery;
+import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
+import com.jnulocker.events.application.port.in.response.LockerResponse;
+import com.jnulocker.events.application.port.out.LoadEventPort;
+import com.jnulocker.events.application.port.out.LoadFloorPort;
+import com.jnulocker.events.application.port.out.LoadLockerPort;
+import com.jnulocker.events.domain.Floor;
+import com.jnulocker.events.exception.EventNotFoundException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GetEventLockerService implements GetEventLockerQuery {
+
+    private final LoadEventPort loadEventPort;
+    private final LoadFloorPort loadFloorPort;
+    private final LoadLockerPort loadLockerPort;
+
+    @Override
+    public List<FloorWithLockersResponse> getLockersByEventId(Long eventId) {
+        if (!loadEventPort.existsById(eventId)) {
+            throw EventNotFoundException.EXCEPTION;
+        }
+
+        List<Floor> floors = loadFloorPort.getFloorsByEventId(eventId);
+
+        return floors.stream()
+                .map(
+                        floor ->
+                                FloorWithLockersResponse.of(
+                                        floor.getId(),
+                                        floor.getFloorNumber(),
+                                        getLockerResponsesByFloor(floor)))
+                .toList();
+    }
+
+    private List<LockerResponse> getLockerResponsesByFloor(Floor floor) {
+        return loadLockerPort.getLockersByFloorId(floor.getId()).stream()
+                .map(LockerResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/jnulocker/events/exception/EventErrorCode.java
+++ b/src/main/java/com/jnulocker/events/exception/EventErrorCode.java
@@ -1,0 +1,17 @@
+package com.jnulocker.events.exception;
+
+import com.jnulocker.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum EventErrorCode implements ErrorCode {
+    EVENT_NOT_FOUND("E001", HttpStatus.NOT_FOUND, "이벤트가 존재하지 않습니다"),
+    ;
+
+    private final String code;
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/jnulocker/events/exception/EventNotFoundException.java
+++ b/src/main/java/com/jnulocker/events/exception/EventNotFoundException.java
@@ -1,0 +1,12 @@
+package com.jnulocker.events.exception;
+
+import com.jnulocker.common.exception.BusinessException;
+
+public class EventNotFoundException extends BusinessException {
+
+    public static final BusinessException EXCEPTION = new EventNotFoundException();
+
+    private EventNotFoundException() {
+        super(EventErrorCode.EVENT_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
### 개요
close #23 

### 작업사항
- 특정 이벤트에 해당하는 사물함 조회 API 구현

### 변경로직
- 사물함 조회 API 구현
- 예외처리 내용 문서화

### 테스트 결과

- 응답 결과

  ```json
  [
    {
      "floorId": 1,
      "floorNumber": 1,
      "lockers": [
        {
          "lockerId": 1,
          "code": "A-001",
          "available": false
        },
        {
          "lockerId": 2,
          "code": "A-002",
          "available": true
        }
      ]
    },
    {
      "floorId": 2,
      "floorNumber": 2,
      "lockers": [
        {
          "lockerId": 3,
          "code": "B-001",
          "available": false
        },
        {
          "lockerId": 4,
          "code": "B-002",
          "available": true
        }
      ]
    }
  ]
  ```

- Swagger 문서 결과
  <img width="1535" alt="image" src="https://github.com/user-attachments/assets/95515dbd-7555-449c-954c-d9193707597a" />


### 참고할점
- `@PersistenceAdapter` 어노테이션을 `@Component`대신 사용하면 됩니다

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 이벤트 관련 라커 정보를 조회할 수 있는 REST API 엔드포인트 추가 ("/v1/events/{event-id}/lockers").
	- API 문서가 강화되어, 이벤트 조회 및 오류 처리 (이벤트 미존재 시 명확한 메시지 전달) 기능이 개선됨.
	- 이벤트와 연관된 층 및 라커 데이터를 효율적으로 처리하는 서비스 계층이 새로 도입됨.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->