### PR TITLE
[FEAT] 사물함 관리자 가입 승인 API 구현

### DIFF
--- a/src/main/java/com/jnulocker/auth/adapter/in/AuthController.java
+++ b/src/main/java/com/jnulocker/auth/adapter/in/AuthController.java
@@ -11,6 +11,7 @@ import com.jnulocker.auth.application.port.in.SendEmailCommand;
 import com.jnulocker.auth.application.port.in.UserSignupCommand;
 import com.jnulocker.auth.application.port.in.VerifyCodeCommand;
 import com.jnulocker.auth.application.port.in.request.LoginRequest;
+import com.jnulocker.auth.application.port.in.request.ManagerApproveRequest;
 import com.jnulocker.auth.application.port.in.request.ManagerSignupRequest;
 import com.jnulocker.auth.application.port.in.request.SendEmailRequest;
 import com.jnulocker.auth.application.port.in.request.UserSignupRequest;
@@ -50,6 +51,12 @@ public class AuthController implements AuthApi {
     public ResponseEntity<Void> signupManager(@Valid @RequestBody ManagerSignupRequest request) {
         managerSignupCommand.signupManager(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping("/managers/approve")
+    public ResponseEntity<Void> approveManager(@Valid @RequestBody ManagerApproveRequest request) {
+        managerSignupCommand.approveManager(request);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     @Override

--- a/src/main/java/com/jnulocker/auth/adapter/in/AuthController.java
+++ b/src/main/java/com/jnulocker/auth/adapter/in/AuthController.java
@@ -53,6 +53,7 @@ public class AuthController implements AuthApi {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
+    @Override
     @PostMapping("/managers/approve")
     public ResponseEntity<Void> approveManager(@Valid @RequestBody ManagerApproveRequest request) {
         managerSignupCommand.approveManager(request);

--- a/src/main/java/com/jnulocker/auth/adapter/in/docs/ApproveManagerExceptionDocs.java
+++ b/src/main/java/com/jnulocker/auth/adapter/in/docs/ApproveManagerExceptionDocs.java
@@ -1,0 +1,35 @@
+package com.jnulocker.auth.adapter.in.docs;
+
+import com.jnulocker.auth.exception.OnlyManagerCanApproveException;
+import com.jnulocker.auth.exception.OnlySameDepartmentCanApproveException;
+import com.jnulocker.common.exception.BusinessException;
+import com.jnulocker.common.swagger.ExceptionDoc;
+import com.jnulocker.common.swagger.ExplainError;
+import com.jnulocker.common.swagger.SwaggerExceptionDoc;
+import com.jnulocker.events.exception.EventNotFoundException;
+import com.jnulocker.member.exception.MemberNotFoundException;
+import com.jnulocker.member.exception.OnlyGuestCanBeManagerException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@ExceptionDoc
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApproveManagerExceptionDocs implements SwaggerExceptionDoc {
+
+    @ExplainError("회원 정보를 조회할 수 없을 때 발생하는 예외입니다.")
+    public static final BusinessException 회원_정보를_조회할_수_없을_때 = MemberNotFoundException.EXCEPTION;
+
+    @ExplainError("이벤트가 존재하지 않을 때 발생하는 예외입니다.")
+    public static final BusinessException 이벤트가_존재하지_않을_때 = EventNotFoundException.EXCEPTION;
+
+    @ExplainError("이벤트 관리자(MANAGER)가 아닐 때 발생하는 예외입니다.")
+    public static final BusinessException 이벤트_관리자가_아닐_때 = OnlyManagerCanApproveException.EXCEPTION;
+
+    @ExplainError("같은 학과 소속이 아닐 때 발생하는 예외입니다.")
+    public static final BusinessException 같은_학과_소속이_아닐_때 =
+            OnlySameDepartmentCanApproveException.EXCEPTION;
+
+    @ExplainError("승인 받는 사람이 GUEST가 아닐 때 발생하는 예외입니다.")
+    public static final BusinessException 승인_받는_사람이_GUEST가_아닐_때 =
+            OnlyGuestCanBeManagerException.EXCEPTION;
+}

--- a/src/main/java/com/jnulocker/auth/adapter/in/docs/ApproveManagerExceptionDocs.java
+++ b/src/main/java/com/jnulocker/auth/adapter/in/docs/ApproveManagerExceptionDocs.java
@@ -8,7 +8,7 @@ import com.jnulocker.common.swagger.ExplainError;
 import com.jnulocker.common.swagger.SwaggerExceptionDoc;
 import com.jnulocker.events.exception.EventNotFoundException;
 import com.jnulocker.member.exception.MemberNotFoundException;
-import com.jnulocker.member.exception.OnlyGuestCanBeManagerException;
+import com.jnulocker.auth.exception.OnlyGuestCanBeManagerException;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/jnulocker/auth/adapter/in/docs/ApproveManagerExceptionDocs.java
+++ b/src/main/java/com/jnulocker/auth/adapter/in/docs/ApproveManagerExceptionDocs.java
@@ -1,5 +1,6 @@
 package com.jnulocker.auth.adapter.in.docs;
 
+import com.jnulocker.auth.exception.OnlyGuestCanBeManagerException;
 import com.jnulocker.auth.exception.OnlyManagerCanApproveException;
 import com.jnulocker.auth.exception.OnlySameDepartmentCanApproveException;
 import com.jnulocker.common.exception.BusinessException;
@@ -8,7 +9,6 @@ import com.jnulocker.common.swagger.ExplainError;
 import com.jnulocker.common.swagger.SwaggerExceptionDoc;
 import com.jnulocker.events.exception.EventNotFoundException;
 import com.jnulocker.member.exception.MemberNotFoundException;
-import com.jnulocker.auth.exception.OnlyGuestCanBeManagerException;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/jnulocker/auth/adapter/in/docs/AuthApi.java
+++ b/src/main/java/com/jnulocker/auth/adapter/in/docs/AuthApi.java
@@ -1,6 +1,7 @@
 package com.jnulocker.auth.adapter.in.docs;
 
 import com.jnulocker.auth.application.port.in.request.LoginRequest;
+import com.jnulocker.auth.application.port.in.request.ManagerApproveRequest;
 import com.jnulocker.auth.application.port.in.request.ManagerSignupRequest;
 import com.jnulocker.auth.application.port.in.request.SendEmailRequest;
 import com.jnulocker.auth.application.port.in.request.UserSignupRequest;
@@ -27,6 +28,11 @@ public interface AuthApi {
     @Operation(summary = "MANAGER 회원가입", description = "사물함 신청 이벤트 관리자인 MANAGER에 대한 회원가입입니다.")
     @ApiResponse(responseCode = "201", description = "MANAGER 회원가입 성공")
     ResponseEntity<Void> signupManager(@Valid @RequestBody ManagerSignupRequest request);
+
+    @ApiExceptionExamples(ApproveManagerExceptionDocs.class)
+    @Operation(summary = "MANAGER 가입 승인", description = "MANAGER 가입을 승인합니다.")
+    @ApiResponse(responseCode = "200", description = "MANAGER 가입 승인 성공")
+    ResponseEntity<Void> approveManager(@Valid @RequestBody ManagerApproveRequest request);
 
     @ApiExceptionExamples(LoginExcepitonDocs.class)
     @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다.")

--- a/src/main/java/com/jnulocker/auth/application/port/in/ManagerSignupCommand.java
+++ b/src/main/java/com/jnulocker/auth/application/port/in/ManagerSignupCommand.java
@@ -1,7 +1,10 @@
 package com.jnulocker.auth.application.port.in;
 
+import com.jnulocker.auth.application.port.in.request.ManagerApproveRequest;
 import com.jnulocker.auth.application.port.in.request.ManagerSignupRequest;
 
 public interface ManagerSignupCommand {
     void signupManager(ManagerSignupRequest request);
+
+    void approveManager(ManagerApproveRequest request);
 }

--- a/src/main/java/com/jnulocker/auth/application/port/in/request/ManagerApproveRequest.java
+++ b/src/main/java/com/jnulocker/auth/application/port/in/request/ManagerApproveRequest.java
@@ -1,3 +1,9 @@
 package com.jnulocker.auth.application.port.in.request;
 
-public record ManagerApproveRequest(Long memberId) {}
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record ManagerApproveRequest(
+        @Schema(description = "승인할 MANAGER ID", example = "1")
+                @NotNull(message = "MANAGER ID는 필수입니다.")
+                Long memberId) {}

--- a/src/main/java/com/jnulocker/auth/application/port/in/request/ManagerApproveRequest.java
+++ b/src/main/java/com/jnulocker/auth/application/port/in/request/ManagerApproveRequest.java
@@ -1,0 +1,3 @@
+package com.jnulocker.auth.application.port.in.request;
+
+public record ManagerApproveRequest(Long memberId) {}

--- a/src/main/java/com/jnulocker/auth/application/service/AuthService.java
+++ b/src/main/java/com/jnulocker/auth/application/service/AuthService.java
@@ -5,12 +5,14 @@ import com.jnulocker.auth.application.port.in.ManagerSignupCommand;
 import com.jnulocker.auth.application.port.in.ReissueCommand;
 import com.jnulocker.auth.application.port.in.UserSignupCommand;
 import com.jnulocker.auth.application.port.in.request.LoginRequest;
+import com.jnulocker.auth.application.port.in.request.ManagerApproveRequest;
 import com.jnulocker.auth.application.port.in.request.ManagerSignupRequest;
 import com.jnulocker.auth.application.port.in.request.UserSignupRequest;
 import com.jnulocker.auth.application.port.in.response.AuthToken;
 import com.jnulocker.auth.exception.UserAlreadyExistException;
 import com.jnulocker.auth.jwt.TokenProvider;
 import com.jnulocker.auth.jwt.exception.InvalidRefreshTokenException;
+import com.jnulocker.auth.security.SecurityUtils;
 import com.jnulocker.common.util.RedisUtil;
 import com.jnulocker.member.application.port.in.MemberCommand;
 import com.jnulocker.member.application.port.in.MemberQuery;
@@ -81,6 +83,19 @@ public class AuthService
                         department);
 
         memberCommand.save(member);
+    }
+
+    @Override
+    @Transactional
+    public void approveManager(ManagerApproveRequest request) {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        Member approver = memberQuery.findByIdOrThrow(memberId); // 승인자
+        Member approvee = memberQuery.findByIdOrThrow(request.memberId()); // 승인받는 사람
+
+        approver.validateManagerApproval(approvee.getDepartment());
+
+        approvee.approveManager();
+        memberCommand.save(approvee);
     }
 
     @Override

--- a/src/main/java/com/jnulocker/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/jnulocker/auth/exception/AuthErrorCode.java
@@ -15,7 +15,10 @@ public enum AuthErrorCode implements ErrorCode {
     SEND_EMAIL_ERROR("A005", HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송 중 오류가 발생했습니다."),
     CODE_NOT_CORRECT("A006", HttpStatus.BAD_REQUEST, "인증 코드가 일치하지 않습니다."),
     CODE_NOT_FOUND("A007", HttpStatus.BAD_REQUEST, "인증 요청 정보가 존재하지 않습니다. 재요청 후 5분 이내로 인증해주세요"),
-    EMAIL_NOT_VERIFIED("A008", HttpStatus.BAD_REQUEST, "이메일 인증이 완료되지 않았습니다.");
+    EMAIL_NOT_VERIFIED("A008", HttpStatus.BAD_REQUEST, "이메일 인증이 완료되지 않았습니다."),
+    ONLY_MANAGER_CAN_APPROVE("A009", HttpStatus.FORBIDDEN, "관리자만 승인할 수 있습니다."),
+    ONLY_SAME_DEPARTMENT_CAN_APPROVE("A010", HttpStatus.FORBIDDEN, "같은 학과의 관리자만 승인할 수 있습니다."),
+    ;
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/jnulocker/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/jnulocker/auth/exception/AuthErrorCode.java
@@ -18,6 +18,7 @@ public enum AuthErrorCode implements ErrorCode {
     EMAIL_NOT_VERIFIED("A008", HttpStatus.BAD_REQUEST, "이메일 인증이 완료되지 않았습니다."),
     ONLY_MANAGER_CAN_APPROVE("A009", HttpStatus.FORBIDDEN, "관리자만 승인할 수 있습니다."),
     ONLY_SAME_DEPARTMENT_CAN_APPROVE("A010", HttpStatus.FORBIDDEN, "같은 학과의 관리자만 승인할 수 있습니다."),
+    ONLY_GUEST_CAN_BE_MANAGER("A011", HttpStatus.FORBIDDEN, "게스트만 매니저로 승인될 수 있습니다"),
     ;
 
     private final String code;

--- a/src/main/java/com/jnulocker/auth/exception/OnlyGuestCanBeManagerException.java
+++ b/src/main/java/com/jnulocker/auth/exception/OnlyGuestCanBeManagerException.java
@@ -1,4 +1,4 @@
-package com.jnulocker.member.exception;
+package com.jnulocker.auth.exception;
 
 import com.jnulocker.common.exception.BusinessException;
 
@@ -7,6 +7,6 @@ public class OnlyGuestCanBeManagerException extends BusinessException {
     public static final BusinessException EXCEPTION = new OnlyGuestCanBeManagerException();
 
     private OnlyGuestCanBeManagerException() {
-        super(MemberErrorCode.ONLY_GUEST_CAN_BE_MANAGER);
+        super(AuthErrorCode.ONLY_GUEST_CAN_BE_MANAGER);
     }
 }

--- a/src/main/java/com/jnulocker/auth/exception/OnlyManagerCanApproveException.java
+++ b/src/main/java/com/jnulocker/auth/exception/OnlyManagerCanApproveException.java
@@ -1,0 +1,12 @@
+package com.jnulocker.auth.exception;
+
+import com.jnulocker.common.exception.BusinessException;
+
+public class OnlyManagerCanApproveException extends BusinessException {
+
+    public static final BusinessException EXCEPTION = new OnlyManagerCanApproveException();
+
+    private OnlyManagerCanApproveException() {
+        super(AuthErrorCode.ONLY_MANAGER_CAN_APPROVE);
+    }
+}

--- a/src/main/java/com/jnulocker/auth/exception/OnlySameDepartmentCanApproveException.java
+++ b/src/main/java/com/jnulocker/auth/exception/OnlySameDepartmentCanApproveException.java
@@ -1,0 +1,12 @@
+package com.jnulocker.auth.exception;
+
+import com.jnulocker.common.exception.BusinessException;
+
+public class OnlySameDepartmentCanApproveException extends BusinessException {
+
+    public static final BusinessException EXCEPTION = new OnlySameDepartmentCanApproveException();
+
+    private OnlySameDepartmentCanApproveException() {
+        super(AuthErrorCode.ONLY_SAME_DEPARTMENT_CAN_APPROVE);
+    }
+}

--- a/src/main/java/com/jnulocker/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/jnulocker/auth/jwt/JwtFilter.java
@@ -36,13 +36,18 @@ public class JwtFilter extends OncePerRequestFilter {
 
     private final TokenProvider tokenProvider;
 
-    private static List<String> EXCLUDE_URLS = new ArrayList<>();
+    private List<String> EXCLUDE_URLS = new ArrayList<>();
 
     @PostConstruct
     public void init() {
         EXCLUDE_URLS =
                 Arrays.asList(
-                        "/v1/auth/**",
+                        "/v1/auth/*/signup",
+                        "/v1/auth/login",
+                        "/v1/auth/reissue",
+                        "/v1/auth/logout",
+                        "/v1/auth/send-email",
+                        "/v1/auth/verify",
                         "/swagger-ui/**",
                         "/swagger-resources/**",
                         "/v3/api-docs/**",

--- a/src/main/java/com/jnulocker/auth/security/SecurityUtils.java
+++ b/src/main/java/com/jnulocker/auth/security/SecurityUtils.java
@@ -1,9 +1,11 @@
 package com.jnulocker.auth.security;
 
 import com.jnulocker.auth.jwt.exception.AuthenticationFailedException;
+import lombok.experimental.UtilityClass;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+@UtilityClass
 public class SecurityUtils {
     public static Long getCurrentMemberId() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();

--- a/src/main/java/com/jnulocker/config/SecurityConfig.java
+++ b/src/main/java/com/jnulocker/config/SecurityConfig.java
@@ -64,19 +64,26 @@ public class SecurityConfig {
                                         "/v1/organizations",
                                         "/v1/organizations/*/departments")
                                 .permitAll() // 소속대학/학과 조회 API 모든 접근 허용
-                                .requestMatchers("/v1/auth/**")
-                                .permitAll() // 인증 API 모든 접근 허용
+                                .requestMatchers(
+                                        "/v1/auth/*/signup",
+                                        "/v1/auth/login",
+                                        "/v1/auth/reissue",
+                                        "/v1/auth/logout",
+                                        "/v1/auth/send-email",
+                                        "/v1/auth/verify")
+                                .permitAll()
                                 .requestMatchers(
                                         HttpMethod.GET, "/v1/events", "/v1/events/*/lockers")
                                 .authenticated()
                                 .requestMatchers(HttpMethod.GET, "/v1/events/*/registrations/me")
                                 .hasAuthority(Role.USER.getRole())
                                 .requestMatchers(HttpMethod.GET, "/v1/events/*/registrations")
-                                .hasAuthority(Role.GUEST.getRole()) // TODO: 추후 manager로 변경
-                                .requestMatchers(HttpMethod.POST, "/v1/events")
-                                .hasAuthority(Role.GUEST.getRole()) // TODO: 추후 manager로 변경
+                                .hasAuthority(Role.MANAGER.getRole())
+                                .requestMatchers(
+                                        HttpMethod.POST, "/v1/events", "/v1/auth/managers/approve")
+                                .hasAuthority(Role.MANAGER.getRole())
                                 .requestMatchers(HttpMethod.DELETE, "/v1/events/*")
-                                .hasAuthority(Role.GUEST.getRole()) // TODO: 추후 manager로 변경
+                                .hasAuthority(Role.MANAGER.getRole())
                                 // 토큰의 role과 db의 role과 다른 문제 고려
                                 .anyRequest()
                                 .authenticated());

--- a/src/main/java/com/jnulocker/member/domain/Member.java
+++ b/src/main/java/com/jnulocker/member/domain/Member.java
@@ -1,5 +1,7 @@
 package com.jnulocker.member.domain;
 
+import com.jnulocker.auth.exception.OnlyManagerCanApproveException;
+import com.jnulocker.auth.exception.OnlySameDepartmentCanApproveException;
 import com.jnulocker.auth.exception.StudentNumberRequiredException;
 import com.jnulocker.common.persistence.BaseEntity;
 import com.jnulocker.member.exception.OnlyGuestCanBeManagerException;
@@ -101,5 +103,15 @@ public class Member extends BaseEntity {
             throw OnlyGuestCanBeManagerException.EXCEPTION;
         }
         role = Role.MANAGER;
+    }
+
+    public void validateManagerApproval(Department approveeDepartment) {
+        if (role != Role.MANAGER) {
+            throw OnlyManagerCanApproveException.EXCEPTION;
+        }
+
+        if (!department.equals(approveeDepartment)) {
+            throw OnlySameDepartmentCanApproveException.EXCEPTION;
+        }
     }
 }

--- a/src/main/java/com/jnulocker/member/domain/Member.java
+++ b/src/main/java/com/jnulocker/member/domain/Member.java
@@ -4,7 +4,7 @@ import com.jnulocker.auth.exception.OnlyManagerCanApproveException;
 import com.jnulocker.auth.exception.OnlySameDepartmentCanApproveException;
 import com.jnulocker.auth.exception.StudentNumberRequiredException;
 import com.jnulocker.common.persistence.BaseEntity;
-import com.jnulocker.member.exception.OnlyGuestCanBeManagerException;
+import com.jnulocker.auth.exception.OnlyGuestCanBeManagerException;
 import com.jnulocker.organization.domain.Department;
 import com.jnulocker.organization.domain.OrganizationType;
 import jakarta.persistence.Column;

--- a/src/main/java/com/jnulocker/member/domain/Member.java
+++ b/src/main/java/com/jnulocker/member/domain/Member.java
@@ -1,10 +1,10 @@
 package com.jnulocker.member.domain;
 
+import com.jnulocker.auth.exception.OnlyGuestCanBeManagerException;
 import com.jnulocker.auth.exception.OnlyManagerCanApproveException;
 import com.jnulocker.auth.exception.OnlySameDepartmentCanApproveException;
 import com.jnulocker.auth.exception.StudentNumberRequiredException;
 import com.jnulocker.common.persistence.BaseEntity;
-import com.jnulocker.auth.exception.OnlyGuestCanBeManagerException;
 import com.jnulocker.organization.domain.Department;
 import com.jnulocker.organization.domain.OrganizationType;
 import jakarta.persistence.Column;

--- a/src/main/java/com/jnulocker/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/jnulocker/member/exception/MemberErrorCode.java
@@ -8,8 +8,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum MemberErrorCode implements ErrorCode {
-    ONLY_GUEST_CAN_BE_MANAGER("M001", HttpStatus.BAD_REQUEST, "게스트만 매니저로 승인될 수 있습니다"),
-    MEMBER_NOT_FOUND("M002", HttpStatus.NOT_FOUND, "회원 정보를 조회할 수 없습니다."),
+    MEMBER_NOT_FOUND("M001", HttpStatus.NOT_FOUND, "회원 정보를 조회할 수 없습니다."),
     ;
 
     private final String code;

--- a/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import com.jnulocker.auth.adapter.out.TokenRepository;
 import com.jnulocker.auth.application.port.in.request.LoginRequest;
+import com.jnulocker.auth.application.port.in.request.ManagerApproveRequest;
 import com.jnulocker.auth.application.port.in.request.ManagerSignupRequest;
 import com.jnulocker.auth.application.port.in.request.SendEmailRequest;
 import com.jnulocker.auth.application.port.in.request.UserSignupRequest;
@@ -16,10 +17,12 @@ import com.jnulocker.auth.application.port.in.request.VerifyCodeRequest;
 import com.jnulocker.auth.exception.AuthErrorCode;
 import com.jnulocker.auth.jwt.RefreshToken;
 import com.jnulocker.auth.jwt.exception.JwtErrorCode;
+import com.jnulocker.auth.utils.AuthTestUtil;
 import com.jnulocker.common.exception.ErrorResponse;
 import com.jnulocker.common.util.RedisUtil;
 import com.jnulocker.member.adapter.out.MemberRepository;
 import com.jnulocker.member.domain.Member;
+import com.jnulocker.member.domain.Role;
 import com.jnulocker.member.exception.MemberErrorCode;
 import com.jnulocker.member.utils.MemberTestUtil;
 import com.jnulocker.organization.domain.Department;
@@ -57,7 +60,6 @@ class AuthControllerIntegrationTest {
     private static final String AUTH_URL = "/v1/auth";
     private static final String ACCESS_TOKEN = "access_token";
     private static final String REFRESH_TOKEN = "refresh_token";
-    private static final String VERIFIED_PREFIX = ":verified";
 
     @LocalServerPort private int port;
 
@@ -72,10 +74,12 @@ class AuthControllerIntegrationTest {
     @Autowired private RedisUtil redisUtil;
 
     @Value("${custom.jwt.access-secret-key}")
-    String accessSecretKey;
+    private String accessSecretKey;
 
     @Value("${custom.jwt.refresh-secret-key}")
     private String refreshSecretKey;
+
+    @Autowired private AuthTestUtil authTestUtil;
 
     @BeforeEach
     void setUp() {
@@ -102,11 +106,8 @@ class AuthControllerIntegrationTest {
         UserSignupRequest request =
                 userSignupRequestBuilder().withDepartmentId(department.getId()).build();
 
-        // when
-        ValidatableResponse response = signupUser(request);
-
-        // then
-        response.statusCode(HttpStatus.CREATED.value());
+        // when, then
+        signupUser(request).statusCode(HttpStatus.CREATED.value());
     }
 
     @Test
@@ -176,11 +177,8 @@ class AuthControllerIntegrationTest {
         ManagerSignupRequest request =
                 managerSignupRequestBuilder().withDepartmentId(department.getId()).build();
 
-        // when
-        ValidatableResponse response = signupManager(request);
-
-        // then
-        response.statusCode(HttpStatus.CREATED.value());
+        // when, then
+        signupManager(request).statusCode(HttpStatus.CREATED.value());
     }
 
     @Test
@@ -562,6 +560,101 @@ class AuthControllerIntegrationTest {
 
         // then
         assertThat(errorResponse.message()).isEqualTo(AuthErrorCode.CODE_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void MANAGER는_새로_가입한_학생회_회원의_가입을_승인할_수_있다() {
+        // given
+        Department department = organizationUtil.createDepartment();
+        ManagerSignupRequest signupRequest =
+                managerSignupRequestBuilder().withDepartmentId(department.getId()).build();
+        signupManager(signupRequest).statusCode(HttpStatus.CREATED.value());
+
+        // 가입 요청한 학생회 회원의 정보 조회
+        Member approveeMember = memberTestUtil.findMemberByEmail(signupRequest.email());
+
+        String accessToken =
+                authTestUtil.generateAccessTokenWithDepartment(Role.MANAGER, department);
+        ManagerApproveRequest approveRequest = new ManagerApproveRequest(approveeMember.getId());
+
+        // when, then
+        approveManagerSignup(accessToken, approveRequest).statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    void 이미_MANAGER인_회원은_가입을_승인할_수_없다() {
+        // given
+        Department department = organizationUtil.createDepartment();
+        ManagerSignupRequest signupRequest =
+                managerSignupRequestBuilder().withDepartmentId(department.getId()).build();
+        signupManager(signupRequest).statusCode(HttpStatus.CREATED.value());
+
+        // 가입 요청한 MANAGER 회원의 정보 조회
+        Member approveeMember = memberTestUtil.findMemberByEmail(signupRequest.email());
+
+        String accessToken =
+                authTestUtil.generateAccessTokenWithDepartment(Role.MANAGER, department);
+        ManagerApproveRequest approveRequest = new ManagerApproveRequest(approveeMember.getId());
+
+        // 미리 가입 승인하기
+        approveManagerSignup(accessToken, approveRequest).statusCode(HttpStatus.OK.value());
+
+        // when
+        ErrorResponse errorResponse =
+                approveManagerSignup(accessToken, approveRequest)
+                        .statusCode(AuthErrorCode.ONLY_GUEST_CAN_BE_MANAGER.getHttpStatus().value())
+                        .extract()
+                        .as(ErrorResponse.class);
+
+        // then
+        assertThat(errorResponse.message())
+                .isEqualTo(AuthErrorCode.ONLY_GUEST_CAN_BE_MANAGER.getMessage());
+    }
+
+    @Test
+    void MANAGER는_다른_학과의_학생회_회원의_가입을_승인할_수_없다() {
+        // given
+        Department department1 = organizationUtil.createDepartment();
+        Department department2 = organizationUtil.createDepartment();
+        ManagerSignupRequest signupRequest =
+                managerSignupRequestBuilder().withDepartmentId(department1.getId()).build();
+        signupManager(signupRequest).statusCode(HttpStatus.CREATED.value());
+
+        // 가입 요청한 학생회 회원의 정보 조회
+        Member approveeMember = memberTestUtil.findMemberByEmail(signupRequest.email());
+
+        String accessToken =
+                authTestUtil.generateAccessTokenWithDepartment(Role.MANAGER, department2);
+
+        ManagerApproveRequest approveRequest = new ManagerApproveRequest(approveeMember.getId());
+
+        // when
+        ErrorResponse errorResponse =
+                approveManagerSignup(accessToken, approveRequest)
+                        .statusCode(
+                                AuthErrorCode.ONLY_SAME_DEPARTMENT_CAN_APPROVE
+                                        .getHttpStatus()
+                                        .value())
+                        .extract()
+                        .as(ErrorResponse.class);
+
+        // then
+        assertThat(errorResponse.message())
+                .isEqualTo(AuthErrorCode.ONLY_SAME_DEPARTMENT_CAN_APPROVE.getMessage());
+    }
+
+    private ValidatableResponse approveManagerSignup(
+            String accessToken, ManagerApproveRequest request) {
+        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
+                .body(request)
+                .log()
+                .all()
+                .when()
+                .post(AUTH_URL + "/managers/approve")
+                .then()
+                .log()
+                .all();
     }
 
     public static ValidatableResponse login(LoginRequest request) {

--- a/src/test/java/com/jnulocker/auth/utils/AuthTestUtil.java
+++ b/src/test/java/com/jnulocker/auth/utils/AuthTestUtil.java
@@ -4,6 +4,7 @@ import com.jnulocker.auth.jwt.TokenProvider;
 import com.jnulocker.member.domain.Member;
 import com.jnulocker.member.domain.Role;
 import com.jnulocker.member.utils.MemberTestUtil;
+import com.jnulocker.organization.domain.Department;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -16,6 +17,11 @@ public class AuthTestUtil {
 
     public String generateAccessToken(Role role) {
         Member member = memberTestUtil.createMemberFromRole(role);
+        return tokenProvider.generateAccessToken(member.getId(), member.getRole());
+    }
+
+    public String generateAccessTokenWithDepartment(Role role, Department department) {
+        Member member = memberTestUtil.createMemberFromRoleWithDepartment(role, department);
         return tokenProvider.generateAccessToken(member.getId(), member.getRole());
     }
 

--- a/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
@@ -65,7 +65,7 @@ public class EventControllerIntegrationTest {
         RestAssured.port = port;
 
         // 토큰 생성
-        accessToken = authTestUtil.generateAccessToken(Role.GUEST);
+        accessToken = authTestUtil.generateAccessToken(Role.MANAGER);
     }
 
     @AfterEach
@@ -289,7 +289,7 @@ public class EventControllerIntegrationTest {
         Long eventId = getLastEventId();
 
         // 비조직원으로 로그인
-        accessToken = authTestUtil.generateAccessTokenWithAnotherDepartment(Role.GUEST);
+        accessToken = authTestUtil.generateAccessTokenWithAnotherDepartment(Role.MANAGER);
 
         // when
         ErrorResponse errorResponse =

--- a/src/test/java/com/jnulocker/member/utils/MemberTestUtil.java
+++ b/src/test/java/com/jnulocker/member/utils/MemberTestUtil.java
@@ -40,23 +40,7 @@ public class MemberTestUtil {
 
     public Member createMemberFromRoleWithAnotherDepartment(Role role) {
         Department department = getDepartment();
-
-        switch (role) {
-            case USER -> {
-                return memberRepository.save(
-                        memberBuilder().withDepartment(department).buildUser());
-            }
-            case GUEST -> {
-                return memberRepository.save(
-                        memberBuilder().withDepartment(department).buildManager());
-            }
-            case MANAGER -> {
-                Member member = memberBuilder().withDepartment(department).buildManager();
-                member.approveManager();
-                return memberRepository.save(member);
-            }
-            default -> throw new IllegalArgumentException("Invalid role: " + role);
-        }
+        return createMemberFromRoleWithDepartment(role, department);
     }
 
     public Member createUser() {
@@ -91,5 +75,28 @@ public class MemberTestUtil {
 
     public void deleteAll() {
         memberRepository.deleteAll();
+    }
+
+    public Member findMemberByEmail(String email) {
+        return memberRepository.findByEmail(email).orElseThrow();
+    }
+
+    public Member createMemberFromRoleWithDepartment(Role role, Department department) {
+        switch (role) {
+            case USER -> {
+                return memberRepository.save(
+                        memberBuilder().withDepartment(department).buildUser());
+            }
+            case GUEST -> {
+                return memberRepository.save(
+                        memberBuilder().withDepartment(department).buildManager());
+            }
+            case MANAGER -> {
+                Member member = memberBuilder().withDepartment(department).buildManager();
+                member.approveManager();
+                return memberRepository.save(member);
+            }
+            default -> throw new IllegalArgumentException("Invalid role: " + role);
+        }
     }
 }

--- a/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
@@ -90,8 +90,7 @@ class RegistrationControllerIntegrationTest {
 
         registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
 
-        // TODO: 추후 manager로 변경
-        accessToken = authTestUtil.generateAccessToken(Role.GUEST);
+        accessToken = authTestUtil.generateAccessToken(Role.MANAGER);
 
         // when
         RegistrationCustomPage registrationCustomPage =


### PR DESCRIPTION
### 개요
close #68 

### 작업사항
- 관리자 가입 승인 API 구현

### 변경로직
- 관리자 가입 승인 API 구현
- 인가 엔드포인트 및 권한 변경
- 학과로 Member, accessToken 생성을 위한 TestUtils 메서드 추가

### 테스트 결과
  
  <img width="363" alt="image" src="https://github.com/user-attachments/assets/1777daf5-21db-4d51-b5c0-e59b98692b92" />

#### 추가된 테스트케이스
  
  <img width="384" alt="image" src="https://github.com/user-attachments/assets/e33c4bad-06cd-4a77-864a-f6e58537d96e" />
  <img width="384" alt="image" src="https://github.com/user-attachments/assets/4afdc917-358e-4310-aa41-7d9a03f4843f" />
  <img width="384" alt="image" src="https://github.com/user-attachments/assets/f2232283-e4e5-4990-be3b-d95ff87ec3e5" />


### reference

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 매니저 가입 승인 기능이 추가되었습니다. 이제 매니저가 학생회 회원의 가입을 승인할 수 있습니다.
- **버그 수정**
  - 인증 관련 엔드포인트의 접근 권한이 세분화되어, 보다 정확한 인증 처리가 이루어집니다.
- **문서화**
  - 매니저 승인 관련 예외 및 API 명세가 추가되어 API 문서가 보완되었습니다.
- **테스트**
  - 매니저 승인 및 권한 관련 통합 테스트가 추가되었습니다.
- **스타일/리팩터**
  - 일부 내부 코드 및 테스트 유틸리티가 정리되고 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->