### PR TITLE
[FEAT] 사물함 신청 API 구현

### DIFF
--- a/src/main/java/com/jnulocker/config/SecurityConfig.java
+++ b/src/main/java/com/jnulocker/config/SecurityConfig.java
@@ -67,7 +67,7 @@ public class SecurityConfig {
                                 .permitAll() // 인증 API 모든 접근 허용
                                 .requestMatchers(
                                         HttpMethod.GET, "/v1/events", "/v1/events/*/lockers")
-                                .hasAuthority("guest")
+                                .authenticated()
                                 .requestMatchers(HttpMethod.POST, "/v1/events")
                                 .hasAuthority(
                                         "guest") // 권한이 MANAGER인 유저만 사용 가능 // TODO: 추후 manager로 변경,

--- a/src/main/java/com/jnulocker/events/adapter/in/docs/EventApi.java
+++ b/src/main/java/com/jnulocker/events/adapter/in/docs/EventApi.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Tag(name = "사물함 이벤트", description = "사물함 이벤트 관련 API")
 public interface EventApi {
 
-    @Operation(summary = "사물함 이벤트 목록 조회", description = "사물함 이벤트 목록을 조회합니다. 페이지네이션이 지원됩니다.")
+    @Operation(summary = "이벤트 목록 조회", description = "사물함 이벤트 목록을 조회합니다. 페이지네이션이 지원됩니다.")
     @ApiResponse(
             responseCode = "200",
             description = "이벤트 목록 조회 성공",

--- a/src/main/java/com/jnulocker/events/adapter/in/docs/EventApi.java
+++ b/src/main/java/com/jnulocker/events/adapter/in/docs/EventApi.java
@@ -19,10 +19,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@Tag(name = "사물함 신청 이벤트", description = "사물함 신청 이벤트 관련 API")
+@Tag(name = "사물함 이벤트", description = "사물함 이벤트 관련 API")
 public interface EventApi {
 
-    @Operation(summary = "사물함 신청 이벤트 목록 조회", description = "사물함 신청 이벤트 목록을 조회합니다. 페이지네이션이 지원됩니다.")
+    @Operation(summary = "사물함 이벤트 목록 조회", description = "사물함 이벤트 목록을 조회합니다. 페이지네이션이 지원됩니다.")
     @ApiResponse(
             responseCode = "200",
             description = "이벤트 목록 조회 성공",
@@ -35,12 +35,12 @@ public interface EventApi {
     @ApiExceptionExamples(CreateEventExceptionDocs.class)
     @Operation(
             summary = "이벤트 생성",
-            description = "새로운 사물함 신청 이벤트를 생성합니다. 이벤트 상태는 기본적으로 READY, 게시 상태는 false로 설정됩니다.")
+            description = "새로운 사물함 이벤트를 생성합니다. 이벤트 상태는 기본적으로 READY, 게시 상태는 false로 설정됩니다.")
     @ApiResponse(responseCode = "201", description = "이벤트 생성 성공")
     ResponseEntity<Void> createEvent(@Valid @RequestBody CreateEventRequest request);
 
     @ApiExceptionExamples(GetLockerExceptionDocs.class)
-    @Operation(summary = "사물함 목록 조회", description = "사물함 신청 이벤트에 대한 사물함 목록을 조회합니다.")
+    @Operation(summary = "사물함 목록 조회", description = "사물함 이벤트에 대한 사물함 목록을 조회합니다.")
     @ApiResponse(
             responseCode = "200",
             description = "사물함 목록 조회 성공",

--- a/src/main/java/com/jnulocker/events/adapter/in/docs/EventApi.java
+++ b/src/main/java/com/jnulocker/events/adapter/in/docs/EventApi.java
@@ -19,10 +19,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@Tag(name = "사물함 이벤트", description = "사물함 이벤트 관련 API")
+@Tag(name = "이벤트", description = "이벤트 관련 API")
 public interface EventApi {
 
-    @Operation(summary = "이벤트 목록 조회", description = "사물함 이벤트 목록을 조회합니다. 페이지네이션이 지원됩니다.")
+    @Operation(summary = "이벤트 목록 조회", description = "이벤트 목록을 조회합니다. 페이지네이션이 지원됩니다.")
     @ApiResponse(
             responseCode = "200",
             description = "이벤트 목록 조회 성공",
@@ -35,12 +35,12 @@ public interface EventApi {
     @ApiExceptionExamples(CreateEventExceptionDocs.class)
     @Operation(
             summary = "이벤트 생성",
-            description = "새로운 사물함 이벤트를 생성합니다. 이벤트 상태는 기본적으로 READY, 게시 상태는 false로 설정됩니다.")
+            description = "새로운 이벤트를 생성합니다. 이벤트 상태는 기본적으로 READY, 게시 상태는 false로 설정됩니다.")
     @ApiResponse(responseCode = "201", description = "이벤트 생성 성공")
     ResponseEntity<Void> createEvent(@Valid @RequestBody CreateEventRequest request);
 
     @ApiExceptionExamples(GetLockerExceptionDocs.class)
-    @Operation(summary = "사물함 목록 조회", description = "사물함 이벤트에 대한 사물함 목록을 조회합니다.")
+    @Operation(summary = "사물함 목록 조회", description = "이벤트에 대한 사물함 목록을 조회합니다.")
     @ApiResponse(
             responseCode = "200",
             description = "사물함 목록 조회 성공",

--- a/src/main/java/com/jnulocker/events/adapter/out/LockerPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/LockerPersistenceAdapter.java
@@ -4,6 +4,7 @@ import com.jnulocker.common.annotation.PersistenceAdapter;
 import com.jnulocker.events.application.port.out.LockerLoadPort;
 import com.jnulocker.events.domain.Locker;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 @PersistenceAdapter
@@ -11,6 +12,11 @@ import lombok.RequiredArgsConstructor;
 public class LockerPersistenceAdapter implements LockerLoadPort {
 
     private final LockerRepository lockerRepository;
+
+    @Override
+    public Optional<Locker> getById(Long lockerId) {
+        return lockerRepository.findByIdWithFloorAndEvent(lockerId);
+    }
 
     @Override
     public List<Locker> getLockersByFloorId(Long floorId) {

--- a/src/main/java/com/jnulocker/events/adapter/out/LockerRepository.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/LockerRepository.java
@@ -2,9 +2,14 @@ package com.jnulocker.events.adapter.out;
 
 import com.jnulocker.events.domain.Locker;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface LockerRepository extends JpaRepository<Locker, Long> {
 
     List<Locker> findAllByFloorId(Long floorId);
+
+    @Query("SELECT l FROM Locker l JOIN FETCH l.floor f JOIN FETCH f.event WHERE l.id = :lockerId")
+    Optional<Locker> findByIdWithFloorAndEvent(Long lockerId);
 }

--- a/src/main/java/com/jnulocker/events/application/port/in/EventQuery.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/EventQuery.java
@@ -3,6 +3,7 @@ package com.jnulocker.events.application.port.in;
 import com.jnulocker.events.application.port.in.response.EventCustomPage;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
 import com.jnulocker.events.domain.Event;
+import com.jnulocker.events.domain.Locker;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 
@@ -11,6 +12,8 @@ public interface EventQuery {
     Event getByIdOrThrow(Long eventId);
 
     EventCustomPage getAllEvents(Pageable pageable);
+
+    Locker getLockerByIdOrThrow(Long lockerId);
 
     List<FloorWithLockersResponse> getLockersByEventId(Long eventId);
 }

--- a/src/main/java/com/jnulocker/events/application/port/out/LockerLoadPort.java
+++ b/src/main/java/com/jnulocker/events/application/port/out/LockerLoadPort.java
@@ -2,8 +2,11 @@ package com.jnulocker.events.application.port.out;
 
 import com.jnulocker.events.domain.Locker;
 import java.util.List;
+import java.util.Optional;
 
 public interface LockerLoadPort {
+
+    Optional<Locker> getById(Long lockerId);
 
     List<Locker> getLockersByFloorId(Long floorId);
 }

--- a/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
+++ b/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
@@ -9,7 +9,9 @@ import com.jnulocker.events.application.port.out.FloorLoadPort;
 import com.jnulocker.events.application.port.out.LockerLoadPort;
 import com.jnulocker.events.domain.Event;
 import com.jnulocker.events.domain.Floor;
+import com.jnulocker.events.domain.Locker;
 import com.jnulocker.events.exception.EventNotFoundException;
+import com.jnulocker.events.exception.LockerNotFoundException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -34,6 +36,13 @@ public class EventQueryService implements EventQuery {
         // TODO: MANAGER가 조회하는 경우 자신이 소속된 조직의 이벤트만 조회할 수 있도록 수정
         Page<Event> events = eventLoadPort.getAllEvents(pageable);
         return EventCustomPage.from(events);
+    }
+
+    @Override
+    public Locker getLockerByIdOrThrow(Long lockerId) {
+        return lockerLoadPort
+                .getById(lockerId)
+                .orElseThrow(() -> LockerNotFoundException.EXCEPTION);
     }
 
     @Override

--- a/src/main/java/com/jnulocker/events/domain/Event.java
+++ b/src/main/java/com/jnulocker/events/domain/Event.java
@@ -58,10 +58,35 @@ public class Event extends BaseEntity {
                 .build();
     }
 
+    public static Event create(
+            String title,
+            Department department,
+            LocalDateTime startAt,
+            LocalDateTime endAt,
+            EventStatus eventStatus,
+            Boolean publish) {
+        return Event.builder()
+                .title(title)
+                .department(department)
+                .eventSchedule(EventSchedule.of(startAt, endAt))
+                .eventStatus(eventStatus)
+                .publish(publish)
+                .build();
+    }
+
     public void validateRegistration(Role role) {
-        // 이벤트 상태가 OPEN인 경우만 신청 가능
-        // publish가 false인 경우 MANAGER만 신청 가능
-        if ((eventStatus != EventStatus.OPEN) || (!publish && role != Role.MANAGER)) {
+        validatePublishStatus(role);
+        validateEventStatus();
+    }
+
+    private void validatePublishStatus(Role role) {
+        if (Boolean.FALSE.equals(publish) && role != Role.MANAGER) {
+            throw EventNotOpenException.EXCEPTION;
+        }
+    }
+
+    private void validateEventStatus() {
+        if (eventStatus != EventStatus.OPEN) {
             throw EventNotOpenException.EXCEPTION;
         }
     }

--- a/src/main/java/com/jnulocker/events/domain/Event.java
+++ b/src/main/java/com/jnulocker/events/domain/Event.java
@@ -1,6 +1,8 @@
 package com.jnulocker.events.domain;
 
 import com.jnulocker.common.persistence.BaseEntity;
+import com.jnulocker.events.exception.EventNotOpenException;
+import com.jnulocker.member.domain.Role;
 import com.jnulocker.organization.domain.Department;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -54,6 +56,14 @@ public class Event extends BaseEntity {
                 .eventStatus(EventStatus.READY)
                 .publish(false)
                 .build();
+    }
+
+    public void validateRegistration(Role role) {
+        // 이벤트 상태가 OPEN인 경우만 신청 가능
+        // publish가 false인 경우 MANAGER만 신청 가능
+        if ((eventStatus != EventStatus.OPEN) || (!publish && role != Role.MANAGER)) {
+            throw EventNotOpenException.EXCEPTION;
+        }
     }
 
     public void openEvent() {

--- a/src/main/java/com/jnulocker/events/domain/Locker.java
+++ b/src/main/java/com/jnulocker/events/domain/Locker.java
@@ -1,6 +1,8 @@
 package com.jnulocker.events.domain;
 
 import com.jnulocker.common.persistence.BaseEntity;
+import com.jnulocker.events.exception.LockerUnavailableException;
+import com.jnulocker.member.domain.Role;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -37,5 +39,14 @@ public class Locker extends BaseEntity {
 
     public static Locker create(Floor floor, String code, Boolean available) {
         return Locker.builder().floor(floor).code(code).available(available).build();
+    }
+
+    public void validateRegistration(Role role) {
+        Event event = floor.getEvent();
+        event.validateRegistration(role);
+
+        if (Boolean.FALSE.equals(available)) {
+            throw LockerUnavailableException.EXCEPTION;
+        }
     }
 }

--- a/src/main/java/com/jnulocker/events/domain/Locker.java
+++ b/src/main/java/com/jnulocker/events/domain/Locker.java
@@ -44,7 +44,16 @@ public class Locker extends BaseEntity {
     public void validateRegistration(Role role) {
         Event event = floor.getEvent();
         event.validateRegistration(role);
+        checkAvailability();
+    }
 
+    // 새로 추가: 사물함을 사용 불가 상태로 변경
+    public void markAsUnavailable() {
+        checkAvailability();
+        this.available = false;
+    }
+
+    private void checkAvailability() {
         if (Boolean.FALSE.equals(available)) {
             throw LockerUnavailableException.EXCEPTION;
         }

--- a/src/main/java/com/jnulocker/events/exception/EventErrorCode.java
+++ b/src/main/java/com/jnulocker/events/exception/EventErrorCode.java
@@ -9,6 +9,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum EventErrorCode implements ErrorCode {
     EVENT_NOT_FOUND("E001", HttpStatus.NOT_FOUND, "이벤트가 존재하지 않습니다"),
+    EVENT_NOT_OPEN("E002", HttpStatus.BAD_REQUEST, "이벤트가 열려있지 않습니다"),
+    LOCKER_NOT_FOUND("E003", HttpStatus.NOT_FOUND, "사물함이 존재하지 않습니다"),
+    LOCKER_UNAVAILABLE("E004", HttpStatus.BAD_REQUEST, "사용중인 사물함입니다"),
     ;
 
     private final String code;

--- a/src/main/java/com/jnulocker/events/exception/EventErrorCode.java
+++ b/src/main/java/com/jnulocker/events/exception/EventErrorCode.java
@@ -12,6 +12,7 @@ public enum EventErrorCode implements ErrorCode {
     EVENT_NOT_OPEN("E002", HttpStatus.BAD_REQUEST, "이벤트가 열려있지 않습니다"),
     LOCKER_NOT_FOUND("E003", HttpStatus.NOT_FOUND, "사물함이 존재하지 않습니다"),
     LOCKER_UNAVAILABLE("E004", HttpStatus.BAD_REQUEST, "사용중인 사물함입니다"),
+    INVALID_LOCKER_FOR_EVENT("E005", HttpStatus.BAD_REQUEST, "이벤트에 해당하지 않는 사물함입니다"),
     ;
 
     private final String code;

--- a/src/main/java/com/jnulocker/events/exception/EventNotOpenException.java
+++ b/src/main/java/com/jnulocker/events/exception/EventNotOpenException.java
@@ -1,0 +1,12 @@
+package com.jnulocker.events.exception;
+
+import com.jnulocker.common.exception.BusinessException;
+
+public class EventNotOpenException extends BusinessException {
+
+    public static final BusinessException EXCEPTION = new EventNotOpenException();
+
+    private EventNotOpenException() {
+        super(EventErrorCode.EVENT_NOT_OPEN);
+    }
+}

--- a/src/main/java/com/jnulocker/events/exception/InvalidLockerForEventException.java
+++ b/src/main/java/com/jnulocker/events/exception/InvalidLockerForEventException.java
@@ -1,0 +1,12 @@
+package com.jnulocker.events.exception;
+
+import com.jnulocker.common.exception.BusinessException;
+
+public class InvalidLockerForEventException extends BusinessException {
+
+    public static final BusinessException EXCEPTION = new InvalidLockerForEventException();
+
+    private InvalidLockerForEventException() {
+        super(EventErrorCode.INVALID_LOCKER_FOR_EVENT);
+    }
+}

--- a/src/main/java/com/jnulocker/events/exception/LockerNotFoundException.java
+++ b/src/main/java/com/jnulocker/events/exception/LockerNotFoundException.java
@@ -1,0 +1,12 @@
+package com.jnulocker.events.exception;
+
+import com.jnulocker.common.exception.BusinessException;
+
+public class LockerNotFoundException extends BusinessException {
+
+    public static final BusinessException EXCEPTION = new LockerNotFoundException();
+
+    private LockerNotFoundException() {
+        super(EventErrorCode.LOCKER_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/jnulocker/events/exception/LockerUnavailableException.java
+++ b/src/main/java/com/jnulocker/events/exception/LockerUnavailableException.java
@@ -1,0 +1,12 @@
+package com.jnulocker.events.exception;
+
+import com.jnulocker.common.exception.BusinessException;
+
+public class LockerUnavailableException extends BusinessException {
+
+    public static final BusinessException EXCEPTION = new LockerUnavailableException();
+
+    private LockerUnavailableException() {
+        super(EventErrorCode.LOCKER_UNAVAILABLE);
+    }
+}

--- a/src/main/java/com/jnulocker/registration/adapter/in/RegistrationController.java
+++ b/src/main/java/com/jnulocker/registration/adapter/in/RegistrationController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/v1/{event-id}/registrations")
+@RequestMapping("/v1/events/{event-id}/registrations")
 public class RegistrationController implements RegistrationApi {
 
     private final RegistrationCommand registrationCommand;

--- a/src/main/java/com/jnulocker/registration/adapter/in/RegistrationController.java
+++ b/src/main/java/com/jnulocker/registration/adapter/in/RegistrationController.java
@@ -1,5 +1,6 @@
 package com.jnulocker.registration.adapter.in;
 
+import com.jnulocker.registration.adapter.in.docs.RegistrationApi;
 import com.jnulocker.registration.application.port.in.RegistrationCommand;
 import com.jnulocker.registration.application.port.in.request.RegisterForEventRequest;
 import jakarta.validation.Valid;
@@ -15,10 +16,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/{event-id}/registrations")
-public class RegistrationController {
+public class RegistrationController implements RegistrationApi {
 
     private final RegistrationCommand registrationCommand;
 
+    @Override
     @PostMapping
     public ResponseEntity<Void> registerForEvent(
             @PathVariable("event-id") Long eventId,

--- a/src/main/java/com/jnulocker/registration/adapter/in/RegistrationController.java
+++ b/src/main/java/com/jnulocker/registration/adapter/in/RegistrationController.java
@@ -1,0 +1,29 @@
+package com.jnulocker.registration.adapter.in;
+
+import com.jnulocker.registration.application.port.in.RegistrationCommand;
+import com.jnulocker.registration.application.port.in.request.RegisterForEventRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/{event-id}/registrations")
+public class RegistrationController {
+
+    private final RegistrationCommand registrationCommand;
+
+    @PostMapping
+    public ResponseEntity<Void> registerForEvent(
+            @PathVariable("event-id") Long eventId,
+            @Valid @RequestBody RegisterForEventRequest request) {
+        registrationCommand.registerForEvent(eventId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/com/jnulocker/registration/adapter/in/docs/RegistrationApi.java
+++ b/src/main/java/com/jnulocker/registration/adapter/in/docs/RegistrationApi.java
@@ -1,0 +1,22 @@
+package com.jnulocker.registration.adapter.in.docs;
+
+import com.jnulocker.common.swagger.ApiExceptionExamples;
+import com.jnulocker.registration.application.port.in.request.RegisterForEventRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "사물함 신청 API", description = "사물함 신청 관련 API")
+public interface RegistrationApi {
+
+    @ApiExceptionExamples(RegistrationForEventExceptionDocs.class)
+    @Operation(summary = "사물함 신청", description = "사물함 이벤트에 신청합니다. 사물함을 선택할 수 있습니다.")
+    @ApiResponse(responseCode = "201", description = "사물함 신청 성공")
+    ResponseEntity<Void> registerForEvent(
+            @PathVariable("event-id") Long eventId,
+            @Valid @RequestBody RegisterForEventRequest request);
+}

--- a/src/main/java/com/jnulocker/registration/adapter/in/docs/RegistrationApi.java
+++ b/src/main/java/com/jnulocker/registration/adapter/in/docs/RegistrationApi.java
@@ -10,7 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@Tag(name = "사물함 신청 API", description = "사물함 신청 관련 API")
+@Tag(name = "사물함 신청", description = "사물함 신청 관련 API")
 public interface RegistrationApi {
 
     @ApiExceptionExamples(RegistrationForEventExceptionDocs.class)

--- a/src/main/java/com/jnulocker/registration/adapter/in/docs/RegistrationForEventExceptionDocs.java
+++ b/src/main/java/com/jnulocker/registration/adapter/in/docs/RegistrationForEventExceptionDocs.java
@@ -1,0 +1,44 @@
+package com.jnulocker.registration.adapter.in.docs;
+
+import com.jnulocker.common.exception.BusinessException;
+import com.jnulocker.common.swagger.ExceptionDoc;
+import com.jnulocker.common.swagger.ExplainError;
+import com.jnulocker.common.swagger.SwaggerExceptionDoc;
+import com.jnulocker.events.exception.EventNotFoundException;
+import com.jnulocker.events.exception.EventNotOpenException;
+import com.jnulocker.events.exception.InvalidLockerForEventException;
+import com.jnulocker.events.exception.LockerNotFoundException;
+import com.jnulocker.events.exception.LockerUnavailableException;
+import com.jnulocker.member.exception.MemberNotFoundException;
+import com.jnulocker.registration.exception.RegistrationAlreadyExistsException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@ExceptionDoc
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RegistrationForEventExceptionDocs implements SwaggerExceptionDoc {
+
+    @ExplainError("회원이 존재하지 않을 때 발생하는 예외입니다.")
+    public static final BusinessException 회원이_존재하지_않을_때 = MemberNotFoundException.EXCEPTION;
+
+    @ExplainError("이벤트가 존재하지 않을 때 발생하는 예외입니다.")
+    public static final BusinessException 이벤트가_존재하지_않을_때 = EventNotFoundException.EXCEPTION;
+
+    @ExplainError("사물함이 존재하지 않을 때 발생하는 예외입니다.")
+    public static final BusinessException 사물함이_존재하지_않을_때 = LockerNotFoundException.EXCEPTION;
+
+    @ExplainError("이벤트에 해당하지 않는 사물함을 신청할 때 발생하는 예외입니다.")
+    public static final BusinessException 이벤트에_해당하지_않는_사물함을_신청할_때 =
+            InvalidLockerForEventException.EXCEPTION;
+
+    @ExplainError("이미 해당 이벤트에서 사물함을 신청했을 때 발생하는 예외입니다.")
+    public static final BusinessException 이미_해당_이벤트에서_사물함을_신청했을_때 =
+            RegistrationAlreadyExistsException.EXCEPTION;
+
+    @ExplainError(
+            "이벤트가 열려있지 않을 때 발생하는 예외입니다. eventStatus가 OPEN이 아니거나, USER가 publish == false인 이벤트에서 신청을 요청하는 경우 발생합니다.")
+    public static final BusinessException 이벤트가_열려있지_않을_때 = EventNotOpenException.EXCEPTION;
+
+    @ExplainError("사물함이 사용중(available == false)일 때 발생하는 예외입니다.")
+    public static final BusinessException 사물함이_사용중일_때 = LockerUnavailableException.EXCEPTION;
+}

--- a/src/main/java/com/jnulocker/registration/adapter/out/RegistrationPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/registration/adapter/out/RegistrationPersistenceAdapter.java
@@ -1,0 +1,18 @@
+package com.jnulocker.registration.adapter.out;
+
+import com.jnulocker.common.annotation.PersistenceAdapter;
+import com.jnulocker.registration.application.port.out.RegistrationRecordPort;
+import com.jnulocker.registration.domain.Registration;
+import lombok.RequiredArgsConstructor;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class RegistrationPersistenceAdapter implements RegistrationRecordPort {
+
+    private final RegistrationRepository registrationRepository;
+
+    @Override
+    public void save(Registration registration) {
+        registrationRepository.save(registration);
+    }
+}

--- a/src/main/java/com/jnulocker/registration/adapter/out/RegistrationPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/registration/adapter/out/RegistrationPersistenceAdapter.java
@@ -1,18 +1,25 @@
 package com.jnulocker.registration.adapter.out;
 
 import com.jnulocker.common.annotation.PersistenceAdapter;
+import com.jnulocker.registration.application.port.out.RegistrationLoadPort;
 import com.jnulocker.registration.application.port.out.RegistrationRecordPort;
 import com.jnulocker.registration.domain.Registration;
 import lombok.RequiredArgsConstructor;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class RegistrationPersistenceAdapter implements RegistrationRecordPort {
+public class RegistrationPersistenceAdapter
+        implements RegistrationLoadPort, RegistrationRecordPort {
 
     private final RegistrationRepository registrationRepository;
 
     @Override
     public void save(Registration registration) {
         registrationRepository.save(registration);
+    }
+
+    @Override
+    public boolean existsByMemberIdAndEventId(Long memberId, Long eventId) {
+        return registrationRepository.existsByMemberIdAndLocker_Floor_EventId(memberId, eventId);
     }
 }

--- a/src/main/java/com/jnulocker/registration/adapter/out/RegistrationRepository.java
+++ b/src/main/java/com/jnulocker/registration/adapter/out/RegistrationRepository.java
@@ -1,0 +1,6 @@
+package com.jnulocker.registration.adapter.out;
+
+import com.jnulocker.registration.domain.Registration;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RegistrationRepository extends JpaRepository<Registration, Long> {}

--- a/src/main/java/com/jnulocker/registration/adapter/out/RegistrationRepository.java
+++ b/src/main/java/com/jnulocker/registration/adapter/out/RegistrationRepository.java
@@ -3,4 +3,6 @@ package com.jnulocker.registration.adapter.out;
 import com.jnulocker.registration.domain.Registration;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RegistrationRepository extends JpaRepository<Registration, Long> {}
+public interface RegistrationRepository extends JpaRepository<Registration, Long> {
+    boolean existsByMemberIdAndLocker_Floor_EventId(Long memberId, Long eventId);
+}

--- a/src/main/java/com/jnulocker/registration/application/port/in/RegistrationCommand.java
+++ b/src/main/java/com/jnulocker/registration/application/port/in/RegistrationCommand.java
@@ -1,0 +1,7 @@
+package com.jnulocker.registration.application.port.in;
+
+import com.jnulocker.registration.application.port.in.request.RegisterForEventRequest;
+
+public interface RegistrationCommand {
+    void registerForEvent(Long eventId, RegisterForEventRequest request);
+}

--- a/src/main/java/com/jnulocker/registration/application/port/in/request/RegisterForEventRequest.java
+++ b/src/main/java/com/jnulocker/registration/application/port/in/request/RegisterForEventRequest.java
@@ -6,6 +6,6 @@ import jakarta.validation.constraints.NotNull;
 
 public record RegisterForEventRequest(
         @Schema(description = "사물함 번호", example = "1")
-        @NotNull(message = "사물함 번호는 필수입니다.")
-        @Min(value = 1, message = "사물함 번호는 1 이상이어야 합니다.")
-        Long lockerId) {}
+                @NotNull(message = "사물함 번호는 필수입니다.")
+                @Min(value = 1, message = "사물함 번호는 1 이상이어야 합니다.")
+                Long lockerId) {}

--- a/src/main/java/com/jnulocker/registration/application/port/in/request/RegisterForEventRequest.java
+++ b/src/main/java/com/jnulocker/registration/application/port/in/request/RegisterForEventRequest.java
@@ -1,3 +1,11 @@
 package com.jnulocker.registration.application.port.in.request;
 
-public record RegisterForEventRequest(Long lockerId) {}
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record RegisterForEventRequest(
+        @Schema(description = "사물함 번호", example = "1")
+        @NotNull(message = "사물함 번호는 필수입니다.")
+        @Min(value = 1, message = "사물함 번호는 1 이상이어야 합니다.")
+        Long lockerId) {}

--- a/src/main/java/com/jnulocker/registration/application/port/in/request/RegisterForEventRequest.java
+++ b/src/main/java/com/jnulocker/registration/application/port/in/request/RegisterForEventRequest.java
@@ -1,0 +1,3 @@
+package com.jnulocker.registration.application.port.in.request;
+
+public record RegisterForEventRequest(Long lockerId) {}

--- a/src/main/java/com/jnulocker/registration/application/port/out/RegistrationLoadPort.java
+++ b/src/main/java/com/jnulocker/registration/application/port/out/RegistrationLoadPort.java
@@ -1,0 +1,6 @@
+package com.jnulocker.registration.application.port.out;
+
+public interface RegistrationLoadPort {
+
+    boolean existsByMemberIdAndEventId(Long memberId, Long eventId);
+}

--- a/src/main/java/com/jnulocker/registration/application/port/out/RegistrationRecordPort.java
+++ b/src/main/java/com/jnulocker/registration/application/port/out/RegistrationRecordPort.java
@@ -1,0 +1,8 @@
+package com.jnulocker.registration.application.port.out;
+
+import com.jnulocker.registration.domain.Registration;
+
+public interface RegistrationRecordPort {
+
+    void save(Registration registration);
+}

--- a/src/main/java/com/jnulocker/registration/application/service/RegistrationCommandService.java
+++ b/src/main/java/com/jnulocker/registration/application/service/RegistrationCommandService.java
@@ -1,0 +1,43 @@
+package com.jnulocker.registration.application.service;
+
+import com.jnulocker.auth.security.SecurityUtils;
+import com.jnulocker.events.application.port.in.EventQuery;
+import com.jnulocker.events.domain.Locker;
+import com.jnulocker.member.application.port.in.MemberQuery;
+import com.jnulocker.member.domain.Member;
+import com.jnulocker.registration.application.port.in.RegistrationCommand;
+import com.jnulocker.registration.application.port.in.request.RegisterForEventRequest;
+import com.jnulocker.registration.application.port.out.RegistrationLoadPort;
+import com.jnulocker.registration.application.port.out.RegistrationRecordPort;
+import com.jnulocker.registration.domain.Registration;
+import com.jnulocker.registration.exception.RegistrationAlreadyExistsException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RegistrationCommandService implements RegistrationCommand {
+
+    private final MemberQuery memberQuery;
+    private final EventQuery eventQuery;
+    private final RegistrationLoadPort registrationLoadPort;
+    private final RegistrationRecordPort registrationRecordPort;
+
+    @Override
+    @Transactional
+    public void registerForEvent(Long eventId, RegisterForEventRequest request) {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        Member member = memberQuery.findByIdOrThrow(memberId);
+
+        // 이미 해당 이벤트에서 사물함 신청을 완료한 경우 예외 발생
+        if (registrationLoadPort.existsByMemberIdAndEventId(memberId, eventId)) {
+            throw RegistrationAlreadyExistsException.EXCEPTION;
+        }
+
+        Locker locker = eventQuery.getLockerByIdOrThrow(request.lockerId());
+
+        Registration registration = Registration.create(member, locker);
+        registrationRecordPort.save(registration);
+    }
+}

--- a/src/main/java/com/jnulocker/registration/application/service/RegistrationCommandService.java
+++ b/src/main/java/com/jnulocker/registration/application/service/RegistrationCommandService.java
@@ -2,7 +2,9 @@ package com.jnulocker.registration.application.service;
 
 import com.jnulocker.auth.security.SecurityUtils;
 import com.jnulocker.events.application.port.in.EventQuery;
+import com.jnulocker.events.domain.Event;
 import com.jnulocker.events.domain.Locker;
+import com.jnulocker.events.exception.InvalidLockerForEventException;
 import com.jnulocker.member.application.port.in.MemberQuery;
 import com.jnulocker.member.domain.Member;
 import com.jnulocker.registration.application.port.in.RegistrationCommand;
@@ -30,12 +32,17 @@ public class RegistrationCommandService implements RegistrationCommand {
         Long memberId = SecurityUtils.getCurrentMemberId();
         Member member = memberQuery.findByIdOrThrow(memberId);
 
+        Event event = eventQuery.getByIdOrThrow(eventId);
+        Locker locker = eventQuery.getLockerByIdOrThrow(request.lockerId());
+
+        if (!event.equals(locker.getFloor().getEvent())) {
+            throw InvalidLockerForEventException.EXCEPTION;
+        }
+
         // 이미 해당 이벤트에서 사물함 신청을 완료한 경우 예외 발생
         if (registrationLoadPort.existsByMemberIdAndEventId(memberId, eventId)) {
             throw RegistrationAlreadyExistsException.EXCEPTION;
         }
-
-        Locker locker = eventQuery.getLockerByIdOrThrow(request.lockerId());
 
         Registration registration = Registration.create(member, locker);
         registrationRecordPort.save(registration);

--- a/src/main/java/com/jnulocker/registration/domain/Registration.java
+++ b/src/main/java/com/jnulocker/registration/domain/Registration.java
@@ -1,5 +1,6 @@
 package com.jnulocker.registration.domain;
 
+import com.jnulocker.common.persistence.BaseEntity;
 import com.jnulocker.events.domain.Locker;
 import com.jnulocker.member.domain.Member;
 import jakarta.persistence.Column;
@@ -21,7 +22,7 @@ import lombok.NoArgsConstructor;
 @Builder(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Registration {
+public class Registration extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/jnulocker/registration/domain/Registration.java
+++ b/src/main/java/com/jnulocker/registration/domain/Registration.java
@@ -1,0 +1,43 @@
+package com.jnulocker.registration.domain;
+
+import com.jnulocker.events.domain.Locker;
+import com.jnulocker.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Registration {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "registration_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "locker_id")
+    private Locker locker;
+
+    public static Registration create(Member member, Locker locker) {
+        locker.validateRegistration(member.getRole());
+        return Registration.builder().member(member).locker(locker).build();
+    }
+}

--- a/src/main/java/com/jnulocker/registration/domain/Registration.java
+++ b/src/main/java/com/jnulocker/registration/domain/Registration.java
@@ -32,7 +32,7 @@ public class Registration {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "locker_id")
     private Locker locker;
 

--- a/src/main/java/com/jnulocker/registration/domain/Registration.java
+++ b/src/main/java/com/jnulocker/registration/domain/Registration.java
@@ -38,6 +38,7 @@ public class Registration {
 
     public static Registration create(Member member, Locker locker) {
         locker.validateRegistration(member.getRole());
+        locker.markAsUnavailable();
         return Registration.builder().member(member).locker(locker).build();
     }
 }

--- a/src/main/java/com/jnulocker/registration/exception/RegistrationAlreadyExistsException.java
+++ b/src/main/java/com/jnulocker/registration/exception/RegistrationAlreadyExistsException.java
@@ -1,0 +1,12 @@
+package com.jnulocker.registration.exception;
+
+import com.jnulocker.common.exception.BusinessException;
+
+public class RegistrationAlreadyExistsException extends BusinessException {
+
+    public static final BusinessException EXCEPTION = new RegistrationAlreadyExistsException();
+
+    private RegistrationAlreadyExistsException() {
+        super(RegistrationErrorCode.REGISTRATION_ALREADY_EXISTS);
+    }
+}

--- a/src/main/java/com/jnulocker/registration/exception/RegistrationErrorCode.java
+++ b/src/main/java/com/jnulocker/registration/exception/RegistrationErrorCode.java
@@ -1,0 +1,17 @@
+package com.jnulocker.registration.exception;
+
+import com.jnulocker.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum RegistrationErrorCode implements ErrorCode {
+    REGISTRATION_ALREADY_EXISTS("R001", HttpStatus.BAD_REQUEST, "이미 해당 회원이 신청한 사물함이 존재합니다."),
+    ;
+
+    private final String code;
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
@@ -4,6 +4,8 @@ import static auth.application.port.in.request.ManagerSignupRequestTestDataBuild
 import static auth.application.port.in.request.UserSignupRequestTestDataBuilder.userSignupRequestBuilder;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static organization.domain.DepartmentTestDataBuilder.*;
+import static organization.domain.OrganizationTestDataBuilder.*;
 
 import com.jnulocker.auth.adapter.out.TokenRepository;
 import com.jnulocker.auth.application.port.in.request.LoginRequest;
@@ -11,7 +13,6 @@ import com.jnulocker.auth.application.port.in.request.ManagerSignupRequest;
 import com.jnulocker.auth.application.port.in.request.UserSignupRequest;
 import com.jnulocker.auth.exception.AuthErrorCode;
 import com.jnulocker.auth.jwt.RefreshToken;
-import com.jnulocker.auth.jwt.TokenProvider;
 import com.jnulocker.auth.jwt.exception.JwtErrorCode;
 import com.jnulocker.common.exception.ErrorResponse;
 import com.jnulocker.member.adapter.out.MemberRepository;
@@ -44,8 +45,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import organization.builder.DepartmentTestDataBuilder;
-import organization.builder.OrganizationTestDataBuilder;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @Testcontainers
@@ -64,8 +63,6 @@ class AuthControllerIntegrationTest {
     @Autowired private DepartmentRepository departmentRepository;
 
     @Autowired private TokenRepository tokenRepository;
-
-    @Autowired private TokenProvider tokenProvider;
 
     @Value("${custom.jwt.access-secret-key}")
     String accessSecretKey;
@@ -237,7 +234,7 @@ class AuthControllerIntegrationTest {
     void 만료된_리프레시토큰으로_재발급하면_Token_Expired_에러가_발생한다() {
         // given
         Member member = createTestMember();
-        String expiredRefreshToken = createExpiredRefreshToken(member.getId(), refreshSecretKey);
+        String expiredRefreshToken = createExpiredToken(member.getId(), refreshSecretKey);
         RefreshToken refreshToken = new RefreshToken(member.getId(), expiredRefreshToken, -1000L);
         tokenRepository.save(refreshToken);
 
@@ -256,7 +253,7 @@ class AuthControllerIntegrationTest {
     void 만료된_액세스토큰으로_요청하면_Token_Expired_에러가_발생한다() {
         // given
         Member member = createTestMember();
-        String expiredAccessToken = createExpiredAccessToken(member.getId(), accessSecretKey);
+        String expiredAccessToken = createExpiredToken(member.getId(), accessSecretKey);
 
         // when
         ErrorResponse errorResponse =
@@ -370,10 +367,9 @@ class AuthControllerIntegrationTest {
 
     // 기존 메서드 (변경 없음)
     Department setDepartment() {
-        Organization organization = OrganizationTestDataBuilder.builder().build();
+        Organization organization = organizationBuilder().build();
         Organization savedOrganization = organizationRepository.save(organization);
-        Department department =
-                DepartmentTestDataBuilder.builder().withOrganization(savedOrganization).build();
+        Department department = departmentBuilder().withOrganization(savedOrganization).build();
         departmentRepository.save(department);
         return department;
     }
@@ -400,37 +396,23 @@ class AuthControllerIntegrationTest {
                 .all();
     }
 
-    public static String createExpiredAccessToken(Long userId, String secretKey) {
+    public static String createExpiredToken(Long userId, String secretKey) {
         long now = System.currentTimeMillis();
         Date issuedAt = new Date(now - 2000);
         Date expiredAt = new Date(now - 1000);
 
         return Jwts.builder()
                 .claim("id", userId)
-                .setIssuedAt(issuedAt)
-                .setExpiration(expiredAt)
-                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
-                .compact();
-    }
-
-    public static String createExpiredRefreshToken(Long userId, String secretKey) {
-        long now = System.currentTimeMillis();
-        Date issuedAt = new Date(now - 2000);
-        Date expiredAt = new Date(now - 1000);
-
-        return Jwts.builder()
-                .claim("id", userId)
-                .setIssuedAt(issuedAt)
-                .setExpiration(expiredAt)
+                .issuedAt(issuedAt)
+                .expiration(expiredAt)
                 .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
                 .compact();
     }
 
     private Member createTestMember() {
-        Organization organization = OrganizationTestDataBuilder.builder().build();
+        Organization organization = organizationBuilder().build();
         Organization savedOrganization = organizationRepository.save(organization);
-        Department department =
-                DepartmentTestDataBuilder.builder().withOrganization(savedOrganization).build();
+        Department department = departmentBuilder().withOrganization(savedOrganization).build();
         departmentRepository.save(department);
 
         Member member =

--- a/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
@@ -18,6 +18,7 @@ import com.jnulocker.common.exception.ErrorResponse;
 import com.jnulocker.member.adapter.out.MemberRepository;
 import com.jnulocker.member.domain.Member;
 import com.jnulocker.member.exception.MemberErrorCode;
+import com.jnulocker.member.utils.MemberTestUtil;
 import com.jnulocker.organization.adapter.out.DepartmentRepository;
 import com.jnulocker.organization.adapter.out.OrganizationRepository;
 import com.jnulocker.organization.domain.Department;
@@ -49,10 +50,12 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @Testcontainers
 @ActiveProfiles("test")
-@DisplayName("인증인가 통합 테스트")
+@DisplayName("인증 통합 테스트")
 class AuthControllerIntegrationTest {
 
     private static final String AUTH_URL = "/v1/auth";
+    private static final String ACCESS_TOKEN = "access_token";
+    private static final String REFRESH_TOKEN = "refresh_token";
 
     @LocalServerPort private int port;
 
@@ -63,6 +66,8 @@ class AuthControllerIntegrationTest {
     @Autowired private DepartmentRepository departmentRepository;
 
     @Autowired private TokenRepository tokenRepository;
+
+    @Autowired private MemberTestUtil memberTestUtil;
 
     @Value("${custom.jwt.access-secret-key}")
     String accessSecretKey;
@@ -183,8 +188,8 @@ class AuthControllerIntegrationTest {
 
         // then
         Cookies cookies = response.detailedCookies();
-        String accessToken = getCookieValue(cookies, "access_token");
-        String refreshToken = getCookieValue(cookies, "refresh_token");
+        String accessToken = getCookieValue(cookies, ACCESS_TOKEN);
+        String refreshToken = getCookieValue(cookies, REFRESH_TOKEN);
 
         assertThat(accessToken).isNotBlank();
         assertThat(refreshToken).isNotBlank();
@@ -202,14 +207,14 @@ class AuthControllerIntegrationTest {
                 new LoginRequest(signupRequest.email(), signupRequest.password());
         ExtractableResponse<Response> loginResponse =
                 loginUser(port, loginRequest).statusCode(HttpStatus.OK.value()).extract();
-        String refreshToken = getCookieValue(loginResponse.detailedCookies(), "refresh_token");
+        String refreshToken = getCookieValue(loginResponse.detailedCookies(), REFRESH_TOKEN);
 
         // when
         ExtractableResponse<Response> response =
                 reissueToken(port, refreshToken).statusCode(HttpStatus.OK.value()).extract();
 
         // then
-        String newAccessToken = getCookieValue(response.detailedCookies(), "access_token");
+        String newAccessToken = getCookieValue(response.detailedCookies(), ACCESS_TOKEN);
         assertThat(newAccessToken).isNotBlank();
     }
 
@@ -233,7 +238,7 @@ class AuthControllerIntegrationTest {
     @Test
     void 만료된_리프레시토큰으로_재발급하면_Token_Expired_에러가_발생한다() {
         // given
-        Member member = createTestMember();
+        Member member = memberTestUtil.createManager();
         String expiredRefreshToken = createExpiredToken(member.getId(), refreshSecretKey);
         RefreshToken refreshToken = new RefreshToken(member.getId(), expiredRefreshToken, -1000L);
         tokenRepository.save(refreshToken);
@@ -252,14 +257,14 @@ class AuthControllerIntegrationTest {
     @Test
     void 만료된_액세스토큰으로_요청하면_Token_Expired_에러가_발생한다() {
         // given
-        Member member = createTestMember();
+        Member member = memberTestUtil.createManager();
         String expiredAccessToken = createExpiredToken(member.getId(), accessSecretKey);
 
         // when
         ErrorResponse errorResponse =
                 given().port(port)
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
-                        .cookie(new Cookie.Builder("access_token", expiredAccessToken).build())
+                        .cookie(new Cookie.Builder(ACCESS_TOKEN, expiredAccessToken).build())
                         .when()
                         .get("/v1/events")
                         .then()
@@ -281,7 +286,7 @@ class AuthControllerIntegrationTest {
         ErrorResponse errorResponse =
                 given().port(port)
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
-                        .cookie(new Cookie.Builder("access_token", nullAccessToken).build())
+                        .cookie(new Cookie.Builder(ACCESS_TOKEN, nullAccessToken).build())
                         .when()
                         .get("/v1/events")
                         .then()
@@ -353,7 +358,7 @@ class AuthControllerIntegrationTest {
     public static ValidatableResponse reissueToken(int port, String refreshToken) {
         return given().port(port)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .cookie(new Cookie.Builder("refresh_token", refreshToken).build()) // 쿠키로 전송
+                .cookie(new Cookie.Builder(REFRESH_TOKEN, refreshToken).build()) // 쿠키로 전송
                 .when()
                 .post(AUTH_URL + "/reissue")
                 .then()
@@ -407,17 +412,5 @@ class AuthControllerIntegrationTest {
                 .expiration(expiredAt)
                 .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
                 .compact();
-    }
-
-    private Member createTestMember() {
-        Organization organization = organizationBuilder().build();
-        Organization savedOrganization = organizationRepository.save(organization);
-        Department department = departmentBuilder().withOrganization(savedOrganization).build();
-        departmentRepository.save(department);
-
-        Member member =
-                Member.createManager(
-                        "test", "test@example.com", "test12345!", "010-1234-1234", department);
-        return memberRepository.save(member);
     }
 }

--- a/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
@@ -98,7 +98,7 @@ class AuthControllerIntegrationTest {
         Department department = setDepartment();
         UserSignupRequest request =
                 userSignupRequestBuilder().withDepartmentId(department.getId()).build();
-        ValidatableResponse response = signupUser(port, request);
+        ValidatableResponse response = signupUser(request);
         response.statusCode(HttpStatus.CREATED.value());
     }
 
@@ -108,7 +108,7 @@ class AuthControllerIntegrationTest {
         UserSignupRequest request =
                 userSignupRequestBuilder().withDepartmentId(nonexistentDepartmentId).build();
         ErrorResponse errorResponse =
-                signupUser(port, request)
+                signupUser(request)
                         .statusCode(
                                 DepartmentErrorCode.DEPARTMENT_NOT_FOUND.getHttpStatus().value())
                         .extract()
@@ -122,9 +122,9 @@ class AuthControllerIntegrationTest {
         Department department = setDepartment();
         UserSignupRequest request =
                 userSignupRequestBuilder().withDepartmentId(department.getId()).build();
-        signupUser(port, request).statusCode(HttpStatus.CREATED.value());
+        signupUser(request).statusCode(HttpStatus.CREATED.value());
         ErrorResponse errorResponse =
-                signupUser(port, request)
+                signupUser(request)
                         .statusCode(AuthErrorCode.USER_ALREADY_EXIST.getHttpStatus().value())
                         .extract()
                         .as(ErrorResponse.class);
@@ -137,7 +137,7 @@ class AuthControllerIntegrationTest {
         Department department = setDepartment();
         ManagerSignupRequest request =
                 managerSignupRequestBuilder().withDepartmentId(department.getId()).build();
-        ValidatableResponse response = signupManager(port, request);
+        ValidatableResponse response = signupManager(request);
         response.statusCode(HttpStatus.CREATED.value());
     }
 
@@ -147,7 +147,7 @@ class AuthControllerIntegrationTest {
         ManagerSignupRequest request =
                 managerSignupRequestBuilder().withDepartmentId(nonexistentDepartmentId).build();
         ErrorResponse errorResponse =
-                signupManager(port, request)
+                signupManager(request)
                         .statusCode(
                                 DepartmentErrorCode.DEPARTMENT_NOT_FOUND.getHttpStatus().value())
                         .extract()
@@ -161,9 +161,9 @@ class AuthControllerIntegrationTest {
         Department department = setDepartment();
         ManagerSignupRequest request =
                 managerSignupRequestBuilder().withDepartmentId(department.getId()).build();
-        signupManager(port, request).statusCode(HttpStatus.CREATED.value());
+        signupManager(request).statusCode(HttpStatus.CREATED.value());
         ErrorResponse errorResponse =
-                signupManager(port, request)
+                signupManager(request)
                         .statusCode(AuthErrorCode.USER_ALREADY_EXIST.getHttpStatus().value())
                         .extract()
                         .as(ErrorResponse.class);
@@ -177,14 +177,14 @@ class AuthControllerIntegrationTest {
         Department department = setDepartment();
         UserSignupRequest signupRequest =
                 userSignupRequestBuilder().withDepartmentId(department.getId()).build();
-        signupUser(port, signupRequest);
+        signupUser(signupRequest);
 
         LoginRequest loginRequest =
                 new LoginRequest(signupRequest.email(), signupRequest.password());
 
         // when
         ExtractableResponse<Response> response =
-                loginUser(port, loginRequest).statusCode(HttpStatus.OK.value()).extract();
+                loginUser(loginRequest).statusCode(HttpStatus.OK.value()).extract();
 
         // then
         Cookies cookies = response.detailedCookies();
@@ -201,17 +201,17 @@ class AuthControllerIntegrationTest {
         Department department = setDepartment();
         UserSignupRequest signupRequest =
                 userSignupRequestBuilder().withDepartmentId(department.getId()).build();
-        signupUser(port, signupRequest);
+        signupUser(signupRequest);
 
         LoginRequest loginRequest =
                 new LoginRequest(signupRequest.email(), signupRequest.password());
         ExtractableResponse<Response> loginResponse =
-                loginUser(port, loginRequest).statusCode(HttpStatus.OK.value()).extract();
+                loginUser(loginRequest).statusCode(HttpStatus.OK.value()).extract();
         String refreshToken = getCookieValue(loginResponse.detailedCookies(), REFRESH_TOKEN);
 
         // when
         ExtractableResponse<Response> response =
-                reissueToken(port, refreshToken).statusCode(HttpStatus.OK.value()).extract();
+                reissueToken(refreshToken).statusCode(HttpStatus.OK.value()).extract();
 
         // then
         String newAccessToken = getCookieValue(response.detailedCookies(), ACCESS_TOKEN);
@@ -225,7 +225,7 @@ class AuthControllerIntegrationTest {
 
         // when
         ErrorResponse errorResponse =
-                reissueToken(port, invalidRefreshToken)
+                reissueToken(invalidRefreshToken)
                         .statusCode(JwtErrorCode.INVALID_REFRESH_TOKEN.getHttpStatus().value())
                         .extract()
                         .as(ErrorResponse.class);
@@ -245,7 +245,7 @@ class AuthControllerIntegrationTest {
 
         // when
         ErrorResponse errorResponse =
-                reissueToken(port, expiredRefreshToken)
+                reissueToken(expiredRefreshToken)
                         .statusCode(JwtErrorCode.EXPIRED_TOKEN.getHttpStatus().value())
                         .extract()
                         .as(ErrorResponse.class);
@@ -262,8 +262,7 @@ class AuthControllerIntegrationTest {
 
         // when
         ErrorResponse errorResponse =
-                given().port(port)
-                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                given().contentType(MediaType.APPLICATION_JSON_VALUE)
                         .cookie(new Cookie.Builder(ACCESS_TOKEN, expiredAccessToken).build())
                         .when()
                         .get("/v1/events")
@@ -284,8 +283,7 @@ class AuthControllerIntegrationTest {
 
         // when
         ErrorResponse errorResponse =
-                given().port(port)
-                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                given().contentType(MediaType.APPLICATION_JSON_VALUE)
                         .cookie(new Cookie.Builder(ACCESS_TOKEN, nullAccessToken).build())
                         .when()
                         .get("/v1/events")
@@ -306,13 +304,13 @@ class AuthControllerIntegrationTest {
         Department department = setDepartment();
         UserSignupRequest signupRequest =
                 userSignupRequestBuilder().withDepartmentId(department.getId()).build();
-        signupUser(port, signupRequest);
+        signupUser(signupRequest);
 
         LoginRequest loginRequest = new LoginRequest("123456@jnu.ac.kr", signupRequest.password());
 
         // when
         ErrorResponse errorResponse =
-                loginUser(port, loginRequest)
+                loginUser(loginRequest)
                         .statusCode(MemberErrorCode.MEMBER_NOT_FOUND.getHttpStatus().value())
                         .extract()
                         .as(ErrorResponse.class);
@@ -328,13 +326,13 @@ class AuthControllerIntegrationTest {
         Department department = setDepartment();
         UserSignupRequest signupRequest =
                 userSignupRequestBuilder().withDepartmentId(department.getId()).build();
-        signupUser(port, signupRequest);
+        signupUser(signupRequest);
 
         LoginRequest loginRequest = new LoginRequest(signupRequest.email(), "wrong12345!");
 
         // when
         ErrorResponse errorResponse =
-                loginUser(port, loginRequest)
+                loginUser(loginRequest)
                         .statusCode(AuthErrorCode.FAIL_AUTHENTICATION.getHttpStatus().value())
                         .extract()
                         .as(ErrorResponse.class);
@@ -344,9 +342,8 @@ class AuthControllerIntegrationTest {
                 .isEqualTo(AuthErrorCode.FAIL_AUTHENTICATION.getMessage());
     }
 
-    public static ValidatableResponse loginUser(int port, LoginRequest request) {
-        return given().port(port)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
+    public static ValidatableResponse loginUser(LoginRequest request) {
+        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(request)
                 .when()
                 .post(AUTH_URL + "/login")
@@ -355,9 +352,8 @@ class AuthControllerIntegrationTest {
                 .all();
     }
 
-    public static ValidatableResponse reissueToken(int port, String refreshToken) {
-        return given().port(port)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
+    public static ValidatableResponse reissueToken(String refreshToken) {
+        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
                 .cookie(new Cookie.Builder(REFRESH_TOKEN, refreshToken).build()) // 쿠키로 전송
                 .when()
                 .post(AUTH_URL + "/reissue")
@@ -379,9 +375,8 @@ class AuthControllerIntegrationTest {
         return department;
     }
 
-    public static ValidatableResponse signupUser(int port, UserSignupRequest request) {
-        return given().port(port)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
+    public static ValidatableResponse signupUser(UserSignupRequest request) {
+        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(request)
                 .when()
                 .post(AUTH_URL + "/users/signup")
@@ -390,9 +385,8 @@ class AuthControllerIntegrationTest {
                 .all();
     }
 
-    public static ValidatableResponse signupManager(int port, ManagerSignupRequest request) {
-        return given().port(port)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
+    public static ValidatableResponse signupManager(ManagerSignupRequest request) {
+        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(request)
                 .when()
                 .post(AUTH_URL + "/managers/signup")

--- a/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
@@ -2,8 +2,6 @@ package com.jnulocker.events.adapter.in;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
-import static organization.domain.DepartmentTestDataBuilder.*;
-import static organization.domain.OrganizationTestDataBuilder.*;
 
 import com.jnulocker.auth.jwt.TokenProvider;
 import com.jnulocker.common.exception.ErrorResponse;
@@ -13,15 +11,15 @@ import com.jnulocker.events.adapter.out.LockerRepository;
 import com.jnulocker.events.application.port.in.response.EventCustomPage;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
 import com.jnulocker.events.domain.Event;
+import com.jnulocker.events.domain.EventStatus;
 import com.jnulocker.events.exception.EventErrorCode;
 import com.jnulocker.events.utils.EventTestUtil;
 import com.jnulocker.member.adapter.out.MemberRepository;
 import com.jnulocker.member.domain.Member;
 import com.jnulocker.member.domain.Role;
+import com.jnulocker.member.utils.MemberTestUtil;
 import com.jnulocker.organization.adapter.out.DepartmentRepository;
 import com.jnulocker.organization.adapter.out.OrganizationRepository;
-import com.jnulocker.organization.domain.Department;
-import com.jnulocker.organization.domain.Organization;
 import io.restassured.RestAssured;
 import io.restassured.http.Cookie;
 import io.restassured.response.ValidatableResponse;
@@ -48,7 +46,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers
 @ActiveProfiles("test")
 @DisplayName("이벤트 컨트롤러 통합 테스트")
-class EventControllerIntegrationTest {
+public class EventControllerIntegrationTest {
 
     private static final String EVENT_URL = "/v1/events";
     private static final String ACCESS_TOKEN = "access_token";
@@ -71,6 +69,8 @@ class EventControllerIntegrationTest {
 
     @Autowired private TokenProvider tokenProvider;
 
+    @Autowired private MemberTestUtil memberTestUtil;
+
     private static String accessToken;
 
     @BeforeEach
@@ -79,11 +79,10 @@ class EventControllerIntegrationTest {
         clearData();
 
         // 테스트 사용자 생성
-        Member member = createTestMember();
-        Long memberId = member.getId();
+        Member member = memberTestUtil.createManager();
 
         // 토큰 생성
-        accessToken = tokenProvider.generateAccessToken(memberId, Role.GUEST);
+        accessToken = tokenProvider.generateAccessToken(member.getId(), Role.GUEST);
     }
 
     @AfterEach
@@ -112,7 +111,7 @@ class EventControllerIntegrationTest {
     void 이벤트_목록을_조회할_수_있다(int createCount, int pageSize, int page, boolean expectedLast) {
         // given
         for (int i = 0; i < createCount; i++) {
-            eventTestUtil.createEventWithFloorAndLockers(List.of(1));
+            eventTestUtil.createEventWithFloorAndLockers(List.of(1), EventStatus.OPEN, true);
         }
 
         // when
@@ -158,11 +157,13 @@ class EventControllerIntegrationTest {
     void 이벤트에_해당하는_층과_사물함_목록을_조회할_수_있다(List<Integer> lockersPerFloor) {
         // given
         // 이벤트 데이터 생성: 층별 사물함 수를 파라미터로 받아 생성
-        Event event = eventTestUtil.createEventWithFloorAndLockers(lockersPerFloor);
+        Event event =
+                eventTestUtil.createEventWithFloorAndLockers(
+                        lockersPerFloor, EventStatus.OPEN, true);
 
         // when
         List<FloorWithLockersResponse> floors =
-                getEventLockers(event.getId())
+                getEventLockers(event.getId(), accessToken)
                         .statusCode(HttpStatus.OK.value())
                         .extract()
                         .jsonPath()
@@ -194,7 +195,7 @@ class EventControllerIntegrationTest {
 
         // when
         ErrorResponse errorResponse =
-                getEventLockers(nonExistentEventId)
+                getEventLockers(nonExistentEventId, accessToken)
                         .statusCode(EventErrorCode.EVENT_NOT_FOUND.getHttpStatus().value())
                         .extract()
                         .as(ErrorResponse.class);
@@ -203,7 +204,7 @@ class EventControllerIntegrationTest {
         assertThat(errorResponse.message()).isEqualTo(EventErrorCode.EVENT_NOT_FOUND.getMessage());
     }
 
-    public static ValidatableResponse getEventLockers(Long eventId) {
+    public static ValidatableResponse getEventLockers(Long eventId, String accessToken) {
         return given().contentType(MediaType.APPLICATION_JSON_VALUE)
                 .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
                 .when()
@@ -211,17 +212,5 @@ class EventControllerIntegrationTest {
                 .then()
                 .log()
                 .all();
-    }
-
-    private Member createTestMember() {
-        Organization organization = organizationBuilder().build();
-        Organization savedOrganization = organizationRepository.save(organization);
-        Department department = departmentBuilder().withOrganization(savedOrganization).build();
-        departmentRepository.save(department);
-
-        Member member =
-                Member.createManager(
-                        "test", "test@example.com", "test12345!", "010-1234-1234", department);
-        return memberRepository.save(member);
     }
 }

--- a/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
@@ -116,7 +116,7 @@ public class EventControllerIntegrationTest {
 
         // when
         EventCustomPage eventCustomPage =
-                getEvents(port, page, pageSize, accessToken)
+                getEvents(page, pageSize, accessToken)
                         .statusCode(HttpStatus.OK.value())
                         .extract()
                         .as(EventCustomPage.class);
@@ -137,9 +137,8 @@ public class EventControllerIntegrationTest {
         return Math.min(remainingItems, pageSize);
     }
 
-    public static ValidatableResponse getEvents(int port, int page, int size, String accessToken) {
-        return given().port(port)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
+    public static ValidatableResponse getEvents(int page, int size, String accessToken) {
+        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
                 .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
                 .queryParam("page", page)
                 .queryParam("size", size)

--- a/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
@@ -2,6 +2,8 @@ package com.jnulocker.events.adapter.in;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
+import static organization.domain.DepartmentTestDataBuilder.*;
+import static organization.domain.OrganizationTestDataBuilder.*;
 
 import com.jnulocker.auth.jwt.TokenProvider;
 import com.jnulocker.common.exception.ErrorResponse;
@@ -41,8 +43,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import organization.builder.DepartmentTestDataBuilder;
-import organization.builder.OrganizationTestDataBuilder;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @Testcontainers
@@ -51,6 +51,7 @@ import organization.builder.OrganizationTestDataBuilder;
 class EventControllerIntegrationTest {
 
     private static final String EVENT_URL = "/v1/events";
+    private static final String ACCESS_TOKEN = "access_token";
 
     @LocalServerPort private int port;
 
@@ -71,7 +72,6 @@ class EventControllerIntegrationTest {
     @Autowired private TokenProvider tokenProvider;
 
     private static String accessToken;
-    private static Long memberId;
 
     @BeforeEach
     void setUp() {
@@ -80,7 +80,7 @@ class EventControllerIntegrationTest {
 
         // 테스트 사용자 생성
         Member member = createTestMember();
-        memberId = member.getId();
+        Long memberId = member.getId();
 
         // 토큰 생성
         accessToken = tokenProvider.generateAccessToken(memberId, Role.GUEST);
@@ -141,7 +141,7 @@ class EventControllerIntegrationTest {
     public static ValidatableResponse getEvents(int port, int page, int size, String accessToken) {
         return given().port(port)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .cookie(new Cookie.Builder("access_token", accessToken).build())
+                .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
                 .queryParam("page", page)
                 .queryParam("size", size)
                 .queryParam("direction", "DESC")
@@ -162,7 +162,7 @@ class EventControllerIntegrationTest {
 
         // when
         List<FloorWithLockersResponse> floors =
-                getEventLockers(port, event.getId(), accessToken)
+                getEventLockers(event.getId())
                         .statusCode(HttpStatus.OK.value())
                         .extract()
                         .jsonPath()
@@ -194,7 +194,7 @@ class EventControllerIntegrationTest {
 
         // when
         ErrorResponse errorResponse =
-                getEventLockers(port, nonExistentEventId, accessToken)
+                getEventLockers(nonExistentEventId)
                         .statusCode(EventErrorCode.EVENT_NOT_FOUND.getHttpStatus().value())
                         .extract()
                         .as(ErrorResponse.class);
@@ -203,10 +203,9 @@ class EventControllerIntegrationTest {
         assertThat(errorResponse.message()).isEqualTo(EventErrorCode.EVENT_NOT_FOUND.getMessage());
     }
 
-    public static ValidatableResponse getEventLockers(int port, Long eventId, String accessToken) {
-        return given().port(port)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .cookie(new Cookie.Builder("access_token", accessToken).build())
+    public static ValidatableResponse getEventLockers(Long eventId) {
+        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
                 .when()
                 .get(EVENT_URL + "/{event-id}/lockers", eventId)
                 .then()
@@ -215,10 +214,9 @@ class EventControllerIntegrationTest {
     }
 
     private Member createTestMember() {
-        Organization organization = OrganizationTestDataBuilder.builder().build();
+        Organization organization = organizationBuilder().build();
         Organization savedOrganization = organizationRepository.save(organization);
-        Department department =
-                DepartmentTestDataBuilder.builder().withOrganization(savedOrganization).build();
+        Department department = departmentBuilder().withOrganization(savedOrganization).build();
         departmentRepository.save(department);
 
         Member member =

--- a/src/test/java/com/jnulocker/events/utils/EventTestUtil.java
+++ b/src/test/java/com/jnulocker/events/utils/EventTestUtil.java
@@ -8,6 +8,7 @@ import com.jnulocker.events.adapter.out.EventRepository;
 import com.jnulocker.events.adapter.out.FloorRepository;
 import com.jnulocker.events.adapter.out.LockerRepository;
 import com.jnulocker.events.domain.Event;
+import com.jnulocker.events.domain.EventStatus;
 import com.jnulocker.events.domain.Floor;
 import com.jnulocker.events.domain.Locker;
 import com.jnulocker.organization.adapter.out.DepartmentRepository;
@@ -32,7 +33,8 @@ public class EventTestUtil {
 
     @Autowired private LockerRepository lockerRepository;
 
-    public Event createEventWithFloorAndLockers(List<Integer> lockersPerFloor) {
+    public Event createEventWithFloorAndLockers(
+            List<Integer> lockersPerFloor, EventStatus eventStatus, boolean publish) {
         // 조직 생성 및 저장
         Organization organization = organizationBuilder().build();
         Organization savedOrganization = organizationRepository.save(organization);
@@ -42,7 +44,12 @@ public class EventTestUtil {
         Department savedDepartment = departmentRepository.save(department);
 
         // 이벤트 생성 및 저장
-        Event event = eventBuilder().withDepartment(savedDepartment).build();
+        Event event =
+                eventBuilder()
+                        .withDepartment(savedDepartment)
+                        .withEventStatus(eventStatus)
+                        .withPublish(publish)
+                        .build();
         Event savedEvent = eventRepository.save(event);
 
         // 층 생성 및 저장

--- a/src/test/java/com/jnulocker/events/utils/EventTestUtil.java
+++ b/src/test/java/com/jnulocker/events/utils/EventTestUtil.java
@@ -1,5 +1,9 @@
 package com.jnulocker.events.utils;
 
+import static events.domain.EventTestDataBuilder.*;
+import static organization.domain.DepartmentTestDataBuilder.*;
+import static organization.domain.OrganizationTestDataBuilder.*;
+
 import com.jnulocker.events.adapter.out.EventRepository;
 import com.jnulocker.events.adapter.out.FloorRepository;
 import com.jnulocker.events.adapter.out.LockerRepository;
@@ -10,13 +14,10 @@ import com.jnulocker.organization.adapter.out.DepartmentRepository;
 import com.jnulocker.organization.adapter.out.OrganizationRepository;
 import com.jnulocker.organization.domain.Department;
 import com.jnulocker.organization.domain.Organization;
-import events.builder.EventTestDataBuilder;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import organization.builder.DepartmentTestDataBuilder;
-import organization.builder.OrganizationTestDataBuilder;
 
 @Component
 public class EventTestUtil {
@@ -33,16 +34,15 @@ public class EventTestUtil {
 
     public Event createEventWithFloorAndLockers(List<Integer> lockersPerFloor) {
         // 조직 생성 및 저장
-        Organization organization = OrganizationTestDataBuilder.builder().build();
+        Organization organization = organizationBuilder().build();
         Organization savedOrganization = organizationRepository.save(organization);
 
         // 학과 생성 및 저장
-        Department department =
-                DepartmentTestDataBuilder.builder().withOrganization(savedOrganization).build();
+        Department department = departmentBuilder().withOrganization(savedOrganization).build();
         Department savedDepartment = departmentRepository.save(department);
 
         // 이벤트 생성 및 저장
-        Event event = EventTestDataBuilder.builder().withDepartment(savedDepartment).build();
+        Event event = eventBuilder().withDepartment(savedDepartment).build();
         Event savedEvent = eventRepository.save(event);
 
         // 층 생성 및 저장

--- a/src/test/java/com/jnulocker/member/utils/MemberTestUtil.java
+++ b/src/test/java/com/jnulocker/member/utils/MemberTestUtil.java
@@ -1,0 +1,47 @@
+package com.jnulocker.member.utils;
+
+import static member.domain.MemberTestDataBuilder.memberBuilder;
+import static organization.domain.DepartmentTestDataBuilder.departmentBuilder;
+import static organization.domain.OrganizationTestDataBuilder.organizationBuilder;
+
+import com.jnulocker.member.adapter.out.MemberRepository;
+import com.jnulocker.member.domain.Member;
+import com.jnulocker.organization.adapter.out.DepartmentRepository;
+import com.jnulocker.organization.adapter.out.OrganizationRepository;
+import com.jnulocker.organization.domain.Department;
+import com.jnulocker.organization.domain.Organization;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MemberTestUtil {
+
+    @Autowired private OrganizationRepository organizationRepository;
+
+    @Autowired private DepartmentRepository departmentRepository;
+
+    @Autowired private MemberRepository memberRepository;
+
+    public Member createUser() {
+        Department department = getDepartment();
+
+        Member member = memberBuilder().withDepartment(department).buildUser();
+        return memberRepository.save(member);
+    }
+
+    public Member createManager() {
+        Department department = getDepartment();
+
+        Member member = memberBuilder().withDepartment(department).buildManager();
+        member.approveManager();
+        return memberRepository.save(member);
+    }
+
+    private Department getDepartment() {
+        Organization organization = organizationBuilder().build();
+        Organization savedOrganization = organizationRepository.save(organization);
+
+        Department department = departmentBuilder().withOrganization(savedOrganization).build();
+        return departmentRepository.save(department);
+    }
+}

--- a/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
@@ -1,0 +1,278 @@
+package com.jnulocker.registration.adapter.in;
+
+import static com.jnulocker.events.adapter.in.EventControllerIntegrationTest.getEventLockers;
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jnulocker.auth.jwt.TokenProvider;
+import com.jnulocker.auth.jwt.exception.JwtErrorCode;
+import com.jnulocker.common.exception.ErrorResponse;
+import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
+import com.jnulocker.events.domain.Event;
+import com.jnulocker.events.domain.EventStatus;
+import com.jnulocker.events.exception.EventErrorCode;
+import com.jnulocker.events.utils.EventTestUtil;
+import com.jnulocker.member.domain.Member;
+import com.jnulocker.member.domain.Role;
+import com.jnulocker.member.utils.MemberTestUtil;
+import com.jnulocker.registration.application.port.in.request.RegisterForEventRequest;
+import com.jnulocker.registration.exception.RegistrationErrorCode;
+import io.restassured.RestAssured;
+import io.restassured.http.Cookie;
+import io.restassured.response.ValidatableResponse;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@Testcontainers
+@ActiveProfiles("test")
+@DisplayName("이벤트 신청 컨트롤러 통합 테스트")
+class RegistrationControllerIntegrationTest {
+
+    private static final String REGISTRATION_URL = "/v1/{event-id}/registrations";
+    private static final String ACCESS_TOKEN = "access_token";
+
+    @LocalServerPort private int port;
+
+    @Autowired private EventTestUtil eventTestUtil;
+
+    @Autowired private TokenProvider tokenProvider;
+
+    @Autowired private MemberTestUtil memberTestUtil;
+
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        accessToken = generateAccessToken(Role.USER);
+    }
+
+    @Test
+    void 사물함_신청을_할_수_있다() {
+        // given
+        Event event = createEventWithLockers(EventStatus.OPEN, true);
+        RegisterForEventRequest request = createRequestForAvailableLocker(event);
+
+        // when, then
+        registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
+    }
+
+    @Test
+    void 인증되지_않은_사용자는_신청할_수_없다() {
+        // given
+        Event event = createEventWithLockers(EventStatus.OPEN, true);
+        RegisterForEventRequest request = createRequestForAvailableLocker(event);
+
+        // when
+        ErrorResponse errorResponse =
+                registerForEventWithoutLoggedUser(event.getId(), request)
+                        .statusCode(JwtErrorCode.INVALID_ACCESS_TOKEN.getHttpStatus().value())
+                        .extract()
+                        .as(ErrorResponse.class);
+
+        // then
+        assertThat(errorResponse.message())
+                .isEqualTo(JwtErrorCode.INVALID_ACCESS_TOKEN.getMessage());
+    }
+
+    @Test
+    void 사용중인_사물함은_신청할_수_없다() {
+        // given
+        Event event = createEventWithLockers(EventStatus.OPEN, true);
+        RegisterForEventRequest request = createRequestForUnavailableLocker(event);
+
+        // when
+        ErrorResponse errorResponse =
+                registerForEvent(event.getId(), request)
+                        .statusCode(EventErrorCode.LOCKER_UNAVAILABLE.getHttpStatus().value())
+                        .extract()
+                        .as(ErrorResponse.class);
+
+        // then
+        assertThat(errorResponse.message())
+                .isEqualTo(EventErrorCode.LOCKER_UNAVAILABLE.getMessage());
+    }
+
+    @Test
+    void 동일한_이벤트에_대해_중복으로_신청할_수_없다() {
+        // given
+        Event event = createEventWithLockers(EventStatus.OPEN, true);
+        RegisterForEventRequest request = createRequestForAvailableLocker(event);
+
+        // when
+        registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
+
+        // then
+        ErrorResponse errorResponse =
+                registerForEvent(event.getId(), request)
+                        .statusCode(
+                                RegistrationErrorCode.REGISTRATION_ALREADY_EXISTS
+                                        .getHttpStatus()
+                                        .value())
+                        .extract()
+                        .as(ErrorResponse.class);
+
+        assertThat(errorResponse.message())
+                .isEqualTo(RegistrationErrorCode.REGISTRATION_ALREADY_EXISTS.getMessage());
+    }
+
+    @Test
+    void 존재하지_않는_이벤트는_신청할_수_없다() {
+        // given
+        Event event = createEventWithLockers(EventStatus.OPEN, true);
+
+        // when
+        ErrorResponse errorResponse =
+                registerForEvent(Long.MAX_VALUE, createRequestForAvailableLocker(event))
+                        .statusCode(EventErrorCode.EVENT_NOT_FOUND.getHttpStatus().value())
+                        .extract()
+                        .as(ErrorResponse.class);
+
+        // then
+        assertThat(errorResponse.message()).isEqualTo(EventErrorCode.EVENT_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 이벤트에_해당하지_않는_사물함은_신청할_수_없다() {
+        // given
+        Event event = createEventWithLockers(EventStatus.OPEN, true);
+        Event anotherEvent = createEventWithLockers(EventStatus.OPEN, true);
+        RegisterForEventRequest request = createRequestForAvailableLocker(anotherEvent);
+
+        // when
+        ErrorResponse errorResponse =
+                registerForEvent(event.getId(), request)
+                        .statusCode(EventErrorCode.INVALID_LOCKER_FOR_EVENT.getHttpStatus().value())
+                        .extract()
+                        .as(ErrorResponse.class);
+
+        // then
+        assertThat(errorResponse.message())
+                .isEqualTo(EventErrorCode.INVALID_LOCKER_FOR_EVENT.getMessage());
+    }
+
+    @Test
+    void 이벤트가_준비중인_경우_신청할_수_없다() {
+        // given
+        Event event = createEventWithLockers(EventStatus.READY, true);
+        RegisterForEventRequest request = createRequestForAvailableLocker(event);
+
+        // when
+        ErrorResponse errorResponse =
+                registerForEvent(event.getId(), request)
+                        .statusCode(EventErrorCode.EVENT_NOT_OPEN.getHttpStatus().value())
+                        .extract()
+                        .as(ErrorResponse.class);
+
+        // then
+        assertThat(errorResponse.message()).isEqualTo(EventErrorCode.EVENT_NOT_OPEN.getMessage());
+    }
+
+    @Test
+    void 이벤트가_종료된_경우_신청할_수_없다() {
+        // given
+        Event event = createEventWithLockers(EventStatus.CLOSED, true);
+        RegisterForEventRequest request = createRequestForAvailableLocker(event);
+
+        // when
+        ErrorResponse errorResponse =
+                registerForEvent(event.getId(), request)
+                        .statusCode(EventErrorCode.EVENT_NOT_OPEN.getHttpStatus().value())
+                        .extract()
+                        .as(ErrorResponse.class);
+
+        // then
+        assertThat(errorResponse.message()).isEqualTo(EventErrorCode.EVENT_NOT_OPEN.getMessage());
+    }
+
+    @Test
+    void USER는_publish_false인_이벤트를_신청할_수_없다() {
+        // given
+        Event event = createEventWithLockers(EventStatus.OPEN, false);
+        RegisterForEventRequest request = createRequestForAvailableLocker(event);
+
+        // when
+        ErrorResponse errorResponse =
+                registerForEvent(event.getId(), request)
+                        .statusCode(EventErrorCode.EVENT_NOT_OPEN.getHttpStatus().value())
+                        .extract()
+                        .as(ErrorResponse.class);
+
+        // then
+        assertThat(errorResponse.message()).isEqualTo(EventErrorCode.EVENT_NOT_OPEN.getMessage());
+    }
+
+    @Test
+    void MANAGER는_publish_false인_이벤트도_신청할_수_있다() {
+        // given
+        accessToken = generateAccessToken(Role.MANAGER);
+        Event event = createEventWithLockers(EventStatus.OPEN, false);
+        RegisterForEventRequest request = createRequestForAvailableLocker(event);
+
+        // when, then
+        registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
+    }
+
+    private ValidatableResponse registerForEvent(Long eventId, RegisterForEventRequest request) {
+        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
+                .body(request)
+                .when()
+                .post(REGISTRATION_URL, eventId)
+                .then()
+                .log()
+                .ifError();
+    }
+
+    private ValidatableResponse registerForEventWithoutLoggedUser(
+            Long eventId, RegisterForEventRequest request) {
+        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when()
+                .post(REGISTRATION_URL, eventId)
+                .then()
+                .log()
+                .ifError();
+    }
+
+    private Event createEventWithLockers(EventStatus status, boolean publish) {
+        return eventTestUtil.createEventWithFloorAndLockers(List.of(5, 10), status, publish);
+    }
+
+    private String generateAccessToken(Role role) {
+        Member member =
+                role == Role.MANAGER ? memberTestUtil.createManager() : memberTestUtil.createUser();
+        return tokenProvider.generateAccessToken(member.getId(), role);
+    }
+
+    private RegisterForEventRequest createRequestForAvailableLocker(Event event) {
+        List<FloorWithLockersResponse> floors = getFloors(event);
+        Long lockerId = floors.getFirst().lockers().get(1).lockerId(); // 짝수 번째 사용 가능
+        return new RegisterForEventRequest(lockerId);
+    }
+
+    private RegisterForEventRequest createRequestForUnavailableLocker(Event event) {
+        List<FloorWithLockersResponse> floors = getFloors(event);
+        Long lockerId = floors.getLast().lockers().getFirst().lockerId(); // 홀수 번째 사용 불가
+        return new RegisterForEventRequest(lockerId);
+    }
+
+    private List<FloorWithLockersResponse> getFloors(Event event) {
+        return getEventLockers(event.getId(), accessToken)
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .jsonPath()
+                .getList(".", FloorWithLockersResponse.class);
+    }
+}

--- a/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
@@ -39,7 +39,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @DisplayName("이벤트 신청 컨트롤러 통합 테스트")
 class RegistrationControllerIntegrationTest {
 
-    private static final String REGISTRATION_URL = "/v1/{event-id}/registrations";
+    private static final String REGISTRATION_URL = "/v1/events/{event-id}/registrations";
     private static final String ACCESS_TOKEN = "access_token";
 
     @LocalServerPort private int port;

--- a/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
@@ -258,12 +258,14 @@ class RegistrationControllerIntegrationTest {
 
     private RegisterForEventRequest createRequestForAvailableLocker(Event event) {
         List<FloorWithLockersResponse> floors = getFloors(event);
+        // 짝수 번째 인덱스의 사물함은 테스트에서 사용 가능한 상태 (eventTestUtil 참고)
         Long lockerId = floors.getFirst().lockers().get(1).lockerId(); // 짝수 번째 사용 가능
         return new RegisterForEventRequest(lockerId);
     }
 
     private RegisterForEventRequest createRequestForUnavailableLocker(Event event) {
         List<FloorWithLockersResponse> floors = getFloors(event);
+        // 홀수 번째 인덱스의 사물함은 테스트에서 사용 불가능한 상태 (eventTestUtil 참고)
         Long lockerId = floors.getLast().lockers().getFirst().lockerId(); // 홀수 번째 사용 불가
         return new RegisterForEventRequest(lockerId);
     }

--- a/src/testFixtures/java/events/domain/EventTestDataBuilder.java
+++ b/src/testFixtures/java/events/domain/EventTestDataBuilder.java
@@ -1,20 +1,21 @@
-package events.builder;
+package events.domain;
+
+import static organization.domain.DepartmentTestDataBuilder.*;
 
 import com.jnulocker.events.domain.Event;
 import com.jnulocker.organization.domain.Department;
 import java.time.LocalDateTime;
-import organization.builder.DepartmentTestDataBuilder;
 
 public class EventTestDataBuilder {
 
     private String title = "테스트 이벤트";
-    private Department department = DepartmentTestDataBuilder.builder().build();
+    private Department department = departmentBuilder().build();
     private LocalDateTime startAt = LocalDateTime.now();
     private LocalDateTime endAt = LocalDateTime.now().plusHours(1);
 
     private EventTestDataBuilder() {}
 
-    public static EventTestDataBuilder builder() {
+    public static EventTestDataBuilder eventBuilder() {
         return new EventTestDataBuilder();
     }
 

--- a/src/testFixtures/java/events/domain/EventTestDataBuilder.java
+++ b/src/testFixtures/java/events/domain/EventTestDataBuilder.java
@@ -3,6 +3,7 @@ package events.domain;
 import static organization.domain.DepartmentTestDataBuilder.*;
 
 import com.jnulocker.events.domain.Event;
+import com.jnulocker.events.domain.EventStatus;
 import com.jnulocker.organization.domain.Department;
 import java.time.LocalDateTime;
 
@@ -12,6 +13,8 @@ public class EventTestDataBuilder {
     private Department department = departmentBuilder().build();
     private LocalDateTime startAt = LocalDateTime.now();
     private LocalDateTime endAt = LocalDateTime.now().plusHours(1);
+    private EventStatus eventStatus = EventStatus.READY;
+    private Boolean publish = false;
 
     private EventTestDataBuilder() {}
 
@@ -39,7 +42,17 @@ public class EventTestDataBuilder {
         return this;
     }
 
+    public EventTestDataBuilder withEventStatus(EventStatus eventStatus) {
+        this.eventStatus = eventStatus;
+        return this;
+    }
+
+    public EventTestDataBuilder withPublish(Boolean publish) {
+        this.publish = publish;
+        return this;
+    }
+
     public Event build() {
-        return Event.create(title, department, startAt, endAt);
+        return Event.create(title, department, startAt, endAt, eventStatus, publish);
     }
 }

--- a/src/testFixtures/java/member/domain/MemberTestDataBuilder.java
+++ b/src/testFixtures/java/member/domain/MemberTestDataBuilder.java
@@ -1,0 +1,54 @@
+package member.domain;
+
+import static organization.domain.DepartmentTestDataBuilder.departmentBuilder;
+
+import com.jnulocker.member.domain.Member;
+import com.jnulocker.organization.domain.Department;
+
+public class MemberTestDataBuilder {
+
+    private String name = "테스트 이름";
+    private String email = "test@email.com";
+    private String phoneNumber = "010-1234-5678";
+    private String password = "password123";
+    private Department department = departmentBuilder().build();
+
+    private MemberTestDataBuilder() {}
+
+    public static MemberTestDataBuilder memberBuilder() {
+        return new MemberTestDataBuilder();
+    }
+
+    public MemberTestDataBuilder withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public MemberTestDataBuilder withEmail(String email) {
+        this.email = email;
+        return this;
+    }
+
+    public MemberTestDataBuilder withPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+        return this;
+    }
+
+    public MemberTestDataBuilder withPassword(String password) {
+        this.password = password;
+        return this;
+    }
+
+    public MemberTestDataBuilder withDepartment(Department department) {
+        this.department = department;
+        return this;
+    }
+
+    public Member buildUser() {
+        return Member.createUser(name, email, phoneNumber, password, department);
+    }
+
+    public Member buildManager() {
+        return Member.createManager(name, email, phoneNumber, password, department);
+    }
+}

--- a/src/testFixtures/java/organization/domain/DepartmentTestDataBuilder.java
+++ b/src/testFixtures/java/organization/domain/DepartmentTestDataBuilder.java
@@ -1,11 +1,13 @@
-package organization.builder;
+package organization.domain;
+
+import static organization.domain.OrganizationTestDataBuilder.*;
 
 import com.jnulocker.organization.domain.Department;
 import com.jnulocker.organization.domain.Organization;
 
 public class DepartmentTestDataBuilder {
 
-    private Organization organization = OrganizationTestDataBuilder.builder().build();
+    private Organization organization = organizationBuilder().build();
     private String name = "테스트 학과명";
     private String nickname = "테스트 학과 학생회 별칭";
     private String email = "test@test.com";
@@ -13,7 +15,7 @@ public class DepartmentTestDataBuilder {
 
     private DepartmentTestDataBuilder() {}
 
-    public static DepartmentTestDataBuilder builder() {
+    public static DepartmentTestDataBuilder departmentBuilder() {
         return new DepartmentTestDataBuilder();
     }
 

--- a/src/testFixtures/java/organization/domain/OrganizationTestDataBuilder.java
+++ b/src/testFixtures/java/organization/domain/OrganizationTestDataBuilder.java
@@ -1,4 +1,4 @@
-package organization.builder;
+package organization.domain;
 
 import com.jnulocker.organization.domain.Organization;
 import com.jnulocker.organization.domain.OrganizationType;
@@ -10,7 +10,7 @@ public class OrganizationTestDataBuilder {
 
     private OrganizationTestDataBuilder() {}
 
-    public static OrganizationTestDataBuilder builder() {
+    public static OrganizationTestDataBuilder organizationBuilder() {
         return new OrganizationTestDataBuilder();
     }
 


### PR DESCRIPTION
### 개요
close #52 

### 작업사항
- 사물함 신청 API 구현

### 변경로직
- 사물함 신청 정보를 가진 `Registration` 도메인 구현
- 테스트코드 작성 및 리팩토링

### 테스트 결과
- 전체 테스트 결과

  <img width="345" alt="image" src="https://github.com/user-attachments/assets/7f4eae68-1714-411f-8eaf-57ba77cb1bf4" />

- 추가가된 테스트케이스

  <img width="345" alt="image" src="https://github.com/user-attachments/assets/e0808ba8-2a5d-45d2-ac25-4bfed87a125e" />

### reference


### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 이벤트별 사물함 신청(등록) API가 추가되어, 사용자는 이벤트에 사물함을 신청할 수 있습니다.
  - 사물함 신청 시 이벤트 상태, 공개 여부, 사물함 사용 가능 여부 등 다양한 유효성 검사가 적용됩니다.
  - 이벤트 및 사물함 관련 상세 오류 코드와 예외 처리가 추가되었습니다.
  - 사물함 및 이벤트 조회 기능이 강화되어, 사물함 단건 조회가 가능해졌습니다.

- **버그 수정**
  - 이벤트 및 사물함 조회 권한이 "guest"에서 인증된 사용자 전체로 확대되었습니다.

- **문서화**
  - 이벤트 및 사물함 신청 API의 Swagger/OpenAPI 문서가 추가 및 개선되었습니다.
  - 예외 상황에 대한 설명이 문서에 반영되었습니다.

- **테스트**
  - 사물함 신청 API에 대한 통합 테스트가 추가되어 다양한 시나리오(중복 신청, 미인증, 잘못된 이벤트/사물함 등)를 검증합니다.
  - 테스트 데이터 빌더 및 유틸리티 클래스가 추가되어 테스트 코드의 재사용성과 가독성이 향상되었습니다.

- **리팩터링/스타일**
  - 테스트 코드의 중복 제거 및 유틸리티 활용으로 코드 품질이 개선되었습니다.
  - 빌더 패턴 및 명명 규칙이 일관성 있게 정비되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->