### PR TITLE
[FEAT] 이벤트 publish 설정 API 구현

### DIFF
--- a/src/main/java/com/jnulocker/config/SecurityConfig.java
+++ b/src/main/java/com/jnulocker/config/SecurityConfig.java
@@ -77,6 +77,8 @@ public class SecurityConfig {
                                 .hasAuthority(Role.GUEST.getRole()) // TODO: 추후 manager로 변경
                                 .requestMatchers(HttpMethod.DELETE, "/v1/events/*")
                                 .hasAuthority(Role.GUEST.getRole()) // TODO: 추후 manager로 변경
+                                .requestMatchers(HttpMethod.PUT, "/v1/events/*/publish")
+                                .hasAuthority(Role.GUEST.getRole()) // TODO: 추후 manager로 변경
                                 // 토큰의 role과 db의 role과 다른 문제 고려
                                 .anyRequest()
                                 .authenticated());

--- a/src/main/java/com/jnulocker/events/adapter/in/EventController.java
+++ b/src/main/java/com/jnulocker/events/adapter/in/EventController.java
@@ -4,6 +4,7 @@ import com.jnulocker.events.adapter.in.docs.EventApi;
 import com.jnulocker.events.application.port.in.EventCommand;
 import com.jnulocker.events.application.port.in.EventQuery;
 import com.jnulocker.events.application.port.in.request.CreateEventRequest;
+import com.jnulocker.events.application.port.in.request.PublishEventRequest;
 import com.jnulocker.events.application.port.in.response.EventCustomPage;
 import com.jnulocker.events.application.port.in.response.EventPageable;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -56,6 +58,15 @@ public class EventController implements EventApi {
     @DeleteMapping("/{event-id}")
     public ResponseEntity<Void> deleteEvent(@PathVariable("event-id") Long eventId) {
         eventCommand.deleteEvent(eventId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @Override
+    @PutMapping("/{event-id}/publish")
+    public ResponseEntity<Void> publishEvent(
+            @PathVariable("event-id") Long eventId,
+            @RequestBody @Valid PublishEventRequest request) {
+        eventCommand.publishEvent(eventId, request);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/com/jnulocker/events/adapter/in/docs/EventApi.java
+++ b/src/main/java/com/jnulocker/events/adapter/in/docs/EventApi.java
@@ -2,6 +2,7 @@ package com.jnulocker.events.adapter.in.docs;
 
 import com.jnulocker.common.swagger.ApiExceptionExamples;
 import com.jnulocker.events.application.port.in.request.CreateEventRequest;
+import com.jnulocker.events.application.port.in.request.PublishEventRequest;
 import com.jnulocker.events.application.port.in.response.EventCustomPage;
 import com.jnulocker.events.application.port.in.response.EventPageable;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
@@ -61,4 +62,10 @@ public interface EventApi {
     @Operation(summary = "이벤트 삭제", description = "이벤트를 삭제합니다. 이벤트가 진행 중인 경우에는 삭제할 수 없습니다.")
     @ApiResponse(responseCode = "204", description = "이벤트 삭제 성공")
     ResponseEntity<Void> deleteEvent(@PathVariable("event-id") Long eventId);
+
+    @Operation(summary = "이벤트 publish", description = "이벤트를 publish 또는 unpublish합니다.")
+    @ApiExceptionExamples(PublishEventExceptionDocs.class)
+    ResponseEntity<Void> publishEvent(
+            @PathVariable("event-id") Long eventId,
+            @RequestBody @Valid PublishEventRequest request);
 }

--- a/src/main/java/com/jnulocker/events/adapter/in/docs/PublishEventExceptionDocs.java
+++ b/src/main/java/com/jnulocker/events/adapter/in/docs/PublishEventExceptionDocs.java
@@ -1,0 +1,17 @@
+package com.jnulocker.events.adapter.in.docs;
+
+import com.jnulocker.common.exception.BusinessException;
+import com.jnulocker.common.swagger.ExceptionDoc;
+import com.jnulocker.common.swagger.ExplainError;
+import com.jnulocker.common.swagger.SwaggerExceptionDoc;
+import com.jnulocker.events.exception.EventNotFoundException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@ExceptionDoc
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PublishEventExceptionDocs implements SwaggerExceptionDoc {
+
+    @ExplainError("이벤트가 존재하지 않을 때 발생하는 예외입니다")
+    public static final BusinessException 이벤트가_존재하지_않을_때 = EventNotFoundException.EXCEPTION;
+}

--- a/src/main/java/com/jnulocker/events/application/port/in/EventCommand.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/EventCommand.java
@@ -1,6 +1,7 @@
 package com.jnulocker.events.application.port.in;
 
 import com.jnulocker.events.application.port.in.request.CreateEventRequest;
+import com.jnulocker.events.application.port.in.request.PublishEventRequest;
 import com.jnulocker.events.domain.Event;
 
 public interface EventCommand {
@@ -9,4 +10,6 @@ public interface EventCommand {
     void deleteEvent(Long eventId);
 
     void save(Event event);
+
+    void publishEvent(Long eventId, PublishEventRequest request);
 }

--- a/src/main/java/com/jnulocker/events/application/port/in/request/PublishEventRequest.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/request/PublishEventRequest.java
@@ -1,0 +1,9 @@
+package com.jnulocker.events.application.port.in.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record PublishEventRequest(
+        @Schema(description = "이벤트 publish 여부", example = "true")
+                @NotNull(message = "이벤트 publish 여부는 필수입니다.")
+                Boolean isPublish) {}

--- a/src/main/java/com/jnulocker/events/application/port/in/response/EventListItem.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/response/EventListItem.java
@@ -1,6 +1,7 @@
 package com.jnulocker.events.application.port.in.response;
 
 import com.jnulocker.events.domain.Event;
+import com.jnulocker.events.domain.EventStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
@@ -9,6 +10,7 @@ public record EventListItem(
         @Schema(description = "이벤트 제목", example = "전자컴퓨터공학부 2025-2 사물함 신청") String title,
         @Schema(description = "이벤트 시작 시간", example = "2025-08-01T15:00:00") LocalDateTime startAt,
         @Schema(description = "이벤트 종료 시간", example = "2025-08-01T16:00:00") LocalDateTime endAt,
+        @Schema(description = "이벤트 상태", example = "OPEN") EventStatus status,
         @Schema(description = "이벤트 게시 여부", example = "true") Boolean publish) {
 
     public static EventListItem from(Event event) {
@@ -17,6 +19,7 @@ public record EventListItem(
                 event.getTitle(),
                 event.getEventSchedule().getStartAt(),
                 event.getEventSchedule().getEndAt(),
+                event.getEventStatus(),
                 event.getPublish());
     }
 }

--- a/src/main/java/com/jnulocker/events/application/service/EventCommandService.java
+++ b/src/main/java/com/jnulocker/events/application/service/EventCommandService.java
@@ -7,6 +7,7 @@ import com.jnulocker.events.application.port.in.request.CreateEventRequest;
 import com.jnulocker.events.application.port.in.request.FloorInfo;
 import com.jnulocker.events.application.port.in.request.LockerRange;
 import com.jnulocker.events.application.port.in.request.PrefixInfo;
+import com.jnulocker.events.application.port.in.request.PublishEventRequest;
 import com.jnulocker.events.application.port.out.EventRecordPort;
 import com.jnulocker.events.domain.Event;
 import com.jnulocker.events.domain.EventParticipation;
@@ -71,6 +72,13 @@ public class EventCommandService implements EventCommand {
 
         // 사물함 이벤트 생성 이벤트 발행
         publishEventCreatedEvent(savedEvent);
+    }
+
+    @Override
+    @Transactional
+    public void publishEvent(Long eventId, PublishEventRequest request) {
+        Event event = eventQuery.getByIdOrThrow(eventId);
+        event.updatePublishStatus(request.isPublish());
     }
 
     private Event createAndSaveEvent(CreateEventRequest request) {

--- a/src/main/java/com/jnulocker/events/domain/Event.java
+++ b/src/main/java/com/jnulocker/events/domain/Event.java
@@ -110,4 +110,8 @@ public class Event extends BaseEntity {
     public void closeEvent() {
         eventStatus = EventStatus.CLOSED;
     }
+
+    public void updatePublishStatus(Boolean publish) {
+        this.publish = publish;
+    }
 }

--- a/src/main/java/com/jnulocker/events/event/LockerEventCreatedEventHandler.java
+++ b/src/main/java/com/jnulocker/events/event/LockerEventCreatedEventHandler.java
@@ -5,6 +5,8 @@ import static org.quartz.TriggerBuilder.newTrigger;
 
 import com.jnulocker.events.quartz.job.EventCloseJob;
 import com.jnulocker.events.quartz.job.EventOpenJob;
+import com.jnulocker.events.quartz.job.EventPublishJob;
+import com.jnulocker.events.quartz.job.EventUnpublishJob;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
@@ -22,6 +24,12 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class LockerEventCreatedEventHandler {
 
+    private static final String PUBLISH_JOB_NAME = "EVENT_PUBLISH_JOB-";
+    private static final String PUBLISH_TRIGGER_NAME = "EVENT_PUBLISH_TRIGGER-";
+
+    private static final String UNPUBLISH_JOB_NAME = "EVENT_UNPUBLISH_JOB-";
+    private static final String UNPUBLISH_TRIGGER_NAME = "EVENT_UNPUBLISH_TRIGGER-";
+
     private static final String OPEN_JOB_NAME = "EVENT_OPEN_JOB-";
     private static final String OPEN_TRIGGER_NAME = "EVENT_OPEN_TRIGGER-";
 
@@ -34,6 +42,9 @@ public class LockerEventCreatedEventHandler {
     private static final String EVENT_ID = "eventId";
     private static final String ASIA_SEOUL = "Asia/Seoul";
 
+    private static final Long TWO_HOURS = 2L;
+    private static final Long ONE_DAY = 1L;
+
     private final Scheduler scheduler;
 
     @TransactionalEventListener(
@@ -42,6 +53,14 @@ public class LockerEventCreatedEventHandler {
     public void handle(LockerEventCreatedEvent lockerEventCreatedEvent) throws SchedulerException {
 
         Long eventId = lockerEventCreatedEvent.getEventId();
+
+        scheduleEventJob( // Event Publish Job 등록: OPEN 2시간 전에 publish를 true로 변경
+                lockerEventCreatedEvent.getStartAt().minusHours(TWO_HOURS),
+                newJob(EventPublishJob.class),
+                PUBLISH_JOB_NAME,
+                eventId,
+                PUBLISH_TRIGGER_NAME
+        );
 
         scheduleEventJob( // Event Open Job 등록
                 lockerEventCreatedEvent.getStartAt(),
@@ -56,6 +75,14 @@ public class LockerEventCreatedEventHandler {
                 CLOSE_JOB_NAME,
                 eventId,
                 CLOSE_TRIGGER_NAME);
+
+        scheduleEventJob( // Event Unpublish Job 등록: CLOSE 1일 후에 publish를 false로 변경
+                lockerEventCreatedEvent.getStartAt().plusDays(ONE_DAY),
+                newJob(EventUnpublishJob.class),
+                UNPUBLISH_JOB_NAME,
+                eventId,
+                UNPUBLISH_TRIGGER_NAME
+        );
     }
 
     private void scheduleEventJob(

--- a/src/main/java/com/jnulocker/events/event/LockerEventCreatedEventHandler.java
+++ b/src/main/java/com/jnulocker/events/event/LockerEventCreatedEventHandler.java
@@ -77,7 +77,7 @@ public class LockerEventCreatedEventHandler {
                 CLOSE_TRIGGER_NAME);
 
         scheduleEventJob( // Event Unpublish Job 등록: CLOSE 1일 후에 publish를 false로 변경
-                lockerEventCreatedEvent.getStartAt().plusDays(ONE_DAY),
+                lockerEventCreatedEvent.getEndAt().plusDays(ONE_DAY),
                 newJob(EventUnpublishJob.class),
                 UNPUBLISH_JOB_NAME,
                 eventId,

--- a/src/main/java/com/jnulocker/events/event/LockerEventDeletedEventHandler.java
+++ b/src/main/java/com/jnulocker/events/event/LockerEventDeletedEventHandler.java
@@ -12,8 +12,10 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class LockerEventDeletedEventHandler {
 
+    private static final String PUBLISH_JOB_NAME = "EVENT_PUBLISH_JOB-";
     private static final String OPEN_JOB_NAME = "EVENT_OPEN_JOB-";
     private static final String CLOSE_JOB_NAME = "EVENT_CLOSE_JOB-";
+    private static final String UNPUBLISH_JOB_NAME = "EVENT_UNPUBLISH_JOB-";
     private static final String EVENT_JOB_GROUP = "EVENT_JOB_GROUP";
 
     private final Scheduler scheduler;
@@ -24,16 +26,23 @@ public class LockerEventDeletedEventHandler {
     public void handle(LockerEventDeletedEvent lockerEventDeletedEvent) throws SchedulerException {
         Long eventId = lockerEventDeletedEvent.getEventId();
 
+        // Event Publish Job 삭제
+        deleteJob(PUBLISH_JOB_NAME, eventId);
+
         // Event Open Job 삭제
-        JobKey openJobKey = new JobKey(OPEN_JOB_NAME + eventId, EVENT_JOB_GROUP);
-        if (scheduler.checkExists(openJobKey)) {
-            scheduler.deleteJob(openJobKey);
-        }
+        deleteJob(OPEN_JOB_NAME, eventId);
 
         // Event Close Job 삭제
-        JobKey closeJobKey = new JobKey(CLOSE_JOB_NAME + eventId, EVENT_JOB_GROUP);
-        if (scheduler.checkExists(closeJobKey)) {
-            scheduler.deleteJob(closeJobKey);
+        deleteJob(CLOSE_JOB_NAME, eventId);
+
+        // Event Unpublish Job 삭제
+        deleteJob(UNPUBLISH_JOB_NAME, eventId);
+    }
+
+    private void deleteJob(String jobName, Long eventId) throws SchedulerException {
+        JobKey publishJobKey = new JobKey(jobName + eventId, EVENT_JOB_GROUP);
+        if (scheduler.checkExists(publishJobKey)) {
+            scheduler.deleteJob(publishJobKey);
         }
     }
 }

--- a/src/main/java/com/jnulocker/events/event/LockerEventDeletedEventHandler.java
+++ b/src/main/java/com/jnulocker/events/event/LockerEventDeletedEventHandler.java
@@ -40,9 +40,9 @@ public class LockerEventDeletedEventHandler {
     }
 
     private void deleteJob(String jobName, Long eventId) throws SchedulerException {
-        JobKey publishJobKey = new JobKey(jobName + eventId, EVENT_JOB_GROUP);
-        if (scheduler.checkExists(publishJobKey)) {
-            scheduler.deleteJob(publishJobKey);
+        JobKey jobKey = new JobKey(jobName + eventId, EVENT_JOB_GROUP);
+        if (scheduler.checkExists(jobKey)) {
+            scheduler.deleteJob(jobKey);
         }
     }
 }

--- a/src/main/java/com/jnulocker/events/quartz/job/EventPublishJob.java
+++ b/src/main/java/com/jnulocker/events/quartz/job/EventPublishJob.java
@@ -1,0 +1,25 @@
+package com.jnulocker.events.quartz.job;
+
+import com.jnulocker.events.application.port.in.EventCommand;
+import com.jnulocker.events.application.port.in.EventQuery;
+import com.jnulocker.events.domain.Event;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+
+@RequiredArgsConstructor
+public class EventPublishJob implements Job {
+
+    private final EventQuery eventQuery;
+    private final EventCommand eventCommand;
+
+    @Setter private Long eventId;
+
+    @Override
+    public void execute(JobExecutionContext jobExecutionContext) {
+        Event event = eventQuery.getByIdOrThrow(eventId);
+        event.updatePublishStatus(Boolean.TRUE);
+        eventCommand.save(event);
+    }
+}

--- a/src/main/java/com/jnulocker/events/quartz/job/EventUnpublishJob.java
+++ b/src/main/java/com/jnulocker/events/quartz/job/EventUnpublishJob.java
@@ -1,0 +1,25 @@
+package com.jnulocker.events.quartz.job;
+
+import com.jnulocker.events.application.port.in.EventCommand;
+import com.jnulocker.events.application.port.in.EventQuery;
+import com.jnulocker.events.domain.Event;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+
+@RequiredArgsConstructor
+public class EventUnpublishJob implements Job {
+
+    private final EventQuery eventQuery;
+    private final EventCommand eventCommand;
+
+    @Setter private Long eventId;
+
+    @Override
+    public void execute(JobExecutionContext jobExecutionContext) {
+        Event event = eventQuery.getByIdOrThrow(eventId);
+        event.updatePublishStatus(Boolean.FALSE);
+        eventCommand.save(event);
+    }
+}

--- a/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.jnulocker.auth.utils.AuthTestUtil;
 import com.jnulocker.common.exception.ErrorResponse;
 import com.jnulocker.events.application.port.in.request.CreateEventRequest;
+import com.jnulocker.events.application.port.in.request.PublishEventRequest;
 import com.jnulocker.events.application.port.in.response.EventCustomPage;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
 import com.jnulocker.events.domain.Event;
@@ -301,5 +302,70 @@ public class EventControllerIntegrationTest {
         // then
         assertThat(errorResponse.message())
                 .isEqualTo(EventErrorCode.ONLY_MANAGER_CAN_DELETE.getMessage());
+    }
+
+    @Test
+    void 생성된_이벤트는_publish_상태로_변경할_수_있다() {
+        // given
+        createEvent();
+
+        // 생성된 이벤트 조회
+        Long eventId = getLastEventId();
+
+        PublishEventRequest request = new PublishEventRequest(true);
+
+        // when
+        publishEvent(eventId, request).statusCode(HttpStatus.NO_CONTENT.value());
+
+        // then
+        Event event = eventTestUtil.getEventById(eventId);
+        assertThat(event.getPublish()).isTrue();
+    }
+
+    @Test
+    void 생성된_이벤트는_unpublish_상태로_변경할_수_있다() {
+        // given
+        createEvent();
+
+        // 생성된 이벤트 조회
+        Long eventId = getLastEventId();
+
+        PublishEventRequest request = new PublishEventRequest(false);
+
+        // when
+        publishEvent(eventId, request).statusCode(HttpStatus.NO_CONTENT.value());
+
+        // then
+        Event event = eventTestUtil.getEventById(eventId);
+        assertThat(event.getPublish()).isFalse();
+    }
+
+    @Test
+    void 존재하지_않는_이벤트는_publish_상태로_변경할_수_없다() {
+        // given
+        Long nonExistentEventId = Long.MAX_VALUE;
+
+        PublishEventRequest request = new PublishEventRequest(true);
+
+        // when
+        ErrorResponse errorResponse =
+                publishEvent(nonExistentEventId, request)
+                        .statusCode(EventErrorCode.EVENT_NOT_FOUND.getHttpStatus().value())
+                        .extract()
+                        .as(ErrorResponse.class);
+
+        // then
+        assertThat(errorResponse.message()).isEqualTo(EventErrorCode.EVENT_NOT_FOUND.getMessage());
+    }
+
+    private ValidatableResponse publishEvent(Long eventId, PublishEventRequest request) {
+        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
+                .body(request)
+                .when()
+                .put(EVENT_URL + "/{event-id}/publish", eventId)
+                .then()
+                .log()
+                .all();
     }
 }

--- a/src/test/java/com/jnulocker/events/utils/EventTestUtil.java
+++ b/src/test/java/com/jnulocker/events/utils/EventTestUtil.java
@@ -90,4 +90,8 @@ public class EventTestUtil {
         departmentRepository.deleteAll();
         organizationRepository.deleteAll();
     }
+
+    public Event getEventById(Long eventId) {
+        return eventRepository.findById(eventId).orElseThrow();
+    }
 }


### PR DESCRIPTION
### 개요
close #66 

### 작업사항
- 이벤트 publish 설정 API 구현

### 변경로직
- 이벤트 publish 설정 API 구현 및 테스트 작성, 문서화
- 이벤트 목록 조회 시 이벤트의 상태 반환 필드 추가

### 테스트 결과
  <img width="366" alt="image" src="https://github.com/user-attachments/assets/346894aa-8e42-469a-bf42-e75010c86948" />

#### 추가된 테스트케이스
  <img width="301" alt="image" src="https://github.com/user-attachments/assets/a1f5acde-e0db-4503-b9c9-1a0bf1b532b7" />
  <img width="302" alt="image" src="https://github.com/user-attachments/assets/44466001-75e3-4de3-888a-437c13f364b6" />


### reference

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 이벤트를 공개(publish) 또는 비공개(unpublish) 상태로 변경할 수 있는 API 엔드포인트가 추가되었습니다.
  - 이벤트 목록에 각 이벤트의 상태 정보가 표시됩니다.
  - 이벤트 공개 및 비공개 상태 변경을 자동으로 처리하는 예약 작업이 추가되어, 이벤트 시작 전후에 자동으로 상태가 변경됩니다.

- **문서화**
  - 이벤트 공개/비공개 관련 API 및 예외 상황에 대한 Swagger 문서가 추가되었습니다.

- **버그 수정 및 테스트**
  - 이벤트 공개/비공개 상태 변경에 대한 통합 테스트가 추가되었습니다.
  - 존재하지 않는 이벤트에 대한 예외 처리 테스트가 포함되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->