### PR TITLE
[FEAT] 사물함 신청 현황 조회 API 구현

### DIFF
--- a/src/main/java/com/jnulocker/config/SecurityConfig.java
+++ b/src/main/java/com/jnulocker/config/SecurityConfig.java
@@ -72,8 +72,7 @@ public class SecurityConfig {
                                         "/v1/events/*/lockers",
                                         "/v1/events/*/registrations/me")
                                 .authenticated()
-                                .requestMatchers(
-                                        HttpMethod.GET, "/v1/events/*/registrations")
+                                .requestMatchers(HttpMethod.GET, "/v1/events/*/registrations")
                                 .hasAuthority(Role.GUEST.getRole()) // TODO: 추후 manager로 변경
                                 .requestMatchers(HttpMethod.POST, "/v1/events")
                                 .hasAuthority(Role.GUEST.getRole()) // TODO: 추후 manager로 변경

--- a/src/main/java/com/jnulocker/config/SecurityConfig.java
+++ b/src/main/java/com/jnulocker/config/SecurityConfig.java
@@ -67,11 +67,10 @@ public class SecurityConfig {
                                 .requestMatchers("/v1/auth/**")
                                 .permitAll() // 인증 API 모든 접근 허용
                                 .requestMatchers(
-                                        HttpMethod.GET,
-                                        "/v1/events",
-                                        "/v1/events/*/lockers",
-                                        "/v1/events/*/registrations/me")
+                                        HttpMethod.GET, "/v1/events", "/v1/events/*/lockers")
                                 .authenticated()
+                                .requestMatchers(HttpMethod.GET, "/v1/events/*/registrations/me")
+                                .hasAuthority(Role.USER.getRole())
                                 .requestMatchers(HttpMethod.GET, "/v1/events/*/registrations")
                                 .hasAuthority(Role.GUEST.getRole()) // TODO: 추후 manager로 변경
                                 .requestMatchers(HttpMethod.POST, "/v1/events")

--- a/src/main/java/com/jnulocker/config/SecurityConfig.java
+++ b/src/main/java/com/jnulocker/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.jnulocker.auth.jwt.JwtFilter;
 import com.jnulocker.auth.security.CustomAccessDeniedHandler;
 import com.jnulocker.auth.security.CustomAuthenticationEntryPoint;
 import com.jnulocker.auth.security.CustomUserDetailsService;
+import com.jnulocker.member.domain.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -68,9 +69,11 @@ public class SecurityConfig {
                                 .requestMatchers(
                                         HttpMethod.GET, "/v1/events", "/v1/events/*/lockers")
                                 .authenticated()
+                                .requestMatchers(HttpMethod.GET, "/v1/{event-id}/registrations")
+                                .hasAuthority(Role.GUEST.getRole()) // TODO: 추후 manager로 변경
                                 .requestMatchers(HttpMethod.POST, "/v1/events")
                                 .hasAuthority(
-                                        "guest") // 권한이 MANAGER인 유저만 사용 가능 // TODO: 추후 manager로 변경,
+                                        Role.GUEST.getRole()) // 권한이 MANAGER인 유저만 사용 가능 // TODO: 추후 manager로 변경,
                                 // 토큰의 role과 db의 role과 다른 문제 고려
                                 .anyRequest()
                                 .authenticated());

--- a/src/main/java/com/jnulocker/config/SecurityConfig.java
+++ b/src/main/java/com/jnulocker/config/SecurityConfig.java
@@ -70,9 +70,11 @@ public class SecurityConfig {
                                         HttpMethod.GET,
                                         "/v1/events",
                                         "/v1/events/*/lockers",
-                                        "/v1/{event-id}/registrations",
                                         "/v1/events/*/registrations/me")
                                 .authenticated()
+                                .requestMatchers(
+                                        HttpMethod.GET, "/v1/events/*/registrations")
+                                .hasAuthority(Role.GUEST.getRole()) // TODO: 추후 manager로 변경
                                 .requestMatchers(HttpMethod.POST, "/v1/events")
                                 .hasAuthority(Role.GUEST.getRole()) // TODO: 추후 manager로 변경
                                 // 토큰의 role과 db의 role과 다른 문제 고려

--- a/src/main/java/com/jnulocker/config/SecurityConfig.java
+++ b/src/main/java/com/jnulocker/config/SecurityConfig.java
@@ -67,13 +67,14 @@ public class SecurityConfig {
                                 .requestMatchers("/v1/auth/**")
                                 .permitAll() // 인증 API 모든 접근 허용
                                 .requestMatchers(
-                                        HttpMethod.GET, "/v1/events", "/v1/events/*/lockers")
+                                        HttpMethod.GET,
+                                        "/v1/events",
+                                        "/v1/events/*/lockers",
+                                        "/v1/{event-id}/registrations",
+                                        "/v1/events/*/registrations/me")
                                 .authenticated()
-                                .requestMatchers(HttpMethod.GET, "/v1/{event-id}/registrations")
-                                .hasAuthority(Role.GUEST.getRole()) // TODO: 추후 manager로 변경
                                 .requestMatchers(HttpMethod.POST, "/v1/events")
-                                .hasAuthority(
-                                        Role.GUEST.getRole()) // 권한이 MANAGER인 유저만 사용 가능 // TODO: 추후 manager로 변경,
+                                .hasAuthority(Role.GUEST.getRole()) // TODO: 추후 manager로 변경
                                 // 토큰의 role과 db의 role과 다른 문제 고려
                                 .anyRequest()
                                 .authenticated());

--- a/src/main/java/com/jnulocker/registration/adapter/in/RegistrationController.java
+++ b/src/main/java/com/jnulocker/registration/adapter/in/RegistrationController.java
@@ -2,11 +2,18 @@ package com.jnulocker.registration.adapter.in;
 
 import com.jnulocker.registration.adapter.in.docs.RegistrationApi;
 import com.jnulocker.registration.application.port.in.RegistrationCommand;
+import com.jnulocker.registration.application.port.in.RegistrationQuery;
 import com.jnulocker.registration.application.port.in.request.RegisterForEventRequest;
+import com.jnulocker.registration.application.port.in.response.RegistrationCustomPage;
+import com.jnulocker.registration.application.port.in.response.RegistrationPageable;
+import com.jnulocker.registration.application.port.in.response.RegistrationResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,7 +25,24 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/events/{event-id}/registrations")
 public class RegistrationController implements RegistrationApi {
 
+    private final RegistrationQuery registrationQuery;
     private final RegistrationCommand registrationCommand;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<RegistrationCustomPage> getRegistrations(
+            @PathVariable("event-id") Long eventId,
+            @Valid @ParameterObject RegistrationPageable registrationPageable) {
+        Pageable pageable = registrationPageable.toPageable();
+        return ResponseEntity.ok(registrationQuery.getRegistrations(eventId, pageable));
+    }
+
+    @Override
+    @GetMapping("/me")
+    public ResponseEntity<RegistrationResponse> getMyRegistration(
+            @PathVariable("event-id") Long eventId) {
+        return ResponseEntity.ok(registrationQuery.getMyRegistration(eventId));
+    }
 
     @Override
     @PostMapping

--- a/src/main/java/com/jnulocker/registration/adapter/in/docs/GetMyRegistrationExceptionDocs.java
+++ b/src/main/java/com/jnulocker/registration/adapter/in/docs/GetMyRegistrationExceptionDocs.java
@@ -1,0 +1,18 @@
+package com.jnulocker.registration.adapter.in.docs;
+
+import com.jnulocker.common.exception.BusinessException;
+import com.jnulocker.common.swagger.ExceptionDoc;
+import com.jnulocker.common.swagger.ExplainError;
+import com.jnulocker.common.swagger.SwaggerExceptionDoc;
+import com.jnulocker.registration.exception.RegistrationNotFoundException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@ExceptionDoc
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetMyRegistrationExceptionDocs implements SwaggerExceptionDoc {
+
+    @ExplainError("신청 정보가 존재하지 않을 때 발생하는 예외입니다")
+    public static final BusinessException 신청_정보가_존재하지_않을_때 =
+            RegistrationNotFoundException.EXCEPTION;
+}

--- a/src/main/java/com/jnulocker/registration/adapter/in/docs/GetRegistrationsExceptionDocs.java
+++ b/src/main/java/com/jnulocker/registration/adapter/in/docs/GetRegistrationsExceptionDocs.java
@@ -1,0 +1,17 @@
+package com.jnulocker.registration.adapter.in.docs;
+
+import com.jnulocker.common.exception.BusinessException;
+import com.jnulocker.common.swagger.ExceptionDoc;
+import com.jnulocker.common.swagger.ExplainError;
+import com.jnulocker.common.swagger.SwaggerExceptionDoc;
+import com.jnulocker.events.exception.EventNotFoundException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@ExceptionDoc
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetRegistrationsExceptionDocs implements SwaggerExceptionDoc {
+
+    @ExplainError("이벤트가 존재하지 않을 때 발생하는 예외입니다")
+    public static final BusinessException 이벤트가_존재하지_않을_때 = EventNotFoundException.EXCEPTION;
+}

--- a/src/main/java/com/jnulocker/registration/adapter/in/docs/RegistrationApi.java
+++ b/src/main/java/com/jnulocker/registration/adapter/in/docs/RegistrationApi.java
@@ -2,16 +2,47 @@ package com.jnulocker.registration.adapter.in.docs;
 
 import com.jnulocker.common.swagger.ApiExceptionExamples;
 import com.jnulocker.registration.application.port.in.request.RegisterForEventRequest;
+import com.jnulocker.registration.application.port.in.response.RegistrationCustomPage;
+import com.jnulocker.registration.application.port.in.response.RegistrationPageable;
+import com.jnulocker.registration.application.port.in.response.RegistrationResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "사물함 신청", description = "사물함 신청 관련 API")
 public interface RegistrationApi {
+
+    @ApiExceptionExamples(GetRegistrationsExceptionDocs.class)
+    @Operation(summary = "사물함 신청 목록 조회", description = "사물함 이벤트에 대한 신청 목록을 조회합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "사물함 신청 목록 조회 성공",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = RegistrationCustomPage.class)))
+    ResponseEntity<RegistrationCustomPage> getRegistrations(
+            @PathVariable("event-id") Long eventId,
+            @Valid @ParameterObject RegistrationPageable registrationPageable);
+
+    @ApiExceptionExamples(GetMyRegistrationExceptionDocs.class)
+    @Operation(summary = "자신의 사물함 신청 현황 조회", description = "사물함 이벤트에 대한 자신의 신청 현황을 조회합니다")
+    @ApiResponse(
+            responseCode = "200",
+            description = "자신의 사물함 신청 현황 조회 성공",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = RegistrationResponse.class)))
+    ResponseEntity<RegistrationResponse> getMyRegistration(@PathVariable("event-id") Long eventId);
 
     @ApiExceptionExamples(RegistrationForEventExceptionDocs.class)
     @Operation(summary = "사물함 신청", description = "사물함 이벤트에 신청합니다. 사물함을 선택할 수 있습니다.")

--- a/src/main/java/com/jnulocker/registration/adapter/in/docs/RegistrationApi.java
+++ b/src/main/java/com/jnulocker/registration/adapter/in/docs/RegistrationApi.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 public interface RegistrationApi {
 
     @ApiExceptionExamples(GetRegistrationsExceptionDocs.class)
-    @Operation(summary = "사물함 신청 목록 조회", description = "사물함 이벤트에 대한 신청 목록을 조회합니다.")
+    @Operation(summary = "사물함 신청 목록 조회", description = "이벤트에 대한 신청 목록을 조회합니다.")
     @ApiResponse(
             responseCode = "200",
             description = "사물함 신청 목록 조회 성공",
@@ -34,7 +34,7 @@ public interface RegistrationApi {
             @Valid @ParameterObject RegistrationPageable registrationPageable);
 
     @ApiExceptionExamples(GetMyRegistrationExceptionDocs.class)
-    @Operation(summary = "자신의 사물함 신청 현황 조회", description = "사물함 이벤트에 대한 자신의 신청 현황을 조회합니다")
+    @Operation(summary = "자신의 사물함 신청 현황 조회", description = "이벤트에 대한 자신의 신청 현황을 조회합니다")
     @ApiResponse(
             responseCode = "200",
             description = "자신의 사물함 신청 현황 조회 성공",
@@ -45,7 +45,7 @@ public interface RegistrationApi {
     ResponseEntity<RegistrationResponse> getMyRegistration(@PathVariable("event-id") Long eventId);
 
     @ApiExceptionExamples(RegistrationForEventExceptionDocs.class)
-    @Operation(summary = "사물함 신청", description = "사물함 이벤트에 신청합니다. 사물함을 선택할 수 있습니다.")
+    @Operation(summary = "사물함 신청", description = "이벤트에 신청합니다. 사물함을 선택할 수 있습니다.")
     @ApiResponse(responseCode = "201", description = "사물함 신청 성공")
     ResponseEntity<Void> registerForEvent(
             @PathVariable("event-id") Long eventId,

--- a/src/main/java/com/jnulocker/registration/adapter/out/RegistrationPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/registration/adapter/out/RegistrationPersistenceAdapter.java
@@ -28,11 +28,11 @@ public class RegistrationPersistenceAdapter
 
     @Override
     public Page<Registration> getRegistrationsByEventId(Long eventId, Pageable pageable) {
-        return registrationRepository.findAllByEventId(eventId, pageable);
+        return registrationRepository.findAllByLocker_Floor_EventId(eventId, pageable);
     }
 
     @Override
     public Optional<Registration> getRegistrationByMemberIdAndEventId(Long memberId, Long eventId) {
-        return registrationRepository.findByMemberAndEvent(memberId, eventId);
+        return registrationRepository.findByMemberIdAndLocker_Floor_EventId(memberId, eventId);
     }
 }

--- a/src/main/java/com/jnulocker/registration/adapter/out/RegistrationPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/registration/adapter/out/RegistrationPersistenceAdapter.java
@@ -4,7 +4,10 @@ import com.jnulocker.common.annotation.PersistenceAdapter;
 import com.jnulocker.registration.application.port.out.RegistrationLoadPort;
 import com.jnulocker.registration.application.port.out.RegistrationRecordPort;
 import com.jnulocker.registration.domain.Registration;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
@@ -21,5 +24,15 @@ public class RegistrationPersistenceAdapter
     @Override
     public boolean existsByMemberIdAndEventId(Long memberId, Long eventId) {
         return registrationRepository.existsByMemberIdAndLocker_Floor_EventId(memberId, eventId);
+    }
+
+    @Override
+    public Page<Registration> getRegistrationsByEventId(Long eventId, Pageable pageable) {
+        return registrationRepository.findAllByEventId(eventId, pageable);
+    }
+
+    @Override
+    public Optional<Registration> getRegistrationByMemberIdAndEventId(Long memberId, Long eventId) {
+        return registrationRepository.findByMemberAndEvent(memberId, eventId);
     }
 }

--- a/src/main/java/com/jnulocker/registration/adapter/out/RegistrationRepository.java
+++ b/src/main/java/com/jnulocker/registration/adapter/out/RegistrationRepository.java
@@ -4,17 +4,15 @@ import com.jnulocker.registration.domain.Registration;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface RegistrationRepository extends JpaRepository<Registration, Long> {
     boolean existsByMemberIdAndLocker_Floor_EventId(Long memberId, Long eventId);
 
-    @Query(
-            "SELECT r FROM Registration r JOIN FETCH r.member m JOIN FETCH m.department JOIN FETCH r.locker l JOIN FETCH l.floor f WHERE f.event.id = :eventId")
-    Page<Registration> findAllByEventId(Long eventId, Pageable pageable);
+    @EntityGraph(attributePaths = {"member", "member.department", "locker", "locker.floor"})
+    Page<Registration> findAllByLocker_Floor_EventId(Long eventId, Pageable pageable);
 
-    @Query(
-            "SELECT r FROM Registration r JOIN FETCH r.member m JOIN FETCH m.department d JOIN FETCH r.locker l WHERE m.id = :memberId AND l.floor.event.id = :eventId")
-    Optional<Registration> findByMemberAndEvent(Long memberId, Long eventId);
+    @EntityGraph(attributePaths = {"member", "member.department", "locker", "locker.floor"})
+    Optional<Registration> findByMemberIdAndLocker_Floor_EventId(Long memberId, Long eventId);
 }

--- a/src/main/java/com/jnulocker/registration/adapter/out/RegistrationRepository.java
+++ b/src/main/java/com/jnulocker/registration/adapter/out/RegistrationRepository.java
@@ -1,8 +1,20 @@
 package com.jnulocker.registration.adapter.out;
 
 import com.jnulocker.registration.domain.Registration;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface RegistrationRepository extends JpaRepository<Registration, Long> {
     boolean existsByMemberIdAndLocker_Floor_EventId(Long memberId, Long eventId);
+
+    @Query(
+            "SELECT r FROM Registration r JOIN FETCH r.member m JOIN FETCH m.department JOIN FETCH r.locker l JOIN FETCH l.floor f WHERE f.event.id = :eventId")
+    Page<Registration> findAllByEventId(Long eventId, Pageable pageable);
+
+    @Query(
+            "SELECT r FROM Registration r JOIN FETCH r.member m JOIN FETCH m.department d JOIN FETCH r.locker l WHERE m.id = :memberId AND l.floor.event.id = :eventId")
+    Optional<Registration> findByMemberAndEvent(Long memberId, Long eventId);
 }

--- a/src/main/java/com/jnulocker/registration/adapter/out/RegistrationRepository.java
+++ b/src/main/java/com/jnulocker/registration/adapter/out/RegistrationRepository.java
@@ -10,7 +10,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface RegistrationRepository extends JpaRepository<Registration, Long> {
     boolean existsByMemberIdAndLocker_Floor_EventId(Long memberId, Long eventId);
 
-    @EntityGraph(attributePaths = {"member", "member.department", "locker", "locker.floor"})
+    @EntityGraph(
+            attributePaths = {
+                "member",
+                "member.department",
+                "member.department.organization",
+                "locker",
+                "locker.floor"
+            })
     Page<Registration> findAllByLocker_Floor_EventId(Long eventId, Pageable pageable);
 
     @EntityGraph(attributePaths = {"member", "member.department", "locker", "locker.floor"})

--- a/src/main/java/com/jnulocker/registration/application/port/in/RegistrationQuery.java
+++ b/src/main/java/com/jnulocker/registration/application/port/in/RegistrationQuery.java
@@ -1,0 +1,11 @@
+package com.jnulocker.registration.application.port.in;
+
+import com.jnulocker.registration.application.port.in.response.RegistrationCustomPage;
+import com.jnulocker.registration.application.port.in.response.RegistrationResponse;
+import org.springframework.data.domain.Pageable;
+
+public interface RegistrationQuery {
+    RegistrationCustomPage getRegistrations(Long eventId, Pageable pageable);
+
+    RegistrationResponse getMyRegistration(Long eventId);
+}

--- a/src/main/java/com/jnulocker/registration/application/port/in/response/RegistrationCustomPage.java
+++ b/src/main/java/com/jnulocker/registration/application/port/in/response/RegistrationCustomPage.java
@@ -1,0 +1,18 @@
+package com.jnulocker.registration.application.port.in.response;
+
+import com.jnulocker.registration.domain.Registration;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record RegistrationCustomPage(
+        @Schema(description = "신청 목록") List<RegistrationListItem> content,
+        @Schema(description = "전체 신청 개수", example = "10") Long totalElements,
+        @Schema(description = "마지막 페이지 여부", example = "false") Boolean last) {
+    public static RegistrationCustomPage from(Page<Registration> registrations) {
+        return new RegistrationCustomPage(
+                registrations.getContent().stream().map(RegistrationListItem::from).toList(),
+                registrations.getTotalElements(),
+                registrations.isLast());
+    }
+}

--- a/src/main/java/com/jnulocker/registration/application/port/in/response/RegistrationListItem.java
+++ b/src/main/java/com/jnulocker/registration/application/port/in/response/RegistrationListItem.java
@@ -1,0 +1,19 @@
+package com.jnulocker.registration.application.port.in.response;
+
+import com.jnulocker.registration.domain.Registration;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record RegistrationListItem(
+        @Schema(description = "신청 ID", example = "1") Long id,
+        @Schema(description = "층 번호", example = "2") Integer floorNumber,
+        @Schema(description = "사물함 번호", example = "A-021") String lockerCode,
+        @Schema(description = "신청자 정보") RegistrationMemberInfo member) {
+
+    public static RegistrationListItem from(Registration registration) {
+        return new RegistrationListItem(
+                registration.getId(),
+                registration.getLocker().getFloor().getFloorNumber(),
+                registration.getLocker().getCode(),
+                RegistrationMemberInfo.from(registration.getMember()));
+    }
+}

--- a/src/main/java/com/jnulocker/registration/application/port/in/response/RegistrationMemberInfo.java
+++ b/src/main/java/com/jnulocker/registration/application/port/in/response/RegistrationMemberInfo.java
@@ -7,7 +7,7 @@ public record RegistrationMemberInfo(
         @Schema(description = "신청자 이름", example = "심민보") String name,
         @Schema(description = "신청자 학번", example = "222312") String studentNumber,
         @Schema(description = "신청자 소속학과", example = "컴퓨터정보통신공학과") String department,
-        @Schema(description = "신청자 이메일", example = "asdf123@example.com") String email) {
+        @Schema(description = "신청자 이메일", example = "asdf123@jnu.ac.kr") String email) {
     public static RegistrationMemberInfo from(Member member) {
         return new RegistrationMemberInfo(
                 member.getName(),

--- a/src/main/java/com/jnulocker/registration/application/port/in/response/RegistrationMemberInfo.java
+++ b/src/main/java/com/jnulocker/registration/application/port/in/response/RegistrationMemberInfo.java
@@ -6,12 +6,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record RegistrationMemberInfo(
         @Schema(description = "신청자 이름", example = "심민보") String name,
         @Schema(description = "신청자 학번", example = "222312") String studentNumber,
+        @Schema(description = "신청자 소속대학", example = "공과대학") String organization,
         @Schema(description = "신청자 소속학과", example = "컴퓨터정보통신공학과") String department,
         @Schema(description = "신청자 이메일", example = "asdf123@jnu.ac.kr") String email) {
     public static RegistrationMemberInfo from(Member member) {
         return new RegistrationMemberInfo(
                 member.getName(),
                 member.getStudentNumber(),
+                member.getDepartment().getOrganization().getName(),
                 member.getDepartment().getName(),
                 member.getEmail());
     }

--- a/src/main/java/com/jnulocker/registration/application/port/in/response/RegistrationMemberInfo.java
+++ b/src/main/java/com/jnulocker/registration/application/port/in/response/RegistrationMemberInfo.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record RegistrationMemberInfo(
         @Schema(description = "신청자 이름", example = "심민보") String name,
-        @Schema(description = "신청자 학번", example = "20231234") String studentNumber,
+        @Schema(description = "신청자 학번", example = "222312") String studentNumber,
         @Schema(description = "신청자 소속학과", example = "컴퓨터정보통신공학과") String department,
         @Schema(description = "신청자 이메일", example = "asdf123@example.com") String email) {
     public static RegistrationMemberInfo from(Member member) {

--- a/src/main/java/com/jnulocker/registration/application/port/in/response/RegistrationMemberInfo.java
+++ b/src/main/java/com/jnulocker/registration/application/port/in/response/RegistrationMemberInfo.java
@@ -1,0 +1,14 @@
+package com.jnulocker.registration.application.port.in.response;
+
+import com.jnulocker.member.domain.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record RegistrationMemberInfo(
+        @Schema(description = "신청자 이름", example = "심민보") String name,
+        @Schema(description = "신청자 소속학과", example = "컴퓨터정보통신공학과") String department,
+        @Schema(description = "신청자 이메일", example = "asdf123@example.com") String email) {
+    public static RegistrationMemberInfo from(Member member) {
+        return new RegistrationMemberInfo(
+                member.getName(), member.getDepartment().getName(), member.getEmail());
+    }
+}

--- a/src/main/java/com/jnulocker/registration/application/port/in/response/RegistrationMemberInfo.java
+++ b/src/main/java/com/jnulocker/registration/application/port/in/response/RegistrationMemberInfo.java
@@ -5,10 +5,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record RegistrationMemberInfo(
         @Schema(description = "신청자 이름", example = "심민보") String name,
+        @Schema(description = "신청자 학번", example = "20231234") String studentNumber,
         @Schema(description = "신청자 소속학과", example = "컴퓨터정보통신공학과") String department,
         @Schema(description = "신청자 이메일", example = "asdf123@example.com") String email) {
     public static RegistrationMemberInfo from(Member member) {
         return new RegistrationMemberInfo(
-                member.getName(), member.getDepartment().getName(), member.getEmail());
+                member.getName(),
+                member.getStudentNumber(),
+                member.getDepartment().getName(),
+                member.getEmail());
     }
 }

--- a/src/main/java/com/jnulocker/registration/application/port/in/response/RegistrationPageable.java
+++ b/src/main/java/com/jnulocker/registration/application/port/in/response/RegistrationPageable.java
@@ -1,0 +1,31 @@
+package com.jnulocker.registration.application.port.in.response;
+
+import com.jnulocker.common.swagger.model.AbstractPageable;
+import jakarta.validation.constraints.AssertTrue;
+import java.util.Set;
+
+public class RegistrationPageable extends AbstractPageable {
+
+    public static final String DEFAULT_SORT = "createdAt";
+
+    public static final String VALID_SORT_MESSAGE =
+            "정렬 기준은 다음 중 하나여야 합니다: [id, memberId, lockerId, createdAt, updatedAt].";
+
+    public static final Set<String> VALID_SORT_FIELDS =
+            Set.of("id", "memberId", "lockerId", "createdAt", "updatedAt");
+
+    public RegistrationPageable(Integer page, Integer size, String direction, String sort) {
+        super(page, size, direction, sort);
+    }
+
+    @Override
+    @AssertTrue(message = VALID_SORT_MESSAGE)
+    protected boolean isValidSort() {
+        return !getSort().isBlank() && VALID_SORT_FIELDS.contains(getSort());
+    }
+
+    @Override
+    protected String getDefaultSort() {
+        return DEFAULT_SORT;
+    }
+}

--- a/src/main/java/com/jnulocker/registration/application/port/in/response/RegistrationResponse.java
+++ b/src/main/java/com/jnulocker/registration/application/port/in/response/RegistrationResponse.java
@@ -5,13 +5,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record RegistrationResponse(
         @Schema(description = "신청 ID", example = "1") Long id,
-        @Schema(description = "사물함 번호", example = "A-021") String lockerCode,
-        @Schema(description = "신청자 자신의 소속학과", example = "컴퓨터정보통신공학과") String department) {
+        @Schema(description = "층 번호", example = "2") Integer floorNumber,
+        @Schema(description = "사물함 번호", example = "A-021") String lockerCode) {
 
     public static RegistrationResponse from(Registration registration) {
         return new RegistrationResponse(
                 registration.getId(),
-                registration.getLocker().getCode(),
-                registration.getMember().getDepartment().getName());
+                registration.getLocker().getFloor().getFloorNumber(),
+                registration.getLocker().getCode());
     }
 }

--- a/src/main/java/com/jnulocker/registration/application/port/in/response/RegistrationResponse.java
+++ b/src/main/java/com/jnulocker/registration/application/port/in/response/RegistrationResponse.java
@@ -1,0 +1,17 @@
+package com.jnulocker.registration.application.port.in.response;
+
+import com.jnulocker.registration.domain.Registration;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record RegistrationResponse(
+        @Schema(description = "신청 ID", example = "1") Long id,
+        @Schema(description = "사물함 번호", example = "A-021") String lockerCode,
+        @Schema(description = "신청자 자신의 소속학과", example = "컴퓨터정보통신공학과") String department) {
+
+    public static RegistrationResponse from(Registration registration) {
+        return new RegistrationResponse(
+                registration.getId(),
+                registration.getLocker().getCode(),
+                registration.getMember().getDepartment().getName());
+    }
+}

--- a/src/main/java/com/jnulocker/registration/application/port/out/RegistrationLoadPort.java
+++ b/src/main/java/com/jnulocker/registration/application/port/out/RegistrationLoadPort.java
@@ -1,6 +1,15 @@
 package com.jnulocker.registration.application.port.out;
 
+import com.jnulocker.registration.domain.Registration;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 public interface RegistrationLoadPort {
 
     boolean existsByMemberIdAndEventId(Long memberId, Long eventId);
+
+    Page<Registration> getRegistrationsByEventId(Long eventId, Pageable pageable);
+
+    Optional<Registration> getRegistrationByMemberIdAndEventId(Long memberId, Long eventId);
 }

--- a/src/main/java/com/jnulocker/registration/application/service/RegistrationQueryService.java
+++ b/src/main/java/com/jnulocker/registration/application/service/RegistrationQueryService.java
@@ -1,0 +1,41 @@
+package com.jnulocker.registration.application.service;
+
+import com.jnulocker.auth.security.SecurityUtils;
+import com.jnulocker.events.application.port.in.EventQuery;
+import com.jnulocker.events.domain.Event;
+import com.jnulocker.registration.application.port.in.RegistrationQuery;
+import com.jnulocker.registration.application.port.in.response.RegistrationCustomPage;
+import com.jnulocker.registration.application.port.in.response.RegistrationResponse;
+import com.jnulocker.registration.application.port.out.RegistrationLoadPort;
+import com.jnulocker.registration.domain.Registration;
+import com.jnulocker.registration.exception.RegistrationNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RegistrationQueryService implements RegistrationQuery {
+
+    private final EventQuery eventQuery;
+    private final RegistrationLoadPort registrationLoadPort;
+
+    @Override
+    public RegistrationCustomPage getRegistrations(Long eventId, Pageable pageable) {
+        Event event = eventQuery.getByIdOrThrow(eventId);
+        Page<Registration> registrations =
+                registrationLoadPort.getRegistrationsByEventId(event.getId(), pageable);
+        return RegistrationCustomPage.from(registrations);
+    }
+
+    @Override
+    public RegistrationResponse getMyRegistration(Long eventId) {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        Registration registration =
+                registrationLoadPort
+                        .getRegistrationByMemberIdAndEventId(memberId, eventId)
+                        .orElseThrow(() -> RegistrationNotFoundException.EXCEPTION);
+        return RegistrationResponse.from(registration);
+    }
+}

--- a/src/main/java/com/jnulocker/registration/exception/RegistrationErrorCode.java
+++ b/src/main/java/com/jnulocker/registration/exception/RegistrationErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum RegistrationErrorCode implements ErrorCode {
     REGISTRATION_ALREADY_EXISTS("R001", HttpStatus.BAD_REQUEST, "이미 해당 회원이 신청한 사물함이 존재합니다."),
+    REGISTRATION_NOT_FOUND("R002", HttpStatus.NOT_FOUND, "신청 정보가 존재하지 않습니다."),
     ;
 
     private final String code;

--- a/src/main/java/com/jnulocker/registration/exception/RegistrationNotFoundException.java
+++ b/src/main/java/com/jnulocker/registration/exception/RegistrationNotFoundException.java
@@ -1,0 +1,12 @@
+package com.jnulocker.registration.exception;
+
+import com.jnulocker.common.exception.BusinessException;
+
+public class RegistrationNotFoundException extends BusinessException {
+
+    public static final BusinessException EXCEPTION = new RegistrationNotFoundException();
+
+    private RegistrationNotFoundException() {
+        super(RegistrationErrorCode.REGISTRATION_NOT_FOUND);
+    }
+}

--- a/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
@@ -5,21 +5,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.jnulocker.auth.jwt.TokenProvider;
 import com.jnulocker.common.exception.ErrorResponse;
-import com.jnulocker.events.adapter.out.EventRepository;
-import com.jnulocker.events.adapter.out.FloorRepository;
-import com.jnulocker.events.adapter.out.LockerRepository;
 import com.jnulocker.events.application.port.in.response.EventCustomPage;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
 import com.jnulocker.events.domain.Event;
 import com.jnulocker.events.domain.EventStatus;
 import com.jnulocker.events.exception.EventErrorCode;
 import com.jnulocker.events.utils.EventTestUtil;
-import com.jnulocker.member.adapter.out.MemberRepository;
 import com.jnulocker.member.domain.Member;
 import com.jnulocker.member.domain.Role;
 import com.jnulocker.member.utils.MemberTestUtil;
-import com.jnulocker.organization.adapter.out.DepartmentRepository;
-import com.jnulocker.organization.adapter.out.OrganizationRepository;
 import io.restassured.RestAssured;
 import io.restassured.http.Cookie;
 import io.restassured.response.ValidatableResponse;
@@ -53,18 +47,6 @@ public class EventControllerIntegrationTest {
 
     @LocalServerPort private int port;
 
-    @Autowired private OrganizationRepository organizationRepository;
-
-    @Autowired private DepartmentRepository departmentRepository;
-
-    @Autowired private EventRepository eventRepository;
-
-    @Autowired private FloorRepository floorRepository;
-
-    @Autowired private LockerRepository lockerRepository;
-
-    @Autowired private MemberRepository memberRepository;
-
     @Autowired private EventTestUtil eventTestUtil;
 
     @Autowired private TokenProvider tokenProvider;
@@ -91,12 +73,8 @@ public class EventControllerIntegrationTest {
     }
 
     private void clearData() {
-        memberRepository.deleteAll();
-        lockerRepository.deleteAll();
-        floorRepository.deleteAll();
-        eventRepository.deleteAll();
-        departmentRepository.deleteAll();
-        organizationRepository.deleteAll();
+        memberTestUtil.deleteAll();
+        eventTestUtil.deleteAll();
     }
 
     // 이벤트 목록 조회 테스트

--- a/src/test/java/com/jnulocker/events/utils/EventTestUtil.java
+++ b/src/test/java/com/jnulocker/events/utils/EventTestUtil.java
@@ -78,4 +78,12 @@ public class EventTestUtil {
         }
         lockerRepository.saveAll(lockers);
     }
+
+    public void deleteAll() {
+        lockerRepository.deleteAll();
+        floorRepository.deleteAll();
+        eventRepository.deleteAll();
+        departmentRepository.deleteAll();
+        organizationRepository.deleteAll();
+    }
 }

--- a/src/test/java/com/jnulocker/member/utils/MemberTestUtil.java
+++ b/src/test/java/com/jnulocker/member/utils/MemberTestUtil.java
@@ -44,4 +44,8 @@ public class MemberTestUtil {
         Department department = departmentBuilder().withOrganization(savedOrganization).build();
         return departmentRepository.save(department);
     }
+
+    public void deleteAll() {
+        memberRepository.deleteAll();
+    }
 }

--- a/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
@@ -129,8 +129,8 @@ class RegistrationControllerIntegrationTest {
                         .extract()
                         .as(RegistrationResponse.class);
 
+        assertThat(registrationResponse.floorNumber()).isEqualTo(1);
         assertThat(registrationResponse.lockerCode()).isEqualTo("A-002");
-        assertThat(registrationResponse.department()).isEqualTo("테스트 학과명");
     }
 
     @Test

--- a/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
@@ -91,6 +91,9 @@ class RegistrationControllerIntegrationTest {
 
         registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
 
+        // TODO: 추후 manager로 변경
+        accessToken = generateAccessToken(Role.GUEST);
+
         // when
         RegistrationCustomPage registrationCustomPage =
                 getRegistrations(event.getId())
@@ -107,6 +110,7 @@ class RegistrationControllerIntegrationTest {
         assertThat(listItem.floorNumber()).isEqualTo(1);
         assertThat(listItem.lockerCode()).isEqualTo("A-002");
         assertThat(member.name()).isEqualTo("테스트 이름");
+        assertThat(member.studentNumber()).isEqualTo("221965");
         assertThat(member.department()).isEqualTo("테스트 학과명");
         assertThat(member.email()).isEqualTo("test@email.com");
     }

--- a/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
@@ -111,6 +111,7 @@ class RegistrationControllerIntegrationTest {
         assertThat(listItem.lockerCode()).isEqualTo("A-002");
         assertThat(member.name()).isEqualTo("테스트 이름");
         assertThat(member.studentNumber()).isEqualTo("221965");
+        assertThat(member.organization()).isEqualTo("테스트 조직명");
         assertThat(member.department()).isEqualTo("테스트 학과명");
         assertThat(member.email()).isEqualTo("test@email.com");
     }

--- a/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
@@ -16,11 +16,17 @@ import com.jnulocker.member.domain.Member;
 import com.jnulocker.member.domain.Role;
 import com.jnulocker.member.utils.MemberTestUtil;
 import com.jnulocker.registration.application.port.in.request.RegisterForEventRequest;
+import com.jnulocker.registration.application.port.in.response.RegistrationCustomPage;
+import com.jnulocker.registration.application.port.in.response.RegistrationListItem;
+import com.jnulocker.registration.application.port.in.response.RegistrationMemberInfo;
+import com.jnulocker.registration.application.port.in.response.RegistrationResponse;
 import com.jnulocker.registration.exception.RegistrationErrorCode;
+import com.jnulocker.registration.utils.RegistrationTestUtil;
 import io.restassured.RestAssured;
 import io.restassured.http.Cookie;
 import io.restassured.response.ValidatableResponse;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -50,12 +56,21 @@ class RegistrationControllerIntegrationTest {
 
     @Autowired private MemberTestUtil memberTestUtil;
 
+    @Autowired private RegistrationTestUtil registrationTestUtil;
+
     private String accessToken;
 
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
         accessToken = generateAccessToken(Role.USER);
+    }
+
+    @AfterEach
+    void tearDown() {
+        registrationTestUtil.deleteAll();
+        memberTestUtil.deleteAll();
+        eventTestUtil.deleteAll();
     }
 
     @Test
@@ -66,6 +81,52 @@ class RegistrationControllerIntegrationTest {
 
         // when, then
         registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
+    }
+
+    @Test
+    void 신청된_사물함_목록을_조회할_수_있다() {
+        // given
+        Event event = createEventWithLockers(EventStatus.OPEN, true);
+        RegisterForEventRequest request = createRequestForAvailableLocker(event);
+
+        registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
+
+        // when
+        RegistrationCustomPage registrationCustomPage =
+                getRegistrations(event.getId())
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .as(RegistrationCustomPage.class);
+
+        // then
+        List<RegistrationListItem> content = registrationCustomPage.content();
+        RegistrationListItem listItem = content.getFirst();
+        RegistrationMemberInfo member = listItem.member();
+
+        assertThat(registrationCustomPage.totalElements()).isEqualTo(1);
+        assertThat(listItem.floorNumber()).isEqualTo(1);
+        assertThat(listItem.lockerCode()).isEqualTo("A-002");
+        assertThat(member.name()).isEqualTo("테스트 이름");
+        assertThat(member.department()).isEqualTo("테스트 학과명");
+        assertThat(member.email()).isEqualTo("test@email.com");
+    }
+
+    @Test
+    void 자신이_신청한_사물함을_조회할_수_있다() {
+        // given
+        Event event = createEventWithLockers(EventStatus.OPEN, true);
+        RegisterForEventRequest request = createRequestForAvailableLocker(event);
+
+        registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
+
+        RegistrationResponse registrationResponse =
+                getMyRegistration(event.getId())
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .as(RegistrationResponse.class);
+
+        assertThat(registrationResponse.lockerCode()).isEqualTo("A-002");
+        assertThat(registrationResponse.department()).isEqualTo("테스트 학과명");
     }
 
     @Test
@@ -222,6 +283,24 @@ class RegistrationControllerIntegrationTest {
 
         // when, then
         registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
+    }
+
+    private ValidatableResponse getRegistrations(Long eventId) {
+        return given().cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
+                .when()
+                .get(REGISTRATION_URL, eventId)
+                .then()
+                .log()
+                .ifError();
+    }
+
+    private ValidatableResponse getMyRegistration(Long eventId) {
+        return given().cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
+                .when()
+                .get(REGISTRATION_URL + "/me", eventId)
+                .then()
+                .log()
+                .ifError();
     }
 
     private ValidatableResponse registerForEvent(Long eventId, RegisterForEventRequest request) {

--- a/src/test/java/com/jnulocker/registration/utils/RegistrationTestUtil.java
+++ b/src/test/java/com/jnulocker/registration/utils/RegistrationTestUtil.java
@@ -1,0 +1,15 @@
+package com.jnulocker.registration.utils;
+
+import com.jnulocker.registration.adapter.out.RegistrationRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RegistrationTestUtil {
+
+    @Autowired private RegistrationRepository registrationRepository;
+
+    public void deleteAll() {
+        registrationRepository.deleteAll();
+    }
+}

--- a/src/testFixtures/java/member/domain/MemberTestDataBuilder.java
+++ b/src/testFixtures/java/member/domain/MemberTestDataBuilder.java
@@ -40,6 +40,11 @@ public class MemberTestDataBuilder {
         return this;
     }
 
+    public MemberTestDataBuilder withStudentNumber(String studentNumber) {
+        this.studentNumber = studentNumber;
+        return this;
+    }
+
     public MemberTestDataBuilder withDepartment(Department department) {
         this.department = department;
         return this;


### PR DESCRIPTION
### 개요
close #54 

### 작업사항
- 사물함 신청 현황 조회 API 구현

### 변경로직
- 사물함 신청 현황 조회 로직 구현
- 통합 테스트 작성
- SecurityConfig에서 인증이 필요한 GET 엔드포인트 묶어둠

### 테스트 결과

- 전체 테스트 결과

  <img width="346" alt="image" src="https://github.com/user-attachments/assets/f33726dd-3823-4422-ad70-8bbf08c82702" />

- 추가된 테스트케이스

  - 자신이 신청한 사물함을 조회할 수 있다
  - 신청된 사물함 목록을 조회할 수 있다

  <img width="344" alt="image" src="https://github.com/user-attachments/assets/eafdeb42-2a8a-4937-accb-e44ee028199c" />

### reference

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 이벤트별 사물함 신청 내역 목록 조회 및 본인 신청 내역 조회 API가 추가되었습니다.
  - 신청 내역 조회 시 페이지네이션 및 정렬 기능이 제공됩니다.
  - 인증된 사용자에 대한 접근 권한이 세분화되어 보안이 강화되었습니다.

- **문서화**
  - 신규 조회 API 및 예외 상황에 대한 Swagger 문서가 추가되었습니다.

- **버그 수정**
  - 사물함 신청 내역이 없을 때의 예외 처리 및 오류 코드가 추가되었습니다.

- **테스트**
  - 신청 내역 조회 및 본인 신청 내역 조회에 대한 통합 테스트가 추가되었습니다.
  - 테스트 데이터 정리 유틸리티가 도입되었습니다.

- **리팩터링/정리**
  - 테스트 코드에서 데이터 정리 로직이 유틸리티 클래스로 일원화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->