### PR TITLE
[TEST] 테스트 환경 구성 및 사물함 조회 API 통합 테스트 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
     id 'com.diffplug.spotless' version '7.0.2'
     id 'com.google.cloud.tools.jib' version '3.4.5'
+    id 'java-test-fixtures'
 }
 
 group = 'com'
@@ -38,6 +39,14 @@ dependencies {
 
     // p6spy
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.10.0'
+
+    // rest assured
+    testImplementation 'io.rest-assured:rest-assured:5.5.1'
+
+    // test containers
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:mysql'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/jnulocker/config/SecurityConfig.java
+++ b/src/main/java/com/jnulocker/config/SecurityConfig.java
@@ -27,10 +27,12 @@ public class SecurityConfig {
                                         "/api-docs/**", "/swagger-resources/**", "/swagger-ui/**")
                                 .permitAll()
                                 .requestMatchers( // actuator TODO: 접근 권한 설정 (ADMIN)
-                                        actuatorBasePath + "/health")
+                                        actuatorBasePath,
+                                        actuatorBasePath + "/health",
+                                        actuatorBasePath + "/prometheus")
                                 .permitAll()
                                 .anyRequest()
-                                //                                .authenticated());
+                                // TODO: 인증 구현 후 이 부분을 .authenticated()로 되돌릴 것
                                 .permitAll());
 
         return http.build();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,10 +20,16 @@ management:
   endpoints:
     web:
       base-path: ${MANAGEMENT_BASE_PATH}
+      exposure:
+        include:
+          - health
+          - prometheus
     access:
       default: none
   endpoint:
     health:
+      access: unrestricted
+    prometheus:
       access: unrestricted
 
 logging:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
       ddl-auto: create
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MySQL8Dialect
+        dialect: org.hibernate.dialect.MySQLDialect
 
 management:
   endpoints:
@@ -61,3 +61,19 @@ decorator:
   datasource:
     p6spy:
       enable-logging: false
+
+---
+spring:
+  config:
+    activate:
+      on-profile: test
+
+  datasource:
+    url: jdbc:tc:mysql:8.0:///
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+
+logging:
+  level:
+    p6spy: info
+    org.springframework:
+      transaction.interceptor: trace

--- a/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
@@ -1,0 +1,132 @@
+package com.jnulocker.events.adapter.in;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jnulocker.common.exception.ErrorResponse;
+import com.jnulocker.events.adapter.out.EventRepository;
+import com.jnulocker.events.adapter.out.FloorRepository;
+import com.jnulocker.events.adapter.out.LockerRepository;
+import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
+import com.jnulocker.events.domain.Event;
+import com.jnulocker.events.exception.EventErrorCode;
+import com.jnulocker.events.utils.EventTestUtil;
+import com.jnulocker.organization.adapter.out.OrganizationRepository;
+import io.restassured.RestAssured;
+import io.restassured.response.ValidatableResponse;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@Testcontainers
+@ActiveProfiles("test")
+@DisplayName("이벤트 컨트롤러 통합 테스트")
+class EventControllerIntegrationTest {
+
+    private static final String EVENT_URL = "/v1/events";
+
+    @LocalServerPort private int port;
+
+    @Autowired private OrganizationRepository organizationRepository;
+
+    @Autowired private EventRepository eventRepository;
+
+    @Autowired private FloorRepository floorRepository;
+
+    @Autowired private LockerRepository lockerRepository;
+
+    @Autowired private EventTestUtil eventTestUtil;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        clearData();
+    }
+
+    @AfterEach
+    void tearDown() {
+        clearData();
+    }
+
+    private void clearData() {
+        lockerRepository.deleteAll();
+        floorRepository.deleteAll();
+        eventRepository.deleteAll();
+        organizationRepository.deleteAll();
+    }
+
+    @ParameterizedTest(name = "층별 사물함 수: {0}")
+    @MethodSource("provideLockersPerFloor")
+    void 이벤트에_해당하는_층과_사물함_목록을_조회할_수_있다(List<Integer> lockersPerFloor) {
+        // given
+        // 이벤트 데이터 생성: 층별 사물함 수를 파라미터로 받아 생성
+        Event event = eventTestUtil.createEventWithFloorAndLockers(lockersPerFloor);
+
+        // when
+        List<FloorWithLockersResponse> floors =
+                getEventLockers(port, event.getId())
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .jsonPath()
+                        .getList(".", FloorWithLockersResponse.class);
+
+        // then
+        // 층 개수 검증
+        assertThat(floors).hasSize(lockersPerFloor.size());
+
+        // 각 층의 사물함 개수 검증
+        assertThat(floors)
+                .extracting(FloorWithLockersResponse::lockers)
+                .map(List::size)
+                .containsExactlyElementsOf(lockersPerFloor);
+    }
+
+    // 파라미터 제공 메서드
+    private static Stream<Arguments> provideLockersPerFloor() {
+        return Stream.of(
+                Arguments.of(List.of(2, 2)), // 첫 번째 테스트 케이스: 층별 2개 사물함
+                Arguments.of(List.of(3, 5)) // 두 번째 테스트 케이스: 1층 3개, 2층 5개
+                );
+    }
+
+    @Test
+    void 존재하지_않는_이벤트_ID로_조회하면_Event_Not_Found_에러_응답을_받는다() {
+        // given
+        Long nonExistentEventId = -1L;
+
+        // when
+        ErrorResponse errorResponse =
+                getEventLockers(port, nonExistentEventId)
+                        .statusCode(EventErrorCode.EVENT_NOT_FOUND.getHttpStatus().value())
+                        .extract()
+                        .as(ErrorResponse.class);
+
+        // then
+        assertThat(errorResponse.message()).isEqualTo(EventErrorCode.EVENT_NOT_FOUND.getMessage());
+    }
+
+    public static ValidatableResponse getEventLockers(int port, Long eventId) {
+        return given().port(port)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .get(EVENT_URL + "/{event-id}/lockers", eventId)
+                .then()
+                .log()
+                .all();
+    }
+}

--- a/src/test/java/com/jnulocker/events/utils/EventTestUtil.java
+++ b/src/test/java/com/jnulocker/events/utils/EventTestUtil.java
@@ -1,0 +1,64 @@
+package com.jnulocker.events.utils;
+
+import com.jnulocker.events.adapter.out.EventRepository;
+import com.jnulocker.events.adapter.out.FloorRepository;
+import com.jnulocker.events.adapter.out.LockerRepository;
+import com.jnulocker.events.domain.Event;
+import com.jnulocker.events.domain.Floor;
+import com.jnulocker.events.domain.Locker;
+import com.jnulocker.organization.adapter.out.OrganizationRepository;
+import com.jnulocker.organization.domain.Organization;
+import events.builder.EventTestDataBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import organization.builder.OrganizationTestDataBuilder;
+
+@Component
+public class EventTestUtil {
+
+    @Autowired private OrganizationRepository organizationRepository;
+
+    @Autowired private EventRepository eventRepository;
+
+    @Autowired private FloorRepository floorRepository;
+
+    @Autowired private LockerRepository lockerRepository;
+
+    public Event createEventWithFloorAndLockers(List<Integer> lockersPerFloor) {
+        // 조직 생성 및 저장
+        Organization organization = OrganizationTestDataBuilder.builder().build();
+        Organization savedOrganization = organizationRepository.save(organization);
+
+        // 이벤트 생성 및 저장
+        Event event = EventTestDataBuilder.builder().withOrganization(savedOrganization).build();
+        Event savedEvent = eventRepository.save(event);
+
+        // 층 생성 및 저장
+        createFloorsWithEvent(lockersPerFloor, savedEvent);
+
+        return savedEvent;
+    }
+
+    private void createFloorsWithEvent(List<Integer> lockersPerFloor, Event savedEvent) {
+        for (int floorLevel = 0; floorLevel < lockersPerFloor.size(); floorLevel++) {
+            int floorNumber = floorLevel + 1;
+            Floor floor = floorRepository.save(Floor.create(savedEvent, floorNumber));
+            createLockersWithFloor(lockersPerFloor, floorLevel, floor);
+        }
+    }
+
+    private void createLockersWithFloor(
+            List<Integer> lockersPerFloor, int floorLevel, Floor floor) {
+        List<Locker> lockers = new ArrayList<>();
+        for (int j = 1; j <= lockersPerFloor.get(floorLevel); j++) {
+            String code =
+                    String.format("%c-%03d", 'A' + floorLevel, j); // A-001, A-002, B-001, B-002 등
+            boolean available = j % 2 == 0; // 짝수 번호 사물함은 사용 가능, 홀수는 사용 불가능으로 설정
+
+            lockers.add(Locker.create(floor, code, available));
+        }
+        lockerRepository.saveAll(lockers);
+    }
+}

--- a/src/testFixtures/java/events/builder/EventTestDataBuilder.java
+++ b/src/testFixtures/java/events/builder/EventTestDataBuilder.java
@@ -15,6 +15,8 @@ public class EventTestDataBuilder {
     private EventStatus eventStatus = EventStatus.OPEN;
     private Boolean publish = true;
 
+    private EventTestDataBuilder() {}
+
     public static EventTestDataBuilder builder() {
         return new EventTestDataBuilder();
     }

--- a/src/testFixtures/java/events/builder/EventTestDataBuilder.java
+++ b/src/testFixtures/java/events/builder/EventTestDataBuilder.java
@@ -1,0 +1,55 @@
+package events.builder;
+
+import com.jnulocker.events.domain.Event;
+import com.jnulocker.events.domain.EventStatus;
+import com.jnulocker.organization.domain.Organization;
+import java.time.LocalDateTime;
+import organization.builder.OrganizationTestDataBuilder;
+
+public class EventTestDataBuilder {
+
+    private String title = "테스트 이벤트";
+    private Organization organization = OrganizationTestDataBuilder.builder().build();
+    private LocalDateTime startAt = LocalDateTime.now();
+    private LocalDateTime endAt = LocalDateTime.now().plusHours(1);
+    private EventStatus eventStatus = EventStatus.OPEN;
+    private Boolean publish = true;
+
+    public static EventTestDataBuilder builder() {
+        return new EventTestDataBuilder();
+    }
+
+    public EventTestDataBuilder withTitle(String title) {
+        this.title = title;
+        return this;
+    }
+
+    public EventTestDataBuilder withOrganization(Organization organization) {
+        this.organization = organization;
+        return this;
+    }
+
+    public EventTestDataBuilder withStartAt(LocalDateTime startAt) {
+        this.startAt = startAt;
+        return this;
+    }
+
+    public EventTestDataBuilder withEndAt(LocalDateTime endAt) {
+        this.endAt = endAt;
+        return this;
+    }
+
+    public EventTestDataBuilder withEventStatus(EventStatus eventStatus) {
+        this.eventStatus = eventStatus;
+        return this;
+    }
+
+    public EventTestDataBuilder withPublish(Boolean publish) {
+        this.publish = publish;
+        return this;
+    }
+
+    public Event build() {
+        return Event.create(title, organization, startAt, endAt, eventStatus, publish);
+    }
+}

--- a/src/testFixtures/java/organization/builder/OrganizationTestDataBuilder.java
+++ b/src/testFixtures/java/organization/builder/OrganizationTestDataBuilder.java
@@ -10,6 +10,8 @@ public class OrganizationTestDataBuilder {
     private String department = "테스트 학과";
     private String name = "테스트 조직명";
 
+    private OrganizationTestDataBuilder() {}
+
     public static OrganizationTestDataBuilder builder() {
         return new OrganizationTestDataBuilder();
     }

--- a/src/testFixtures/java/organization/builder/OrganizationTestDataBuilder.java
+++ b/src/testFixtures/java/organization/builder/OrganizationTestDataBuilder.java
@@ -1,0 +1,45 @@
+package organization.builder;
+
+import com.jnulocker.organization.domain.Organization;
+
+public class OrganizationTestDataBuilder {
+
+    private String email = "테스트 이메일";
+    private String phoneNumber = "010-1234-5678";
+    private String affiliation = "테스트 소속";
+    private String department = "테스트 학과";
+    private String name = "테스트 조직명";
+
+    public static OrganizationTestDataBuilder builder() {
+        return new OrganizationTestDataBuilder();
+    }
+
+    public OrganizationTestDataBuilder withEmail(String email) {
+        this.email = email;
+        return this;
+    }
+
+    public OrganizationTestDataBuilder withPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+        return this;
+    }
+
+    public OrganizationTestDataBuilder withAffiliation(String affiliation) {
+        this.affiliation = affiliation;
+        return this;
+    }
+
+    public OrganizationTestDataBuilder withDepartment(String department) {
+        this.department = department;
+        return this;
+    }
+
+    public OrganizationTestDataBuilder withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public Organization build() {
+        return Organization.create(email, phoneNumber, affiliation, department, name);
+    }
+}

--- a/src/testFixtures/java/organization/builder/OrganizationTestDataBuilder.java
+++ b/src/testFixtures/java/organization/builder/OrganizationTestDataBuilder.java
@@ -4,7 +4,7 @@ import com.jnulocker.organization.domain.Organization;
 
 public class OrganizationTestDataBuilder {
 
-    private String email = "테스트 이메일";
+    private String email = "test@example.com";
     private String phoneNumber = "010-1234-5678";
     private String affiliation = "테스트 소속";
     private String department = "테스트 학과";


### PR DESCRIPTION
### 개요
close #26 

### 작업사항
- 내용을 적어주세요.

### 변경로직

- 테스트 환경 구성
  - test fixture 플러그인 추가
  - test container, rest assured 의존성 추가

- 사물함 조회 API 통합 테스트 작성

### 테스트 결과
<img width="440" alt="image" src="https://github.com/user-attachments/assets/c48fe325-acd7-430d-9cc9-5bfe13fea340" />


### reference
- 추후 사물함 생성 API 구현하게되면 통합 테스트에서는 생성 API 를 활용해 데이터를 넣을까 생각중입니다.

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - 모니터링 엔드포인트 접근이 개선되어, 기본, 건강 상태 및 Prometheus 관련 엔드포인트가 추가되었습니다.

- **Chores**
  - 테스트 지원을 강화하기 위해 새로운 플러그인과 의존성이 도입되었습니다.
  - Hibernate 다이얼렉트, 관리 엔드포인트 설정, 데이터소스 및 로깅 구성이 업데이트되었습니다.

- **Tests**
  - 이벤트 관련 통합 테스트와 테스트 데이터 빌더 유틸리티가 추가되어 테스트 커버리지가 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->