### PR TITLE
[FEAT] 소속학과 조회 API 구현

### DIFF
--- a/src/main/java/com/jnulocker/organization/adapter/in/OrganizationController.java
+++ b/src/main/java/com/jnulocker/organization/adapter/in/OrganizationController.java
@@ -20,13 +20,13 @@ public class OrganizationController {
 
     @GetMapping("/affiliations")
     public ResponseEntity<Set<String>> getAffiliations() {
-        Set<String> affiliations = getAffiliationQuery.findAffiliations();
+        Set<String> affiliations = getAffiliationQuery.getAffiliations();
         return ResponseEntity.ok(affiliations);
     }
 
     @GetMapping("/departments")
     public ResponseEntity<List<String>> getDepartment(@RequestParam String affiliation) {
-        List<String> departments = getDepartmentQuery.findDepartments(affiliation);
+        List<String> departments = getDepartmentQuery.getDepartments(affiliation);
         return ResponseEntity.ok(departments);
     }
 }

--- a/src/main/java/com/jnulocker/organization/adapter/in/OrganizationController.java
+++ b/src/main/java/com/jnulocker/organization/adapter/in/OrganizationController.java
@@ -4,7 +4,6 @@ import com.jnulocker.organization.application.port.in.OrganizationUseCase;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,12 +19,12 @@ public class OrganizationController {
     @GetMapping("/affiliations")
     public ResponseEntity<Set<String>> getAffiliations() {
         Set<String> affiliations = organizationUseCase.findAffiliations();
-        return new ResponseEntity<>(affiliations, HttpStatus.OK);
+        return ResponseEntity.ok(affiliations);
     }
 
     @GetMapping("/departments")
     public ResponseEntity<List<String>> getDepartment(@RequestParam String affiliation) {
         List<String> departments = organizationUseCase.findDepartments(affiliation);
-        return new ResponseEntity<>(departments, HttpStatus.OK);
+        return ResponseEntity.ok(departments);
     }
 }

--- a/src/main/java/com/jnulocker/organization/adapter/in/OrganizationController.java
+++ b/src/main/java/com/jnulocker/organization/adapter/in/OrganizationController.java
@@ -1,5 +1,6 @@
 package com.jnulocker.organization.adapter.in;
 
+import com.jnulocker.organization.adapter.in.docs.OrganizationApi;
 import com.jnulocker.organization.application.port.in.GetAffiliationQuery;
 import com.jnulocker.organization.application.port.in.GetDepartmentQuery;
 import java.util.List;
@@ -14,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/v1/organizations")
 @RequiredArgsConstructor
-public class OrganizationController {
+public class OrganizationController implements OrganizationApi {
     private final GetAffiliationQuery getAffiliationQuery;
     private final GetDepartmentQuery getDepartmentQuery;
 
@@ -25,7 +26,7 @@ public class OrganizationController {
     }
 
     @GetMapping("/departments")
-    public ResponseEntity<List<String>> getDepartment(@RequestParam String affiliation) {
+    public ResponseEntity<List<String>> getDepartments(@RequestParam String affiliation) {
         List<String> departments = getDepartmentQuery.getDepartments(affiliation);
         return ResponseEntity.ok(departments);
     }

--- a/src/main/java/com/jnulocker/organization/adapter/in/OrganizationController.java
+++ b/src/main/java/com/jnulocker/organization/adapter/in/OrganizationController.java
@@ -1,12 +1,14 @@
 package com.jnulocker.organization.adapter.in;
 
 import com.jnulocker.organization.application.port.in.OrganizationUseCase;
+import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -19,5 +21,11 @@ public class OrganizationController {
     public ResponseEntity<Set<String>> getAffiliations() {
         Set<String> affiliations = organizationUseCase.findAffiliations();
         return new ResponseEntity<>(affiliations, HttpStatus.OK);
+    }
+
+    @GetMapping("/departments")
+    public ResponseEntity<List<String>> getDepartment(@RequestParam String affiliation) {
+        List<String> departments = organizationUseCase.findDepartments(affiliation);
+        return new ResponseEntity<>(departments, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/jnulocker/organization/adapter/in/OrganizationController.java
+++ b/src/main/java/com/jnulocker/organization/adapter/in/OrganizationController.java
@@ -1,6 +1,7 @@
 package com.jnulocker.organization.adapter.in;
 
 import com.jnulocker.organization.application.port.in.GetAffiliationQuery;
+import com.jnulocker.organization.application.port.in.GetDepartmentQuery;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class OrganizationController {
     private final GetAffiliationQuery getAffiliationQuery;
+    private final GetDepartmentQuery getDepartmentQuery;
 
     @GetMapping("/affiliations")
     public ResponseEntity<Set<String>> getAffiliations() {
@@ -24,7 +26,7 @@ public class OrganizationController {
 
     @GetMapping("/departments")
     public ResponseEntity<List<String>> getDepartment(@RequestParam String affiliation) {
-        List<String> departments = getAffiliationQuery.findDepartments(affiliation);
+        List<String> departments = getDepartmentQuery.findDepartments(affiliation);
         return ResponseEntity.ok(departments);
     }
 }

--- a/src/main/java/com/jnulocker/organization/adapter/in/OrganizationController.java
+++ b/src/main/java/com/jnulocker/organization/adapter/in/OrganizationController.java
@@ -1,6 +1,6 @@
 package com.jnulocker.organization.adapter.in;
 
-import com.jnulocker.organization.application.port.in.OrganizationUseCase;
+import com.jnulocker.organization.application.port.in.GetAffiliationQuery;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -14,17 +14,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/organizations")
 @RequiredArgsConstructor
 public class OrganizationController {
-    private final OrganizationUseCase organizationUseCase;
+    private final GetAffiliationQuery getAffiliationQuery;
 
     @GetMapping("/affiliations")
     public ResponseEntity<Set<String>> getAffiliations() {
-        Set<String> affiliations = organizationUseCase.findAffiliations();
+        Set<String> affiliations = getAffiliationQuery.findAffiliations();
         return ResponseEntity.ok(affiliations);
     }
 
     @GetMapping("/departments")
     public ResponseEntity<List<String>> getDepartment(@RequestParam String affiliation) {
-        List<String> departments = organizationUseCase.findDepartments(affiliation);
+        List<String> departments = getAffiliationQuery.findDepartments(affiliation);
         return ResponseEntity.ok(departments);
     }
 }

--- a/src/main/java/com/jnulocker/organization/adapter/in/docs/OrganizationApi.java
+++ b/src/main/java/com/jnulocker/organization/adapter/in/docs/OrganizationApi.java
@@ -13,5 +13,5 @@ public interface OrganizationApi {
     ResponseEntity<Set<String>> getAffiliations();
 
     @Operation(summary = "소속학과 조회", description = "소속학과 목록을 조회합니다.")
-    ResponseEntity<List<String>> getDepartment(@RequestParam String affiliation);
+    ResponseEntity<List<String>> getDepartments(@RequestParam String affiliation);
 }

--- a/src/main/java/com/jnulocker/organization/adapter/in/docs/OrganizationApi.java
+++ b/src/main/java/com/jnulocker/organization/adapter/in/docs/OrganizationApi.java
@@ -1,0 +1,17 @@
+package com.jnulocker.organization.adapter.in.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import java.util.Set;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Organization", description = "Organization 관련 API")
+public interface OrganizationApi {
+    @Operation(summary = "소속대학 조회", description = "소속대학 목록을 조회합니다.")
+    ResponseEntity<Set<String>> getAffiliations();
+
+    @Operation(summary = "소속학과 조회", description = "소속학과 목록을 조회합니다.")
+    ResponseEntity<List<String>> getDepartment(@RequestParam String affiliation);
+}

--- a/src/main/java/com/jnulocker/organization/adapter/in/docs/OrganizationApi.java
+++ b/src/main/java/com/jnulocker/organization/adapter/in/docs/OrganizationApi.java
@@ -7,11 +7,11 @@ import java.util.Set;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
 
-@Tag(name = "Organization", description = "Organization 관련 API")
+@Tag(name = "위원회", description = "위원회 관련 API")
 public interface OrganizationApi {
-    @Operation(summary = "소속대학 조회", description = "소속대학 목록을 조회합니다.")
+    @Operation(summary = "단과대학/위원회 목록 조회", description = "단과대학/위원회 목록을 조회합니다.")
     ResponseEntity<Set<String>> getAffiliations();
 
-    @Operation(summary = "소속학과 조회", description = "소속학과 목록을 조회합니다.")
+    @Operation(summary = "소속학과 조회", description = "단과대학에 속하는 소속학과 목록을 조회합니다.")
     ResponseEntity<List<String>> getDepartments(@RequestParam String affiliation);
 }

--- a/src/main/java/com/jnulocker/organization/adapter/out/OrganizationPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/organization/adapter/out/OrganizationPersistenceAdapter.java
@@ -1,12 +1,12 @@
 package com.jnulocker.organization.adapter.out;
 
+import com.jnulocker.common.annotation.PersistenceAdapter;
 import com.jnulocker.organization.application.port.out.OrganizationLoadPort;
 import com.jnulocker.organization.domain.Organization;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 
-@Component
+@PersistenceAdapter
 @RequiredArgsConstructor
 public class OrganizationPersistenceAdapter implements OrganizationLoadPort {
     private final OrganizationRepository organizationRepository;

--- a/src/main/java/com/jnulocker/organization/adapter/out/OrganizationPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/organization/adapter/out/OrganizationPersistenceAdapter.java
@@ -12,12 +12,12 @@ public class OrganizationPersistenceAdapter implements OrganizationLoadPort {
     private final OrganizationRepository organizationRepository;
 
     @Override
-    public List<Organization> findAll() {
+    public List<Organization> getAll() {
         return organizationRepository.findAll();
     }
 
     @Override
-    public List<Organization> loadByAffiliation(String affiliation) {
+    public List<Organization> getByAffiliation(String affiliation) {
         return organizationRepository.findByAffiliation(affiliation);
     }
 }

--- a/src/main/java/com/jnulocker/organization/adapter/out/OrganizationPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/organization/adapter/out/OrganizationPersistenceAdapter.java
@@ -15,4 +15,9 @@ public class OrganizationPersistenceAdapter implements OrganizationLoadPort {
     public List<Organization> findAll() {
         return organizationRepository.findAll();
     }
+
+    @Override
+    public List<Organization> loadByAffiliation(String affiliation) {
+        return organizationRepository.findByAffiliation(affiliation);
+    }
 }

--- a/src/main/java/com/jnulocker/organization/adapter/out/OrganizationRepository.java
+++ b/src/main/java/com/jnulocker/organization/adapter/out/OrganizationRepository.java
@@ -1,6 +1,9 @@
 package com.jnulocker.organization.adapter.out;
 
 import com.jnulocker.organization.domain.Organization;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface OrganizationRepository extends JpaRepository<Organization, Long> {}
+public interface OrganizationRepository extends JpaRepository<Organization, Long> {
+    List<Organization> findByAffiliation(String affiliation);
+}

--- a/src/main/java/com/jnulocker/organization/application/port/in/GetAffiliationQuery.java
+++ b/src/main/java/com/jnulocker/organization/application/port/in/GetAffiliationQuery.java
@@ -1,10 +1,7 @@
 package com.jnulocker.organization.application.port.in;
 
-import java.util.List;
 import java.util.Set;
 
 public interface GetAffiliationQuery {
     Set<String> findAffiliations();
-
-    List<String> findDepartments(String affiliation);
 }

--- a/src/main/java/com/jnulocker/organization/application/port/in/GetAffiliationQuery.java
+++ b/src/main/java/com/jnulocker/organization/application/port/in/GetAffiliationQuery.java
@@ -3,7 +3,7 @@ package com.jnulocker.organization.application.port.in;
 import java.util.List;
 import java.util.Set;
 
-public interface OrganizationUseCase {
+public interface GetAffiliationQuery {
     Set<String> findAffiliations();
 
     List<String> findDepartments(String affiliation);

--- a/src/main/java/com/jnulocker/organization/application/port/in/GetAffiliationQuery.java
+++ b/src/main/java/com/jnulocker/organization/application/port/in/GetAffiliationQuery.java
@@ -3,5 +3,5 @@ package com.jnulocker.organization.application.port.in;
 import java.util.Set;
 
 public interface GetAffiliationQuery {
-    Set<String> findAffiliations();
+    Set<String> getAffiliations();
 }

--- a/src/main/java/com/jnulocker/organization/application/port/in/GetDepartmentQuery.java
+++ b/src/main/java/com/jnulocker/organization/application/port/in/GetDepartmentQuery.java
@@ -3,5 +3,5 @@ package com.jnulocker.organization.application.port.in;
 import java.util.List;
 
 public interface GetDepartmentQuery {
-    List<String> findDepartments(String affiliation);
+    List<String> getDepartments(String affiliation);
 }

--- a/src/main/java/com/jnulocker/organization/application/port/in/GetDepartmentQuery.java
+++ b/src/main/java/com/jnulocker/organization/application/port/in/GetDepartmentQuery.java
@@ -1,0 +1,7 @@
+package com.jnulocker.organization.application.port.in;
+
+import java.util.List;
+
+public interface GetDepartmentQuery {
+    List<String> findDepartments(String affiliation);
+}

--- a/src/main/java/com/jnulocker/organization/application/port/in/OrganizationUseCase.java
+++ b/src/main/java/com/jnulocker/organization/application/port/in/OrganizationUseCase.java
@@ -1,7 +1,10 @@
 package com.jnulocker.organization.application.port.in;
 
+import java.util.List;
 import java.util.Set;
 
 public interface OrganizationUseCase {
     Set<String> findAffiliations();
+
+    List<String> findDepartments(String affiliation);
 }

--- a/src/main/java/com/jnulocker/organization/application/port/out/OrganizationLoadPort.java
+++ b/src/main/java/com/jnulocker/organization/application/port/out/OrganizationLoadPort.java
@@ -5,4 +5,6 @@ import java.util.List;
 
 public interface OrganizationLoadPort {
     List<Organization> findAll();
+
+    List<Organization> loadByAffiliation(String affiliation);
 }

--- a/src/main/java/com/jnulocker/organization/application/port/out/OrganizationLoadPort.java
+++ b/src/main/java/com/jnulocker/organization/application/port/out/OrganizationLoadPort.java
@@ -4,7 +4,7 @@ import com.jnulocker.organization.domain.Organization;
 import java.util.List;
 
 public interface OrganizationLoadPort {
-    List<Organization> findAll();
+    List<Organization> getAll();
 
-    List<Organization> loadByAffiliation(String affiliation);
+    List<Organization> getByAffiliation(String affiliation);
 }

--- a/src/main/java/com/jnulocker/organization/application/service/OrganizationService.java
+++ b/src/main/java/com/jnulocker/organization/application/service/OrganizationService.java
@@ -27,6 +27,6 @@ public class OrganizationService implements OrganizationUseCase {
         return organizations.stream()
                 .map(Organization::getDepartment)
                 .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/src/main/java/com/jnulocker/organization/application/service/OrganizationService.java
+++ b/src/main/java/com/jnulocker/organization/application/service/OrganizationService.java
@@ -1,6 +1,6 @@
 package com.jnulocker.organization.application.service;
 
-import com.jnulocker.organization.application.port.in.OrganizationUseCase;
+import com.jnulocker.organization.application.port.in.GetAffiliationQuery;
 import com.jnulocker.organization.application.port.out.OrganizationLoadPort;
 import com.jnulocker.organization.domain.Organization;
 import java.util.List;
@@ -12,13 +12,15 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class OrganizationService implements OrganizationUseCase {
+public class OrganizationService implements GetAffiliationQuery {
     private final OrganizationLoadPort organizationLoadPort;
 
     @Override
     public Set<String> findAffiliations() {
         List<Organization> organizations = organizationLoadPort.findAll();
-        return organizations.stream().map(Organization::getAffiliation).collect(Collectors.toUnmodifiableSet());
+        return organizations.stream()
+                .map(Organization::getAffiliation)
+                .collect(Collectors.toUnmodifiableSet());
     }
 
     @Override

--- a/src/main/java/com/jnulocker/organization/application/service/OrganizationService.java
+++ b/src/main/java/com/jnulocker/organization/application/service/OrganizationService.java
@@ -18,7 +18,7 @@ public class OrganizationService implements OrganizationUseCase {
     @Override
     public Set<String> findAffiliations() {
         List<Organization> organizations = organizationLoadPort.findAll();
-        return organizations.stream().map(Organization::getAffiliation).collect(Collectors.toSet());
+        return organizations.stream().map(Organization::getAffiliation).collect(Collectors.toUnmodifiableSet());
     }
 
     @Override

--- a/src/main/java/com/jnulocker/organization/application/service/OrganizationService.java
+++ b/src/main/java/com/jnulocker/organization/application/service/OrganizationService.java
@@ -17,7 +17,7 @@ public class OrganizationService implements GetAffiliationQuery, GetDepartmentQu
     private final OrganizationLoadPort organizationLoadPort;
 
     @Override
-    public Set<String> findAffiliations() {
+    public Set<String> getAffiliations() {
         List<Organization> organizations = organizationLoadPort.findAll();
         return organizations.stream()
                 .map(Organization::getAffiliation)
@@ -25,8 +25,8 @@ public class OrganizationService implements GetAffiliationQuery, GetDepartmentQu
     }
 
     @Override
-    public List<String> findDepartments(String affiliation) {
-        List<Organization> organizations = organizationLoadPort.loadByAffiliation(affiliation);
+    public List<String> getDepartments(String affiliation) {
+        List<Organization> organizations = organizationLoadPort.findByAffiliation(affiliation);
         return organizations.stream()
                 .map(Organization::getDepartment)
                 .filter(Objects::nonNull)

--- a/src/main/java/com/jnulocker/organization/application/service/OrganizationService.java
+++ b/src/main/java/com/jnulocker/organization/application/service/OrganizationService.java
@@ -18,7 +18,7 @@ public class OrganizationService implements GetAffiliationQuery, GetDepartmentQu
 
     @Override
     public Set<String> getAffiliations() {
-        List<Organization> organizations = organizationLoadPort.findAll();
+        List<Organization> organizations = organizationLoadPort.getAll();
         return organizations.stream()
                 .map(Organization::getAffiliation)
                 .collect(Collectors.toUnmodifiableSet());
@@ -26,7 +26,7 @@ public class OrganizationService implements GetAffiliationQuery, GetDepartmentQu
 
     @Override
     public List<String> getDepartments(String affiliation) {
-        List<Organization> organizations = organizationLoadPort.findByAffiliation(affiliation);
+        List<Organization> organizations = organizationLoadPort.getByAffiliation(affiliation);
         return organizations.stream()
                 .map(Organization::getDepartment)
                 .filter(Objects::nonNull)

--- a/src/main/java/com/jnulocker/organization/application/service/OrganizationService.java
+++ b/src/main/java/com/jnulocker/organization/application/service/OrganizationService.java
@@ -1,6 +1,7 @@
 package com.jnulocker.organization.application.service;
 
 import com.jnulocker.organization.application.port.in.GetAffiliationQuery;
+import com.jnulocker.organization.application.port.in.GetDepartmentQuery;
 import com.jnulocker.organization.application.port.out.OrganizationLoadPort;
 import com.jnulocker.organization.domain.Organization;
 import java.util.List;
@@ -12,7 +13,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class OrganizationService implements GetAffiliationQuery {
+public class OrganizationService implements GetAffiliationQuery, GetDepartmentQuery {
     private final OrganizationLoadPort organizationLoadPort;
 
     @Override

--- a/src/main/java/com/jnulocker/organization/application/service/OrganizationService.java
+++ b/src/main/java/com/jnulocker/organization/application/service/OrganizationService.java
@@ -4,6 +4,7 @@ import com.jnulocker.organization.application.port.in.OrganizationUseCase;
 import com.jnulocker.organization.application.port.out.OrganizationLoadPort;
 import com.jnulocker.organization.domain.Organization;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -18,5 +19,14 @@ public class OrganizationService implements OrganizationUseCase {
     public Set<String> findAffiliations() {
         List<Organization> organizations = organizationLoadPort.findAll();
         return organizations.stream().map(Organization::getAffiliation).collect(Collectors.toSet());
+    }
+
+    @Override
+    public List<String> findDepartments(String affiliation) {
+        List<Organization> organizations = organizationLoadPort.loadByAffiliation(affiliation);
+        return organizations.stream()
+                .map(Organization::getDepartment)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
### 개요
close #19 

### 작업사항
- 소속대학에 속한 소속학과를 조회하는 API를 구현하였습니다.

### 테스트 결과
![image](https://github.com/user-attachments/assets/5d1a9cc3-ac1d-4a5d-bddf-7d11fab75ec4)

### 리뷰어에게

소속학과가 없거나(ex.치대) 회원가입시 소속학과를 선택하지 않는 경우(ex.단과대 학생회, 위원회)일 경우 소속학과 선택란에 '선택 없음' 같은 선택도 있어야할 것 같은데 사실 프론트에서 이 부분을 어떻게 처리하는지 잘 모르겠기도 하고 리스트에 '선택 없음'을 포함시켜야할 필요는 없겠죠?

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
	- 소속 조회 기능이 개선되어, 보다 명확한 소속 목록을 제공합니다.
	- 새로운 엔드포인트를 통해 특정 소속에 따른 부서 목록을 조회할 수 있게 되었습니다.
- **리팩터링**
	- API 응답 및 명명 규칙이 정리되어, 사용자 경험이 향상되었습니다.
- **문서**
	- 업데이트된 API 문서를 통해 소속 및 부서 조회 기능에 대한 설명이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->