### PR TITLE
[REFACTOR] 로그인 요청 이메일 검증 메시지 지정 및 Docker redis 환경변수 정리 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,6 @@ services:
     ports:
       - "6379:6379"
     environment: # Redis 계정 추가
-      REDIS_HOST: ${REDIS_HOST}
       REDIS_PASSWORD: ${REDIS_PASSWORD}
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]

--- a/src/main/java/com/jnulocker/auth/application/port/in/request/LoginRequest.java
+++ b/src/main/java/com/jnulocker/auth/application/port/in/request/LoginRequest.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.NotBlank;
 public record LoginRequest(
         @Schema(description = "이메일", example = "abcde@example.com")
                 @NotBlank(message = "이메일은 필수 입력값입니다")
-                @Email
+                @Email(message = "올바른 형식의 이메일 주소여야 합니다")
                 String email,
         @Schema(description = "비밀번호", example = "abcde12345!")
                 @NotBlank(message = "비밀번호는 필수 입력값입니다")


### PR DESCRIPTION
### 개요
close #44 

### 작업사항
- LoginRequest 이메일 형식 검증 응답 반환 메시지 지정
- 도커컴포즈 파일에서 REDIS-HOST 제거

### 변경로직
-로그인 요청 객체에서 이메일 형식 검증 응답 메시지를 설정하였습니다.

### 테스트 결과
<img width="523" alt="image" src="https://github.com/user-attachments/assets/d72d14b9-37a9-46b5-82a1-22c053c4b28f" />

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 로그인 시 이메일 형식이 올바르지 않을 경우 사용자에게 한글로 된 오류 메시지가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->