### PR TITLE
[FIX] application.yml에 redis 패스워드 추가 및 health-check를 인증 작업에서 제외

### DIFF
--- a/src/main/java/com/jnulocker/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/jnulocker/auth/jwt/JwtFilter.java
@@ -8,15 +8,18 @@ import com.jnulocker.auth.jwt.exception.InvalidAccessTokenException;
 import com.jnulocker.common.exception.BusinessException;
 import com.jnulocker.common.exception.ErrorCode;
 import com.jnulocker.common.exception.ErrorResponse;
+import jakarta.annotation.PostConstruct;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -28,15 +31,26 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
+    @Value(("${management.endpoints.web.base-path}"))
+    private String actuatorBasePath;
+
     private final TokenProvider tokenProvider;
 
-    private static final List<String> EXCLUDE_URLS =
-            Arrays.asList(
-                    "/v1/auth/**",
-                    "/swagger-ui/**",
-                    "/swagger-resources/**",
-                    "/v3/api-docs/**",
-                    "/api-docs/**");
+    private static List<String> EXCLUDE_URLS = new ArrayList<>();
+
+    @PostConstruct
+    public void init() {
+        EXCLUDE_URLS =
+                Arrays.asList(
+                        "/v1/auth/**",
+                        "/swagger-ui/**",
+                        "/swagger-resources/**",
+                        "/v3/api-docs/**",
+                        "/api-docs/**",
+                        actuatorBasePath,
+                        actuatorBasePath + "/health",
+                        actuatorBasePath + "/prometheus");
+    }
 
     private static final String MEDIA_TYPE = "application/json; charset=UTF-8";
     private final AntPathMatcher pathMatcher = new AntPathMatcher();

--- a/src/main/java/com/jnulocker/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/jnulocker/auth/jwt/JwtFilter.java
@@ -30,7 +30,14 @@ public class JwtFilter extends OncePerRequestFilter {
 
     private final TokenProvider tokenProvider;
 
-    private static final List<String> EXCLUDE_URLS = Arrays.asList("/v1/auth/**");
+    private static final List<String> EXCLUDE_URLS =
+            Arrays.asList(
+                    "/v1/auth/**",
+                    "/swagger-ui/**",
+                    "/swagger-resources/**",
+                    "/v3/api-docs/**",
+                    "/api-docs/**");
+
     private static final String MEDIA_TYPE = "application/json; charset=UTF-8";
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,7 @@ spring:
   data:
     redis:
       host: ${REDIS_HOST}
+      password: ${REDIS_PASSWORD}
       port: ${REDIS_PORT}
 
 management:
@@ -72,8 +73,6 @@ custom:
     refresh-secret-key: ${JWT_REFRESH_SECRET_KEY:dGVzdC1yZWZyZXNoLXNlY3JldC1rZXktdGVzdC1yZWZyZXNoLXNlY3JldC1rZXktdGVzdC1yZWZyZXNoLXNlY3JldC1rZXktdGVzdC1yZWZyZXNo}
     access-token-expire-time: ${JWT_ACCESS_TOKEN_EXPIRE_TIME:3600}
     refresh-token-expire-time: ${JWT_REFRESH_TOKEN_EXPIRE_TIME:86400}
-
-
 
 ---
 spring:


### PR DESCRIPTION
### 개요
close #48 

### 작업사항
- application.yml에 redis 환경변수로 패스워드를 추가하였습니다.
- JwtFilter에서 `shouldNotFilter`메서드에 health-check url 경로와 프로메테우스 url 경로를 추가시켜 인증 작업에서 제외시켰습니다.

### 테스트 결과
<img width="518" alt="image" src="https://github.com/user-attachments/assets/274d74d2-f066-4cc8-bda0-545f5cb600c5" />

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - Swagger 관련 엔드포인트가 JWT 인증 필터에서 제외되어 API 문서 접근이 원활해졌습니다.

- **환경설정**
  - Redis 데이터 소스에 비밀번호 설정이 추가되어, 환경 변수로부터 비밀번호를 불러올 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->