### PR TITLE
[FEAT] 사물함 이벤트 생성 로직 층-접두사-범위 계층으로 개선

### DIFF
--- a/src/main/java/com/jnulocker/auth/util/CookieUtil.java
+++ b/src/main/java/com/jnulocker/auth/util/CookieUtil.java
@@ -50,12 +50,12 @@ public class CookieUtil {
     public static void addCookieFromAuthToken(HttpServletResponse response, AuthToken authToken) {
         addCookie(
                 response,
-                "access_token",
+                ACCESS_TOKEN,
                 authToken.accessToken(),
                 Math.toIntExact(authToken.accessTokenExpiresIn()));
         addCookie(
                 response,
-                "refresh_token",
+                REFRESH_TOKEN,
                 authToken.refreshToken(),
                 Math.toIntExact(authToken.refreshTokenExpiresIn()));
     }

--- a/src/main/java/com/jnulocker/events/application/port/in/request/CreateEventRequest.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/request/CreateEventRequest.java
@@ -14,9 +14,6 @@ public record CreateEventRequest(
         @Schema(description = "이벤트 제목", example = "전자컴퓨터공학부 2025-2 사물함 신청")
                 @NotBlank(message = "이벤트 제목은 필수입니다.")
                 String title,
-        @Schema(description = "주최 조직의 department ID", example = "1")
-                @NotNull(message = "주최 조직 department ID는 필수입니다.")
-                Long departmentId,
         @Schema(description = "이벤트 시작 시간", example = "2025-08-01T15:00:00")
                 @NotNull(message = "이벤트 시작 시간은 필수입니다.")
                 @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")

--- a/src/main/java/com/jnulocker/events/application/port/in/request/FloorInfo.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/request/FloorInfo.java
@@ -1,13 +1,13 @@
 package com.jnulocker.events.application.port.in.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 
 public record FloorInfo(
         @Schema(description = "층 번호", example = "1") @NotNull(message = "층 번호는 필수입니다.")
                 Integer floorNumber,
-        @Schema(description = "사물함 접두사(선택 사항)", example = "A") String lockerPrefix,
-        @Schema(description = "사물함 시작 번호", example = "1") @NotNull(message = "사물함 시작 번호는 필수입니다.")
-                Integer lockerStartNumber,
-        @Schema(description = "사물함 종료 번호", example = "20") @NotNull(message = "사물함 종료 번호는 필수입니다.")
-                Integer lockerEndNumber) {}
+        @Schema(description = "접두사 목록") @NotEmpty(message = "접두사 정보는 최소 1개 이상이어야 합니다.") @Valid
+                List<PrefixInfo> prefixes) {}

--- a/src/main/java/com/jnulocker/events/application/port/in/request/LockerRange.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/request/LockerRange.java
@@ -1,0 +1,21 @@
+package com.jnulocker.events.application.port.in.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+
+public record LockerRange(
+        @Schema(description = "사물함 시작 번호", example = "1") @NotNull(message = "사물함 시작 번호는 필수입니다.")
+                Integer lockerStartNumber,
+        @Schema(description = "사물함 종료 번호", example = "20") @NotNull(message = "사물함 종료 번호는 필수입니다.")
+                Integer lockerEndNumber) {
+
+    @AssertTrue(message = "사물함 종료 번호는 시작 번호보다 크거나 같아야 합니다.")
+    private boolean isEndNumberGreaterThanStartNumber() {
+        // null 체크: @NotNull에 의해 처리되므로, null이면 검증 스킵
+        if (lockerStartNumber == null || lockerEndNumber == null) {
+            return true;
+        }
+        return lockerEndNumber >= lockerStartNumber;
+    }
+}

--- a/src/main/java/com/jnulocker/events/application/port/in/request/PrefixInfo.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/request/PrefixInfo.java
@@ -1,0 +1,14 @@
+package com.jnulocker.events.application.port.in.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record PrefixInfo(
+        @Schema(description = "사물함 접두사 (선택사항, 기본값: 빈 문자열)", example = "A", nullable = true)
+                String lockerPrefix,
+        @Schema(description = "사물함 번호 범위 목록")
+                @NotEmpty(message = "사물함 번호 범위는 최소 1개 이상이어야 합니다.")
+                @Valid
+                List<LockerRange> ranges) {}

--- a/src/main/java/com/jnulocker/events/application/service/EventCommandService.java
+++ b/src/main/java/com/jnulocker/events/application/service/EventCommandService.java
@@ -1,5 +1,6 @@
 package com.jnulocker.events.application.service;
 
+import com.jnulocker.auth.security.SecurityUtils;
 import com.jnulocker.events.application.port.in.EventCommand;
 import com.jnulocker.events.application.port.in.request.CreateEventRequest;
 import com.jnulocker.events.application.port.in.request.FloorInfo;
@@ -11,6 +12,7 @@ import com.jnulocker.events.domain.EventParticipation;
 import com.jnulocker.events.domain.Floor;
 import com.jnulocker.events.domain.Locker;
 import com.jnulocker.events.event.LockerEventCreatedEvent;
+import com.jnulocker.member.application.port.in.MemberQuery;
 import com.jnulocker.organization.application.port.in.DepartmentQuery;
 import com.jnulocker.organization.domain.Department;
 import com.jnulocker.organization.exception.DepartmentNotFoundException;
@@ -26,6 +28,7 @@ import org.springframework.stereotype.Service;
 public class EventCommandService implements EventCommand {
 
     private final ApplicationEventPublisher eventPublisher;
+    private final MemberQuery memberQuery;
     private final DepartmentQuery departmentQuery;
     private final EventRecordPort eventRecordPort;
 
@@ -53,9 +56,8 @@ public class EventCommandService implements EventCommand {
 
     private Event createAndSaveEvent(CreateEventRequest request) {
         // 이벤트를 주최하는 department 조회
-        // TODO: 회원 정보를 통해 MANAGER 소속의 departmentId를 가져오는 로직으로 변경
-        Department organizerDepartment =
-                departmentQuery.getDepartmentByIdOrThrow(request.departmentId());
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        Department organizerDepartment = memberQuery.findByIdOrThrow(memberId).getDepartment();
 
         // 이벤트 생성 및 저장
         return eventRecordPort.saveEvent(

--- a/src/main/java/com/jnulocker/events/application/service/EventCommandService.java
+++ b/src/main/java/com/jnulocker/events/application/service/EventCommandService.java
@@ -3,6 +3,8 @@ package com.jnulocker.events.application.service;
 import com.jnulocker.events.application.port.in.EventCommand;
 import com.jnulocker.events.application.port.in.request.CreateEventRequest;
 import com.jnulocker.events.application.port.in.request.FloorInfo;
+import com.jnulocker.events.application.port.in.request.LockerRange;
+import com.jnulocker.events.application.port.in.request.PrefixInfo;
 import com.jnulocker.events.application.port.out.EventRecordPort;
 import com.jnulocker.events.domain.Event;
 import com.jnulocker.events.domain.EventParticipation;
@@ -90,9 +92,13 @@ public class EventCommandService implements EventCommand {
 
     private List<Locker> createLockersForFloor(FloorInfo floorInfo, Floor floor) {
         List<Locker> lockers = new ArrayList<>();
-        for (int i = floorInfo.lockerStartNumber(); i <= floorInfo.lockerEndNumber(); i++) {
-            String code = generateLockerCode(floorInfo.lockerPrefix(), i);
-            lockers.add(Locker.create(floor, code, true));
+        for (PrefixInfo prefixInfo : floorInfo.prefixes()) {
+            for (LockerRange range : prefixInfo.ranges()) {
+                for (int i = range.lockerStartNumber(); i <= range.lockerEndNumber(); i++) {
+                    String code = generateLockerCode(prefixInfo.lockerPrefix(), i);
+                    lockers.add(Locker.create(floor, code, true));
+                }
+            }
         }
         return lockers;
     }

--- a/src/test/java/com/jnulocker/events/application/port/in/request/CreateEventRequestTest.java
+++ b/src/test/java/com/jnulocker/events/application/port/in/request/CreateEventRequestTest.java
@@ -54,16 +54,6 @@ class CreateEventRequestTest {
     }
 
     @Test
-    void departmentId가_null이면_검증에_실패한다() {
-        CreateEventRequest request = createEventRequestBuilder().withDepartmentId(null).build();
-
-        Set<ConstraintViolation<CreateEventRequest>> violations = validator.validate(request);
-        assertThat(violations).hasSize(1);
-        assertThat(violations.iterator().next().getMessage())
-                .isEqualTo("주최 조직 department ID는 필수입니다.");
-    }
-
-    @Test
     void 시작_시간이_null이면_검증에_실패한다() {
         CreateEventRequest request = createEventRequestBuilder().withStartAt(null).build();
 
@@ -134,7 +124,18 @@ class CreateEventRequestTest {
     void 사물함_시작_번호가_null이면_검증에_실패한다() {
         CreateEventRequest request =
                 createEventRequestBuilder()
-                        .withFloors(List.of(floorInfoBuilder().withLockerStartNumber(null).build()))
+                        .withFloors(
+                                List.of(
+                                        floorInfoBuilder()
+                                                .withPrefixes(
+                                                        List.of(
+                                                                new PrefixInfo(
+                                                                        "A",
+                                                                        List.of(
+                                                                                new LockerRange(
+                                                                                        null,
+                                                                                        20)))))
+                                                .build()))
                         .build();
 
         Set<ConstraintViolation<CreateEventRequest>> violations = validator.validate(request);
@@ -146,11 +147,63 @@ class CreateEventRequestTest {
     void 사물함_종료_번호가_null이면_검증에_실패한다() {
         CreateEventRequest request =
                 createEventRequestBuilder()
-                        .withFloors(List.of(floorInfoBuilder().withLockerEndNumber(null).build()))
+                        .withFloors(
+                                List.of(
+                                        floorInfoBuilder()
+                                                .withPrefixes(
+                                                        List.of(
+                                                                new PrefixInfo(
+                                                                        "A",
+                                                                        List.of(
+                                                                                new LockerRange(
+                                                                                        1, null)))))
+                                                .build()))
                         .build();
 
         Set<ConstraintViolation<CreateEventRequest>> violations = validator.validate(request);
         assertThat(violations).hasSize(1);
         assertThat(violations.iterator().next().getMessage()).isEqualTo("사물함 종료 번호는 필수입니다.");
+    }
+
+    @Test
+    void 사물함_종료_번호가_시작_번호보다_작으면_검증에_실패한다() {
+        CreateEventRequest request =
+                createEventRequestBuilder()
+                        .withFloors(
+                                List.of(
+                                        floorInfoBuilder()
+                                                .withPrefixes(
+                                                        List.of(
+                                                                new PrefixInfo(
+                                                                        "A",
+                                                                        List.of(
+                                                                                new LockerRange(
+                                                                                        10,
+                                                                                        8) // 종료 번호
+                                                                                // < 시작
+                                                                                // 번호
+                                                                                ))))
+                                                .build()))
+                        .build();
+
+        Set<ConstraintViolation<CreateEventRequest>> violations = validator.validate(request);
+        assertThat(violations).hasSize(1);
+        assertThat(violations.iterator().next().getMessage())
+                .isEqualTo("사물함 종료 번호는 시작 번호보다 크거나 같아야 합니다.");
+    }
+
+    @Test
+    void 사물함_범위가_단일_번호여도_검증에_성공한다() {
+        CreateEventRequest request =
+                createEventRequestBuilder()
+                        .withFloors(
+                                List.of(
+                                        floorInfoBuilder()
+                                                .withPrefix("A", 5, 5) // 단일 사물함
+                                                .build()))
+                        .build();
+
+        Set<ConstraintViolation<CreateEventRequest>> violations = validator.validate(request);
+        assertThat(violations).isEmpty();
     }
 }

--- a/src/testFixtures/java/events/application/port/in/request/CreateEventRequestTestDataBuilder.java
+++ b/src/testFixtures/java/events/application/port/in/request/CreateEventRequestTestDataBuilder.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 public class CreateEventRequestTestDataBuilder {
     private String title = "전자컴퓨터공학부 2025-2 사물함 신청";
-    private Long departmentId = 1L;
     private LocalDateTime startAt = LocalDateTime.of(2025, 8, 1, 15, 0);
     private LocalDateTime endAt = LocalDateTime.of(2025, 8, 1, 16, 0);
     private List<Long> participationDepartmentIds = List.of(1L, 2L, 3L);
@@ -21,11 +20,6 @@ public class CreateEventRequestTestDataBuilder {
 
     public CreateEventRequestTestDataBuilder withTitle(String title) {
         this.title = title;
-        return this;
-    }
-
-    public CreateEventRequestTestDataBuilder withDepartmentId(Long departmentId) {
-        this.departmentId = departmentId;
         return this;
     }
 
@@ -51,7 +45,6 @@ public class CreateEventRequestTestDataBuilder {
     }
 
     public CreateEventRequest build() {
-        return new CreateEventRequest(
-                title, departmentId, startAt, endAt, participationDepartmentIds, floors);
+        return new CreateEventRequest(title, startAt, endAt, participationDepartmentIds, floors);
     }
 }

--- a/src/testFixtures/java/events/application/port/in/request/FloorInfoTestDataBuilder.java
+++ b/src/testFixtures/java/events/application/port/in/request/FloorInfoTestDataBuilder.java
@@ -1,14 +1,19 @@
 package events.application.port.in.request;
 
 import com.jnulocker.events.application.port.in.request.FloorInfo;
+import com.jnulocker.events.application.port.in.request.LockerRange;
+import com.jnulocker.events.application.port.in.request.PrefixInfo;
+import java.util.ArrayList;
+import java.util.List;
 
 public class FloorInfoTestDataBuilder {
     private Integer floorNumber = 1;
-    private String lockerPrefix = "A";
-    private Integer lockerStartNumber = 1;
-    private Integer lockerEndNumber = 20;
+    private List<PrefixInfo> prefixes = new ArrayList<>();
 
-    private FloorInfoTestDataBuilder() {}
+    private FloorInfoTestDataBuilder() {
+        // 기본적으로 하나의 PrefixInfo와 LockerRange 추가
+        prefixes.add(new PrefixInfo("A", List.of(new LockerRange(1, 20))));
+    }
 
     public static FloorInfoTestDataBuilder floorInfoBuilder() {
         return new FloorInfoTestDataBuilder();
@@ -19,22 +24,35 @@ public class FloorInfoTestDataBuilder {
         return this;
     }
 
-    public FloorInfoTestDataBuilder withLockerPrefix(String lockerPrefix) {
-        this.lockerPrefix = lockerPrefix;
+    public FloorInfoTestDataBuilder withPrefix(String lockerPrefix, List<LockerRange> ranges) {
+        this.prefixes.add(new PrefixInfo(lockerPrefix, ranges));
         return this;
     }
 
-    public FloorInfoTestDataBuilder withLockerStartNumber(Integer lockerStartNumber) {
-        this.lockerStartNumber = lockerStartNumber;
+    public FloorInfoTestDataBuilder withPrefix(
+            String lockerPrefix, Integer startNumber, Integer endNumber) {
+        this.prefixes.add(
+                new PrefixInfo(lockerPrefix, List.of(new LockerRange(startNumber, endNumber))));
         return this;
     }
 
-    public FloorInfoTestDataBuilder withLockerEndNumber(Integer lockerEndNumber) {
-        this.lockerEndNumber = lockerEndNumber;
+    public FloorInfoTestDataBuilder withPrefixes(List<PrefixInfo> prefixes) {
+        this.prefixes = new ArrayList<>(prefixes);
+        return this;
+    }
+
+    public FloorInfoTestDataBuilder addRangeToLastPrefix(Integer startNumber, Integer endNumber) {
+        if (prefixes.isEmpty()) {
+            prefixes.add(new PrefixInfo("A", new ArrayList<>()));
+        }
+        PrefixInfo lastPrefix = prefixes.get(prefixes.size() - 1);
+        List<LockerRange> updatedRanges = new ArrayList<>(lastPrefix.ranges());
+        updatedRanges.add(new LockerRange(startNumber, endNumber));
+        prefixes.set(prefixes.size() - 1, new PrefixInfo(lastPrefix.lockerPrefix(), updatedRanges));
         return this;
     }
 
     public FloorInfo build() {
-        return new FloorInfo(floorNumber, lockerPrefix, lockerStartNumber, lockerEndNumber);
+        return new FloorInfo(floorNumber, prefixes);
     }
 }

--- a/src/testFixtures/java/events/application/port/in/request/FloorInfoTestDataBuilder.java
+++ b/src/testFixtures/java/events/application/port/in/request/FloorInfoTestDataBuilder.java
@@ -41,17 +41,6 @@ public class FloorInfoTestDataBuilder {
         return this;
     }
 
-    public FloorInfoTestDataBuilder addRangeToLastPrefix(Integer startNumber, Integer endNumber) {
-        if (prefixes.isEmpty()) {
-            prefixes.add(new PrefixInfo("A", new ArrayList<>()));
-        }
-        PrefixInfo lastPrefix = prefixes.get(prefixes.size() - 1);
-        List<LockerRange> updatedRanges = new ArrayList<>(lastPrefix.ranges());
-        updatedRanges.add(new LockerRange(startNumber, endNumber));
-        prefixes.set(prefixes.size() - 1, new PrefixInfo(lastPrefix.lockerPrefix(), updatedRanges));
-        return this;
-    }
-
     public FloorInfo build() {
         return new FloorInfo(floorNumber, prefixes);
     }


### PR DESCRIPTION
### 개요
close #50 

### 작업사항
- 사물함 이벤트 생성 시 **층 목록 - 접두사 목록 - 범위 목록** 순으로 입력받아 생성하도록 개선

### 변경로직
- 사물함 이벤트 생성 요청 본문 수정
<details><summary>기본 요청 본문 - 층 목록만 받아서 해당 층 아이템마다 접두사와 사물함 범위 넘김</summary>

```json
{
  "title": "전자컴퓨터공학부 2025-2 사물함 신청",
  "departmentId": 1,
  "startAt": "2025-08-01T15:00:00",
  "endAt": "2025-08-01T16:00:00",
  "participationDepartmentIds": [
    1,
    2,
    3
  ],
  "floors": [
    {
      "floorNumber": 1,
      "lockerPrefix": "A",
      "lockerStartNumber": 1,
      "lockerEndNumber": 20
    }
  ]
}
```

</details> 

<details><summary>수정된 요청 본문 - 층 목록, 접두사 목록, 범위 목록 순의 계층구조로 수정</summary>

```json
{
  "title": "전자컴퓨터공학부 2025-2 사물함 신청",
  "departmentId": 1,
  "startAt": "2025-08-01T15:00:00",
  "endAt": "2025-08-01T16:00:00",
  "participationDepartmentIds": [
    1,
    2,
    3
  ],
  "floors": [
    {
      "floorNumber": 1,
      "prefixes": [
        {
          "lockerPrefix": "A",
          "ranges": [
            {
              "lockerStartNumber": 1,
              "lockerEndNumber": 20
            },
            {
              "lockerStartNumber": 30,
              "lockerEndNumber": 40
            }
          ]
        },
        {
          "lockerPrefix": "B",
          "ranges": [
            {
              "lockerStartNumber": 1,
              "lockerEndNumber": 15
            }
          ]
        }
      ]
    },
    {
      "floorNumber": 2,
      "prefixes": [
        {
          "lockerPrefix": "C",
          "ranges": [
            {
              "lockerStartNumber": 1,
              "lockerEndNumber": 10
            },
            {
              "lockerStartNumber": 20,
              "lockerEndNumber": 25
            }
          ]
        }
      ]
    }
  ]
}
```

</details> 


### 테스트 결과

<img width="307" alt="image" src="https://github.com/user-attachments/assets/5d4e1eec-e50b-4d75-8575-7d55681315c3" />
<img width="347" alt="image" src="https://github.com/user-attachments/assets/9ab6f372-c7c3-4949-9572-aab087805c38" />

### reference
- 현재는 각 사물함마다 `INSERT` 쿼리가 나가고있습니다. PK 생성에 대해 `IDENTITY` 전략을 사용하고 있어 `Batch Insert`는 적용하지 못했습니다. `Batch Insert`를 적용하기 위해 기본키 생성 전략을 바꾸어야 할지는 논의해 보아야겠습니다.

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 여러 개의 사물함 접두사 및 번호 범위를 한 층에 지정할 수 있도록 이벤트 생성 기능이 확장되었습니다.

- **버그 수정**
  - 사물함 종료 번호가 시작 번호보다 작을 경우 유효성 검증 오류가 발생하도록 개선되었습니다.

- **변경 사항**
  - 이벤트 생성 시 주최 부서 정보가 요청에서 입력되지 않고, 인증된 사용자의 소속 부서로 자동 지정됩니다.
  - 이벤트 생성 요청에서 부서 ID(departmentId) 필드가 제거되었습니다.
  - 사물함 정보 입력 방식이 접두사 및 범위 리스트 구조로 변경되었습니다.

- **테스트**
  - 새로운 사물함 범위 및 접두사 구조에 맞춘 테스트가 추가 및 수정되었습니다.
  - 부서 ID 관련 테스트가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->