### PR TITLE
[FEAT] 이메일 인증 시 동일 계정 존재 여부에 대한 검사

### DIFF
--- a/src/main/java/com/jnulocker/auth/adapter/in/docs/MailSendExceptionDocs.java
+++ b/src/main/java/com/jnulocker/auth/adapter/in/docs/MailSendExceptionDocs.java
@@ -1,6 +1,7 @@
 package com.jnulocker.auth.adapter.in.docs;
 
 import com.jnulocker.auth.exception.SendEmailException;
+import com.jnulocker.auth.exception.UserAlreadyExistException;
 import com.jnulocker.common.exception.BusinessException;
 import com.jnulocker.common.swagger.ExceptionDoc;
 import com.jnulocker.common.swagger.ExplainError;
@@ -13,4 +14,8 @@ import lombok.NoArgsConstructor;
 public class MailSendExceptionDocs implements SwaggerExceptionDoc {
     @ExplainError("이메일 전송 중 오류가 발생했을 때 발생하는 예외입니다.")
     public static final BusinessException 이메일_전송_중_오류가_발생했을_때 = SendEmailException.EXCEPTION;
+
+    @ExplainError("동일 계정이 이미 사용중일 때 발생하는 예외입니다.")
+    public static final BusinessException 입력한_이메일_계정이_이미_사용중일_때 =
+            UserAlreadyExistException.EXCEPTION;
 }

--- a/src/main/java/com/jnulocker/auth/application/port/in/request/VerifyCodeRequest.java
+++ b/src/main/java/com/jnulocker/auth/application/port/in/request/VerifyCodeRequest.java
@@ -1,5 +1,6 @@
 package com.jnulocker.auth.application.port.in.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -8,6 +9,7 @@ public record VerifyCodeRequest(
         @NotBlank(message = "이메일은 필수 입력 값입니다") @Email(message = "올바른 형식의 이메일 주소여야 합니다")
                 String email,
         @NotBlank(message = "인증 코드는 필수 입력 값입니다") String code) {
+    @Schema(hidden = true)
     @AssertTrue(message = "인증 코드는 100000에서 999999 사이의 6자리 숫자여야 합니다")
     public boolean isCodeValid() {
         if (code == null) {

--- a/src/main/java/com/jnulocker/auth/application/port/in/request/VerifyCodeRequest.java
+++ b/src/main/java/com/jnulocker/auth/application/port/in/request/VerifyCodeRequest.java
@@ -1,6 +1,5 @@
 package com.jnulocker.auth.application.port.in.request;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -9,9 +8,8 @@ public record VerifyCodeRequest(
         @NotBlank(message = "이메일은 필수 입력 값입니다") @Email(message = "올바른 형식의 이메일 주소여야 합니다")
                 String email,
         @NotBlank(message = "인증 코드는 필수 입력 값입니다") String code) {
-    @Schema(hidden = true)
     @AssertTrue(message = "인증 코드는 100000에서 999999 사이의 6자리 숫자여야 합니다")
-    public boolean isCodeValid() {
+    private boolean isCodeValid() {
         if (code == null) {
             return false;
         }

--- a/src/main/java/com/jnulocker/auth/application/service/AuthService.java
+++ b/src/main/java/com/jnulocker/auth/application/service/AuthService.java
@@ -114,7 +114,7 @@ public class AuthService
         return tokenProvider.createAuthToken(memberId, member.getRole());
     }
 
-    private void validateDuplicateEmail(String email) {
+    public void validateDuplicateEmail(String email) {
         if (memberQuery.existsByEmail(email)) {
             throw UserAlreadyExistException.EXCEPTION;
         }

--- a/src/main/java/com/jnulocker/auth/application/service/EmailService.java
+++ b/src/main/java/com/jnulocker/auth/application/service/EmailService.java
@@ -22,9 +22,12 @@ public class EmailService implements SendEmailCommand, VerifyCodeCommand {
     private final TemplateEngine templateEngine;
     private final JavaMailSender javaMailSender;
     private final RedisUtil redisUtil;
+    private final AuthService authService;
 
     @Override
     public void sendEmail(SendEmailRequest request) {
+        authService.validateDuplicateEmail(request.email());
+
         // 기존 이메일 인증 완료 기록이 있으면 삭제
         if (redisUtil.existsVerifiedEmail(request.email())) {
             redisUtil.deleteVerifiedData(request.email());

--- a/src/main/java/com/jnulocker/events/adapter/in/docs/DeleteEventExceptionDocs.java
+++ b/src/main/java/com/jnulocker/events/adapter/in/docs/DeleteEventExceptionDocs.java
@@ -21,6 +21,5 @@ public class DeleteEventExceptionDocs implements SwaggerExceptionDoc {
     public static final BusinessException 이벤트가_존재하지_않을_때 = EventNotFoundException.EXCEPTION;
 
     @ExplainError("이벤트 주최 학과가 아닐 때 발생하는 예외입니다")
-    public static final BusinessException 이벤트_주최_학과가_아닐_때 =
-            OnlyManagerCanDeleteException.EXCEPTION;
+    public static final BusinessException 이벤트_주최_학과가_아닐_때 = OnlyManagerCanDeleteException.EXCEPTION;
 }

--- a/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
@@ -97,151 +97,205 @@ class AuthControllerIntegrationTest {
     // USER 회원가입 테스트 (변경 없음)
     @Test
     void USER_회원가입을_할_수_있다() {
+        // given
         Department department = organizationUtil.createDepartment();
         UserSignupRequest request =
                 userSignupRequestBuilder().withDepartmentId(department.getId()).build();
+
+        // when
         ValidatableResponse response = signupUser(request);
+
+        // then
         response.statusCode(HttpStatus.CREATED.value());
     }
 
     @Test
     void USER_존재하지_않는_학과로_회원가입하면_Department_Not_Found_에러_응답을_받는다() {
+        // given
         Long nonexistentDepartmentId = -1L;
         UserSignupRequest request =
                 userSignupRequestBuilder().withDepartmentId(nonexistentDepartmentId).build();
+
+        // when
         ErrorResponse errorResponse =
                 signupUser(request)
                         .statusCode(
                                 DepartmentErrorCode.DEPARTMENT_NOT_FOUND.getHttpStatus().value())
                         .extract()
                         .as(ErrorResponse.class);
+
+        // then
         assertThat(errorResponse.message())
                 .isEqualTo(DepartmentErrorCode.DEPARTMENT_NOT_FOUND.getMessage());
     }
 
     @Test
     void USER_동일메일로_회원가입하면_User_Already_Exist_에러_응답을_받는다() {
+        // given
         Department department = organizationUtil.createDepartment();
         UserSignupRequest request =
                 userSignupRequestBuilder().withDepartmentId(department.getId()).build();
         signupUser(request).statusCode(HttpStatus.CREATED.value());
+
+        // when
         ErrorResponse errorResponse =
                 signupUser(request)
                         .statusCode(AuthErrorCode.USER_ALREADY_EXIST.getHttpStatus().value())
                         .extract()
                         .as(ErrorResponse.class);
+
+        // then
         assertThat(errorResponse.message())
                 .isEqualTo(AuthErrorCode.USER_ALREADY_EXIST.getMessage());
     }
 
     @Test
     void USER_회원가입_시_이메일_인증이_완료되지_않았으면_Email_Not_Verified_에러_응답을_받는다() {
+        // given
         Department department = organizationUtil.createDepartment();
         UserSignupRequest request =
                 userSignupRequestBuilder().withDepartmentId(department.getId()).build();
-
         redisUtil.deleteVerifiedData(request.email());
+
+        // when
         ErrorResponse errorResponse =
                 signupUserNotEmailVerified(request)
                         .statusCode(AuthErrorCode.EMAIL_NOT_VERIFIED.getHttpStatus().value())
                         .extract()
                         .as(ErrorResponse.class);
+
+        // then
         assertThat(errorResponse.message())
                 .isEqualTo(AuthErrorCode.EMAIL_NOT_VERIFIED.getMessage());
     }
 
     @Test
     void MANAGER_회원가입을_할_수_있다() {
+        // given
         Department department = organizationUtil.createDepartment();
         ManagerSignupRequest request =
                 managerSignupRequestBuilder().withDepartmentId(department.getId()).build();
+
+        // when
         ValidatableResponse response = signupManager(request);
+
+        // then
         response.statusCode(HttpStatus.CREATED.value());
     }
 
     @Test
     void MANAGER_학생회_회원가입_시_학번이_null이면_Student_Number_Required_에러_응답을_받는다() {
+        // given
         Department department = organizationUtil.createDepartment();
         ManagerSignupRequest request =
                 managerSignupRequestBuilder()
                         .withDepartmentId(department.getId())
                         .withStudentNumber(null)
                         .build();
+
+        // when
         ErrorResponse errorResponse =
                 signupManager(request)
                         .statusCode(AuthErrorCode.STUDENT_NUMBER_REQUIRED.getHttpStatus().value())
                         .extract()
                         .as(ErrorResponse.class);
+
+        // then
         assertThat(errorResponse.message())
                 .isEqualTo(AuthErrorCode.STUDENT_NUMBER_REQUIRED.getMessage());
     }
 
     @Test
     void MANAGER_학생회_회원가입_시_학번이_입력되면_정상적으로_회원가입된다() {
+        // given
         Department department = organizationUtil.createDepartment();
         ManagerSignupRequest request =
                 managerSignupRequestBuilder()
                         .withDepartmentId(department.getId())
                         .withStudentNumber("221965")
                         .build();
+
+        // when
         ValidatableResponse response = signupManager(request);
+
+        // then
         response.statusCode(HttpStatus.CREATED.value());
     }
 
     @Test
     void MANAGER_자치회_회원가입_시_학번이_입력되지_않으면_정상적으로_회원가입된다() {
+        // given
         Department department = organizationUtil.createCommitteeDepartment();
         ManagerSignupRequest request =
                 managerSignupRequestBuilder()
                         .withDepartmentId(department.getId())
                         .withStudentNumber(null)
                         .build();
+
+        // when
         ValidatableResponse response = signupManager(request);
+
+        // then
         response.statusCode(HttpStatus.CREATED.value());
     }
 
     @Test
     void MANAGER_존재하지_않는_학과로_회원가입하면_Department_Not_Found_에러_응답을_받는다() {
+        // given
         Long nonexistentDepartmentId = -1L;
         ManagerSignupRequest request =
                 managerSignupRequestBuilder().withDepartmentId(nonexistentDepartmentId).build();
+
+        // when
         ErrorResponse errorResponse =
                 signupManager(request)
                         .statusCode(
                                 DepartmentErrorCode.DEPARTMENT_NOT_FOUND.getHttpStatus().value())
                         .extract()
                         .as(ErrorResponse.class);
+
+        // then
         assertThat(errorResponse.message())
                 .isEqualTo(DepartmentErrorCode.DEPARTMENT_NOT_FOUND.getMessage());
     }
 
     @Test
     void MANAGER_동일메일로_회원가입하면_User_Already_Exist_에러_응답을_받는다() {
+        // given
         Department department = organizationUtil.createDepartment();
         ManagerSignupRequest request =
                 managerSignupRequestBuilder().withDepartmentId(department.getId()).build();
         signupManager(request).statusCode(HttpStatus.CREATED.value());
+
+        // when
         ErrorResponse errorResponse =
                 signupManager(request)
                         .statusCode(AuthErrorCode.USER_ALREADY_EXIST.getHttpStatus().value())
                         .extract()
                         .as(ErrorResponse.class);
+
+        // then
         assertThat(errorResponse.message())
                 .isEqualTo(AuthErrorCode.USER_ALREADY_EXIST.getMessage());
     }
 
     @Test
     void MANAGER_회원가입_시_이메일_인증이_완료되지_않았으면_Email_Not_Verified_에러_응답을_받는다() {
+        // given
         Department department = organizationUtil.createDepartment();
 
         ManagerSignupRequest request =
                 managerSignupRequestBuilder().withDepartmentId(department.getId()).build();
         redisUtil.deleteVerifiedData(request.email());
+
+        // when
         ErrorResponse errorResponse =
                 signupManagerNotEmailVerified(request)
                         .statusCode(AuthErrorCode.EMAIL_NOT_VERIFIED.getHttpStatus().value())
                         .extract()
                         .as(ErrorResponse.class);
+
+        // then
         assertThat(errorResponse.message())
                 .isEqualTo(AuthErrorCode.EMAIL_NOT_VERIFIED.getMessage());
     }
@@ -427,6 +481,29 @@ class AuthControllerIntegrationTest {
 
         // then
         response.statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    void 이미_사용중인_이메일로_인증_요청_시_User_Already_Exist_에러_응답을_받는다() {
+        // given
+        Department department = organizationUtil.createDepartment();
+        UserSignupRequest signupRequest =
+                userSignupRequestBuilder().withDepartmentId(department.getId()).build();
+        signupUser(signupRequest).statusCode(HttpStatus.CREATED.value());
+
+        SendEmailRequest sendEmailRequest =
+                sendEmailRequestBuilder().withEmail(signupRequest.email()).build();
+
+        // when
+        ErrorResponse errorResponse =
+                sendEmail(sendEmailRequest)
+                        .statusCode(AuthErrorCode.USER_ALREADY_EXIST.getHttpStatus().value())
+                        .extract()
+                        .as(ErrorResponse.class);
+
+        // then
+        assertThat(errorResponse.message())
+                .isEqualTo(AuthErrorCode.USER_ALREADY_EXIST.getMessage());
     }
 
     @Test

--- a/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
@@ -294,8 +294,7 @@ public class EventControllerIntegrationTest {
         // when
         ErrorResponse errorResponse =
                 deleteEvent(eventId)
-                        .statusCode(
-                                EventErrorCode.ONLY_MANAGER_CAN_DELETE.getHttpStatus().value())
+                        .statusCode(EventErrorCode.ONLY_MANAGER_CAN_DELETE.getHttpStatus().value())
                         .extract()
                         .as(ErrorResponse.class);
 


### PR DESCRIPTION
### 개요
close #64 

### 작업사항
- 이메일 인증 요청 시 동일 계정이 사용중인지 검사하고 이에 따른 예외 응답을 제공합니다.

### 변경로직
- 회원가입 이전 이메일 인증 절차에서 동일 계정 존재에 대해 검사합니다.

### 테스트 결과
<p >
  <img src="https://github.com/user-attachments/assets/d857130f-8c28-4310-a3d9-8ca0db9f24a7" width="400px">
</p>

**추가된 테스트케이스**
<p >
  <img src="https://github.com/user-attachments/assets/2a7af35f-b098-4e29-af79-5c58daf3df91" width="400px">
</p>

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 이미 사용 중인 이메일로 인증 요청 시, "이미 사용 중인 이메일" 오류가 반환됩니다.

- **문서화**
    - 이메일 인증 요청 시 발생할 수 있는 "이미 사용 중인 이메일" 오류가 API 문서에 추가되었습니다.
    - 이메일 인증 코드 검증 관련 일부 메서드가 API 문서에서 숨김 처리되었습니다.

- **테스트**
    - 이미 등록된 이메일로 인증 요청 시 오류 응답을 확인하는 테스트가 추가되었습니다.
    - 테스트 코드에 "given-when-then" 주석을 추가하여 가독성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->