### PR TITLE
[FIX] 필터에서 스웨거 URL 경로 제외

### DIFF
--- a/src/main/java/com/jnulocker/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/jnulocker/auth/jwt/JwtFilter.java
@@ -30,7 +30,14 @@ public class JwtFilter extends OncePerRequestFilter {
 
     private final TokenProvider tokenProvider;
 
-    private static final List<String> EXCLUDE_URLS = Arrays.asList("/v1/auth/**");
+    private static final List<String> EXCLUDE_URLS =
+            Arrays.asList(
+                    "/v1/auth/**",
+                    "/swagger-ui/**",
+                    "/swagger-resources/**",
+                    "/v3/api-docs/**",
+                    "/api-docs/**");
+
     private static final String MEDIA_TYPE = "application/json; charset=UTF-8";
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
 


### PR DESCRIPTION
### 개요
close #46 

### 작업사항
- JwtFilter의 `shouldNotFilter`에 스웨거 URL 경로를 추가시켰습니다.

### 변경로직
- 스웨거 URL로 요청시 JwtFilter를 거치지 않습니다.

### 테스트 결과
<img width="520" alt="image" src="https://github.com/user-attachments/assets/4d963552-2449-4198-b7ee-c6ced15bf1fa" />


### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - Swagger API 문서 관련 경로들이 JWT 인증 필터에서 제외되어, 해당 문서 페이지 접근 시 인증이 필요하지 않도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->