### PR TITLE
[CHORE] 배포된 FE/BE 서버 CORS 허용

### DIFF
--- a/src/main/java/com/jnulocker/config/WebConfig.java
+++ b/src/main/java/com/jnulocker/config/WebConfig.java
@@ -12,8 +12,12 @@ public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) { // CORS 설정
         registry.addMapping("/**")
                 .allowedOriginPatterns(
-                        "http://localhost:3000", "https://localhost:3000",
-                        "http://localhost:8080", "https://localhost:8080")
+                        "http://localhost:3000",
+                        "https://localhost:3000",
+                        "http://localhost:8080",
+                        "https://localhost:8080",
+                        "https://jnu-locker.vercel.app",
+                        "https://api.dev.jnu-locker.site")
                 .allowedMethods(
                         HttpMethod.GET.name(),
                         HttpMethod.POST.name(),


### PR DESCRIPTION
### 개요
close #41 

### 작업사항
배포된 FE/BE 서버 CORS 허용

- `https://jnu-locker.vercel.app`
- `https://api.dev.jnu-locker.site`

### 변경로직

### 테스트 결과
  <img width="313" alt="image" src="https://github.com/user-attachments/assets/dfcaafb9-dffb-4762-8d93-5180389feef2" />

### reference

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 크로스-오리진 리소스 공유(CORS) 정책이 업데이트되어, 기존의 네 도메인 외에 추가된 두 개의 외부 도메인(https://jnu-locker.vercel.app, https://api.dev.jnu-locker.site)에서 안정적인 서비스 요청을 지원합니다. 이를 통해 다양한 플랫폼에서 보다 원활한 서비스 이용이 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->