### PR TITLE
[FEAT] 사물함 신청 취소 API 구현

### DIFF
--- a/src/main/java/com/jnulocker/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/jnulocker/auth/jwt/JwtFilter.java
@@ -47,6 +47,8 @@ public class JwtFilter extends OncePerRequestFilter {
                         "/swagger-resources/**",
                         "/v3/api-docs/**",
                         "/api-docs/**",
+                        "/v1/organizations",
+                        "/v1/organizations/*/departments",
                         actuatorBasePath,
                         actuatorBasePath + "/health",
                         actuatorBasePath + "/prometheus");

--- a/src/main/java/com/jnulocker/registration/adapter/in/RegistrationController.java
+++ b/src/main/java/com/jnulocker/registration/adapter/in/RegistrationController.java
@@ -13,6 +13,7 @@ import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -51,5 +52,12 @@ public class RegistrationController implements RegistrationApi {
             @Valid @RequestBody RegisterForEventRequest request) {
         registrationCommand.registerForEvent(eventId, request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Override
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> cancelMyRegistration(@PathVariable("event-id") Long eventId) {
+        registrationCommand.cancelMyRegistration(eventId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/jnulocker/registration/adapter/in/docs/CancelMyRegistrationExceptionDocs.java
+++ b/src/main/java/com/jnulocker/registration/adapter/in/docs/CancelMyRegistrationExceptionDocs.java
@@ -1,0 +1,17 @@
+package com.jnulocker.registration.adapter.in.docs;
+
+import com.jnulocker.common.exception.BusinessException;
+import com.jnulocker.common.swagger.ExceptionDoc;
+import com.jnulocker.common.swagger.ExplainError;
+import com.jnulocker.common.swagger.SwaggerExceptionDoc;
+import com.jnulocker.events.exception.EventNotFoundException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@ExceptionDoc
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CancelMyRegistrationExceptionDocs implements SwaggerExceptionDoc {
+
+    @ExplainError("이벤트가 존재하지 않을 때 발생하는 예외입니다")
+    public static final BusinessException 이벤트가_존재하지_않을_때 = EventNotFoundException.EXCEPTION;
+}

--- a/src/main/java/com/jnulocker/registration/adapter/in/docs/CancelMyRegistrationExceptionDocs.java
+++ b/src/main/java/com/jnulocker/registration/adapter/in/docs/CancelMyRegistrationExceptionDocs.java
@@ -5,6 +5,7 @@ import com.jnulocker.common.swagger.ExceptionDoc;
 import com.jnulocker.common.swagger.ExplainError;
 import com.jnulocker.common.swagger.SwaggerExceptionDoc;
 import com.jnulocker.events.exception.EventNotFoundException;
+import com.jnulocker.registration.exception.RegistrationNotFoundException;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -14,4 +15,7 @@ public class CancelMyRegistrationExceptionDocs implements SwaggerExceptionDoc {
 
     @ExplainError("이벤트가 존재하지 않을 때 발생하는 예외입니다")
     public static final BusinessException 이벤트가_존재하지_않을_때 = EventNotFoundException.EXCEPTION;
+
+    @ExplainError("사물함 신청 내역이 존재하지 않을 때 발생하는 예외입니다")
+    public static final BusinessException 신청_내역이_존재하지_않을_때 = RegistrationNotFoundException.EXCEPTION;
 }

--- a/src/main/java/com/jnulocker/registration/adapter/in/docs/RegistrationApi.java
+++ b/src/main/java/com/jnulocker/registration/adapter/in/docs/RegistrationApi.java
@@ -50,4 +50,9 @@ public interface RegistrationApi {
     ResponseEntity<Void> registerForEvent(
             @PathVariable("event-id") Long eventId,
             @Valid @RequestBody RegisterForEventRequest request);
+
+    @ApiExceptionExamples(CancelMyRegistrationExceptionDocs.class)
+    @Operation(summary = "사물함 신청 취소", description = "해당 이벤트에 대한 사물함 신청을 취소합니다.")
+    @ApiResponse(responseCode = "204", description = "사물함 신청 취소 성공")
+    ResponseEntity<Void> cancelMyRegistration(@PathVariable("event-id") Long eventId);
 }

--- a/src/main/java/com/jnulocker/registration/adapter/out/RegistrationPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/registration/adapter/out/RegistrationPersistenceAdapter.java
@@ -22,6 +22,11 @@ public class RegistrationPersistenceAdapter
     }
 
     @Override
+    public void delete(Registration registration) {
+        registrationRepository.delete(registration);
+    }
+
+    @Override
     public boolean existsByMemberIdAndEventId(Long memberId, Long eventId) {
         return registrationRepository.existsByMemberIdAndLocker_Floor_EventId(memberId, eventId);
     }

--- a/src/main/java/com/jnulocker/registration/application/port/in/RegistrationCommand.java
+++ b/src/main/java/com/jnulocker/registration/application/port/in/RegistrationCommand.java
@@ -4,4 +4,6 @@ import com.jnulocker.registration.application.port.in.request.RegisterForEventRe
 
 public interface RegistrationCommand {
     void registerForEvent(Long eventId, RegisterForEventRequest request);
+
+    void cancelMyRegistration(Long eventId);
 }

--- a/src/main/java/com/jnulocker/registration/application/port/out/RegistrationRecordPort.java
+++ b/src/main/java/com/jnulocker/registration/application/port/out/RegistrationRecordPort.java
@@ -5,4 +5,6 @@ import com.jnulocker.registration.domain.Registration;
 public interface RegistrationRecordPort {
 
     void save(Registration registration);
+
+    void delete(Registration registration);
 }

--- a/src/main/java/com/jnulocker/registration/application/service/RegistrationCommandService.java
+++ b/src/main/java/com/jnulocker/registration/application/service/RegistrationCommandService.java
@@ -13,6 +13,7 @@ import com.jnulocker.registration.application.port.out.RegistrationLoadPort;
 import com.jnulocker.registration.application.port.out.RegistrationRecordPort;
 import com.jnulocker.registration.domain.Registration;
 import com.jnulocker.registration.exception.RegistrationAlreadyExistsException;
+import com.jnulocker.registration.exception.RegistrationNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,5 +47,17 @@ public class RegistrationCommandService implements RegistrationCommand {
 
         Registration registration = Registration.create(member, locker);
         registrationRecordPort.save(registration);
+    }
+
+    @Override
+    @Transactional
+    public void cancelMyRegistration(Long eventId) {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        Event event = eventQuery.getByIdOrThrow(eventId);
+        Registration registration =
+                registrationLoadPort
+                        .getRegistrationByMemberIdAndEventId(memberId, event.getId())
+                        .orElseThrow(() -> RegistrationNotFoundException.EXCEPTION);
+        registrationRecordPort.delete(registration);
     }
 }

--- a/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
@@ -290,6 +290,36 @@ class RegistrationControllerIntegrationTest {
         registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
     }
 
+    @Test
+    void 신청한_이벤트를_취소할_수_있다() {
+        // given
+        Event event = createEventWithLockers(EventStatus.OPEN, true);
+        RegisterForEventRequest request = createRequestForAvailableLocker(event);
+
+        registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
+
+        // when, then
+        cancelMyRegistration(event.getId()).statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    @Test
+    void 존재하지_않는_이벤트를_취소할_수_없다() {
+        // given
+        Event event = createEventWithLockers(EventStatus.OPEN, true);
+        RegisterForEventRequest request = createRequestForAvailableLocker(event);
+
+        registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
+
+        // when, then
+        ErrorResponse errorResponse =
+                cancelMyRegistration(Long.MAX_VALUE)
+                        .statusCode(EventErrorCode.EVENT_NOT_FOUND.getHttpStatus().value())
+                        .extract()
+                        .as(ErrorResponse.class);
+
+        assertThat(errorResponse.message()).isEqualTo(EventErrorCode.EVENT_NOT_FOUND.getMessage());
+    }
+
     private ValidatableResponse getRegistrations(Long eventId) {
         return given().cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
                 .when()
@@ -325,6 +355,15 @@ class RegistrationControllerIntegrationTest {
                 .body(request)
                 .when()
                 .post(REGISTRATION_URL, eventId)
+                .then()
+                .log()
+                .ifError();
+    }
+
+    private ValidatableResponse cancelMyRegistration(Long eventId) {
+        return given().cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
+                .when()
+                .delete(REGISTRATION_URL + "/me", eventId)
                 .then()
                 .log()
                 .ifError();

--- a/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
@@ -303,7 +303,7 @@ class RegistrationControllerIntegrationTest {
     }
 
     @Test
-    void 존재하지_않는_이벤트를_취소할_수_없다() {
+    void 존재하지_않는_이벤트의_사물함_신청을_취소할_수_없다() {
         // given
         Event event = createEventWithLockers(EventStatus.OPEN, true);
         RegisterForEventRequest request = createRequestForAvailableLocker(event);

--- a/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
@@ -291,7 +291,7 @@ class RegistrationControllerIntegrationTest {
     }
 
     @Test
-    void 신청한_이벤트를_취소할_수_있다() {
+    void 신청한_사물함을_취소할_수_있다() {
         // given
         Event event = createEventWithLockers(EventStatus.OPEN, true);
         RegisterForEventRequest request = createRequestForAvailableLocker(event);


### PR DESCRIPTION
### 개요
close #59 

### 작업사항
- 사물함 신청 취소 API 구현

### 변경로직
- 조직 및 학과 조회 엔드포인트 JWT 인가 제외

### 테스트 결과

- 전체 테스트 결과
  <img width="346" alt="image" src="https://github.com/user-attachments/assets/d203018a-8df7-41a7-8fd9-dc0a2065415b" />

- 추가된 테스트 결과

  - 신청한 사물함을 취소할 수 있다

  - 존재하지 않는 이벤트의 사물함 신청을 취소할 수 없다

  <img width="350" alt="image" src="https://github.com/user-attachments/assets/bb051d6f-b944-41a0-be51-1bd5002634a4" />


### reference


### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 사용자가 본인의 이벤트 사물함 신청을 취소할 수 있는 기능이 추가되었습니다. 이제 /v1/events/{event-id}/registrations/me 엔드포인트에서 신청 취소가 가능합니다.
  - JWT 인증 필터에서 "/v1/organizations" 및 "/v1/organizations/*/departments" 경로가 인증 예외 대상에 추가되었습니다.
- **문서화**
  - 사물함 신청 취소 관련 API 및 예외 상황이 Swagger 문서에 추가되었습니다.
- **버그 수정**
  - 없음
- **테스트**
  - 사물함 신청 취소 성공 및 실패(존재하지 않는 이벤트) 시나리오에 대한 통합 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->