### PR TITLE
[FEAT] 회원 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/jnulocker/config/SecurityConfig.java
+++ b/src/main/java/com/jnulocker/config/SecurityConfig.java
@@ -82,7 +82,7 @@ public class SecurityConfig {
                                 .requestMatchers(
                                         HttpMethod.POST, "/v1/events", "/v1/auth/managers/approve")
                                 .hasAuthority(Role.MANAGER.getRole())
-                                .requestMatchers(HttpMethod.GET, "/v1/members/mypage")
+                                .requestMatchers(HttpMethod.GET, "/v1/members/*")
                                 .authenticated()
                                 .requestMatchers(HttpMethod.DELETE, "/v1/events/*")
                                 .hasAuthority(Role.MANAGER.getRole())

--- a/src/main/java/com/jnulocker/config/SecurityConfig.java
+++ b/src/main/java/com/jnulocker/config/SecurityConfig.java
@@ -82,6 +82,8 @@ public class SecurityConfig {
                                 .requestMatchers(
                                         HttpMethod.POST, "/v1/events", "/v1/auth/managers/approve")
                                 .hasAuthority(Role.MANAGER.getRole())
+                                .requestMatchers(HttpMethod.GET, "/v1/members/mypage")
+                                .authenticated()
                                 .requestMatchers(HttpMethod.DELETE, "/v1/events/*")
                                 .hasAuthority(Role.MANAGER.getRole())
                                 .requestMatchers(HttpMethod.PUT, "/v1/events/*/publish")

--- a/src/main/java/com/jnulocker/member/adapter/in/MemberController.java
+++ b/src/main/java/com/jnulocker/member/adapter/in/MemberController.java
@@ -1,5 +1,6 @@
 package com.jnulocker.member.adapter.in;
 
+import com.jnulocker.member.adapter.in.docs.MemberApi;
 import com.jnulocker.member.application.port.in.MemberQuery;
 import com.jnulocker.member.application.port.in.response.MemberInfoResponse;
 import lombok.RequiredArgsConstructor;
@@ -11,10 +12,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/v1/members")
 @RequiredArgsConstructor
-public class MemberController {
+public class MemberController implements MemberApi {
 
     private final MemberQuery memberQuery;
 
+    @Override
     @GetMapping("/info")
     public ResponseEntity<MemberInfoResponse> getMemberInfo() {
         return ResponseEntity.ok(memberQuery.getMemberInfo());

--- a/src/main/java/com/jnulocker/member/adapter/in/MemberController.java
+++ b/src/main/java/com/jnulocker/member/adapter/in/MemberController.java
@@ -15,7 +15,7 @@ public class MemberController {
 
     private final MemberQuery memberQuery;
 
-    @GetMapping("/mypage")
+    @GetMapping("/info")
     public ResponseEntity<MemberInfoResponse> getMemberInfo() {
         return ResponseEntity.ok(memberQuery.getMemberInfo());
     }

--- a/src/main/java/com/jnulocker/member/adapter/in/MemberController.java
+++ b/src/main/java/com/jnulocker/member/adapter/in/MemberController.java
@@ -1,0 +1,22 @@
+package com.jnulocker.member.adapter.in;
+
+import com.jnulocker.member.application.port.in.MemberQuery;
+import com.jnulocker.member.application.port.in.response.MemberInfoResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberQuery memberQuery;
+
+    @GetMapping("/mypage")
+    public ResponseEntity<MemberInfoResponse> getMemberInfo() {
+        return ResponseEntity.ok(memberQuery.getMemberInfo());
+    }
+}

--- a/src/main/java/com/jnulocker/member/adapter/in/docs/MemberApi.java
+++ b/src/main/java/com/jnulocker/member/adapter/in/docs/MemberApi.java
@@ -1,0 +1,30 @@
+package com.jnulocker.member.adapter.in.docs;
+
+import com.jnulocker.member.application.port.in.response.MemberInfoResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "회원 API", description = "회원 관련 API")
+public interface MemberApi {
+
+    @Operation(summary = "회원 정보 조회", description = "회원 정보를 조회합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "회원 정보 조회 성공",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            array =
+                                    @ArraySchema(
+                                            schema =
+                                                    @Schema(
+                                                            implementation =
+                                                                    MemberInfoResponse.class))))
+    ResponseEntity<MemberInfoResponse> getMemberInfo();
+}

--- a/src/main/java/com/jnulocker/member/adapter/in/docs/MemberApi.java
+++ b/src/main/java/com/jnulocker/member/adapter/in/docs/MemberApi.java
@@ -2,7 +2,6 @@ package com.jnulocker.member.adapter.in.docs;
 
 import com.jnulocker.member.application.port.in.response.MemberInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -20,11 +19,6 @@ public interface MemberApi {
             content =
                     @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            array =
-                                    @ArraySchema(
-                                            schema =
-                                                    @Schema(
-                                                            implementation =
-                                                                    MemberInfoResponse.class))))
+                            schema = @Schema(implementation = MemberInfoResponse.class)))
     ResponseEntity<MemberInfoResponse> getMemberInfo();
 }

--- a/src/main/java/com/jnulocker/member/application/port/in/MemberQuery.java
+++ b/src/main/java/com/jnulocker/member/application/port/in/MemberQuery.java
@@ -1,5 +1,6 @@
 package com.jnulocker.member.application.port.in;
 
+import com.jnulocker.member.application.port.in.response.MemberInfoResponse;
 import com.jnulocker.member.domain.Member;
 
 public interface MemberQuery {
@@ -11,4 +12,6 @@ public interface MemberQuery {
     Member findByIdOrThrow(Long id);
 
     Member findByIdWithDepartmentOrThrow(Long memberId);
+
+    MemberInfoResponse getMemberInfo();
 }

--- a/src/main/java/com/jnulocker/member/application/port/in/response/MemberInfoResponse.java
+++ b/src/main/java/com/jnulocker/member/application/port/in/response/MemberInfoResponse.java
@@ -4,6 +4,7 @@ import com.jnulocker.member.domain.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record MemberInfoResponse(
+        @Schema(description = "회원 ID", example = "1") Long memberId,
         @Schema(description = "이름", example = "심민보") String name,
         @Schema(description = "학번", example = "222222") String studentNumber,
         @Schema(description = "소속", example = "수학과") String affiliation,
@@ -11,6 +12,7 @@ public record MemberInfoResponse(
         @Schema(description = "이메일", example = "test@example.com") String email) {
     public static MemberInfoResponse from(Member member) {
         return new MemberInfoResponse(
+                member.getId(),
                 member.getName(),
                 member.getStudentNumber(),
                 member.getDepartment().getName(),

--- a/src/main/java/com/jnulocker/member/application/port/in/response/MemberInfoResponse.java
+++ b/src/main/java/com/jnulocker/member/application/port/in/response/MemberInfoResponse.java
@@ -1,8 +1,5 @@
 package com.jnulocker.member.application.port.in.response;
 
-import com.jnulocker.member.domain.Member;
-import com.jnulocker.member.domain.Role;
-import com.jnulocker.organization.domain.OrganizationType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record MemberInfoResponse(
@@ -12,29 +9,14 @@ public record MemberInfoResponse(
         @Schema(description = "소속", example = "수학과") String affiliation,
         @Schema(description = "전화번호", example = "010-1234-1234") String phoneNumber,
         @Schema(description = "이메일", example = "test@example.com") String email) {
-    public static MemberInfoResponse from(Member member) {
-        String studentNumber = null;
-        String affiliation = null;
-
-        Role role = member.getRole();
-        OrganizationType orgType = member.getDepartment().getOrganization().getType();
-
-        if (role == Role.USER) {
-            studentNumber = member.getStudentNumber();
-            affiliation = member.getDepartment().getName();
-        } else if (role == Role.MANAGER) { // 쉽게 테스트하려면 GUEST로 권한 바꾸기
-            if (orgType == OrganizationType.COUNCIL) {
-                studentNumber = member.getStudentNumber();
-            }
-            affiliation = member.getDepartment().getNickname();
-        }
-
+    public static MemberInfoResponse of(
+            Long memberId,
+            String name,
+            String studentNumber,
+            String affiliation,
+            String phoneNumber,
+            String email) {
         return new MemberInfoResponse(
-                member.getId(),
-                member.getName(),
-                studentNumber,
-                affiliation,
-                member.getPhoneNumber(),
-                member.getEmail());
+                memberId, name, studentNumber, affiliation, phoneNumber, email);
     }
 }

--- a/src/main/java/com/jnulocker/member/application/port/in/response/MemberInfoResponse.java
+++ b/src/main/java/com/jnulocker/member/application/port/in/response/MemberInfoResponse.java
@@ -1,0 +1,20 @@
+package com.jnulocker.member.application.port.in.response;
+
+import com.jnulocker.member.domain.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MemberInfoResponse(
+        @Schema(description = "이름", example = "심민보") String name,
+        @Schema(description = "학번", example = "222222") String studentNumber,
+        @Schema(description = "소속", example = "수학과") String affiliation,
+        @Schema(description = "전화번호", example = "010-1234-1234") String phoneNumber,
+        @Schema(description = "이메일", example = "test@example.com") String email) {
+    public static MemberInfoResponse from(Member member) {
+        return new MemberInfoResponse(
+                member.getName(),
+                member.getStudentNumber(),
+                member.getDepartment().getName(),
+                member.getPhoneNumber(),
+                member.getEmail());
+    }
+}

--- a/src/main/java/com/jnulocker/member/application/port/in/response/MemberInfoResponse.java
+++ b/src/main/java/com/jnulocker/member/application/port/in/response/MemberInfoResponse.java
@@ -1,6 +1,8 @@
 package com.jnulocker.member.application.port.in.response;
 
 import com.jnulocker.member.domain.Member;
+import com.jnulocker.member.domain.Role;
+import com.jnulocker.organization.domain.OrganizationType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record MemberInfoResponse(
@@ -11,11 +13,27 @@ public record MemberInfoResponse(
         @Schema(description = "전화번호", example = "010-1234-1234") String phoneNumber,
         @Schema(description = "이메일", example = "test@example.com") String email) {
     public static MemberInfoResponse from(Member member) {
+        String studentNumber = null;
+        String affiliation = null;
+
+        Role role = member.getRole();
+        OrganizationType orgType = member.getDepartment().getOrganization().getType();
+
+        if (role == Role.USER) {
+            studentNumber = member.getStudentNumber();
+            affiliation = member.getDepartment().getName();
+        } else if (role == Role.MANAGER) { // 쉽게 테스트하려면 GUEST로 권한 바꾸기
+            if (orgType == OrganizationType.COUNCIL) {
+                studentNumber = member.getStudentNumber();
+            }
+            affiliation = member.getDepartment().getNickname();
+        }
+
         return new MemberInfoResponse(
                 member.getId(),
                 member.getName(),
-                member.getStudentNumber(),
-                member.getDepartment().getName(),
+                studentNumber,
+                affiliation,
                 member.getPhoneNumber(),
                 member.getEmail());
     }

--- a/src/main/java/com/jnulocker/member/application/service/MemberQueryService.java
+++ b/src/main/java/com/jnulocker/member/application/service/MemberQueryService.java
@@ -43,7 +43,7 @@ public class MemberQueryService implements MemberQuery {
     }
 
     @Override
-    @Transactional
+    @Transactional(readOnly = true)
     public MemberInfoResponse getMemberInfo() {
         Long memberId = SecurityUtils.getCurrentMemberId();
         Member member = findByIdOrThrow(memberId);

--- a/src/main/java/com/jnulocker/member/application/service/MemberQueryService.java
+++ b/src/main/java/com/jnulocker/member/application/service/MemberQueryService.java
@@ -5,7 +5,9 @@ import com.jnulocker.member.application.port.in.MemberQuery;
 import com.jnulocker.member.application.port.in.response.MemberInfoResponse;
 import com.jnulocker.member.application.port.out.MemberLoadPort;
 import com.jnulocker.member.domain.Member;
+import com.jnulocker.member.domain.Role;
 import com.jnulocker.member.exception.MemberNotFoundException;
+import com.jnulocker.organization.domain.OrganizationType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -45,6 +47,29 @@ public class MemberQueryService implements MemberQuery {
     public MemberInfoResponse getMemberInfo() {
         Long memberId = SecurityUtils.getCurrentMemberId();
         Member member = findByIdOrThrow(memberId);
-        return MemberInfoResponse.from(member);
+
+        String studentNumber = null;
+        String affiliation = null;
+
+        Role role = member.getRole();
+        OrganizationType orgType = member.getDepartment().getOrganization().getType();
+
+        if (role == Role.USER) {
+            studentNumber = member.getStudentNumber();
+            affiliation = member.getDepartment().getName();
+        } else if (role == Role.MANAGER) {
+            if (orgType == OrganizationType.COUNCIL) {
+                studentNumber = member.getStudentNumber();
+            }
+            affiliation = member.getDepartment().getNickname();
+        }
+
+        return MemberInfoResponse.of(
+                member.getId(),
+                member.getName(),
+                studentNumber,
+                affiliation,
+                member.getPhoneNumber(),
+                member.getEmail());
     }
 }

--- a/src/main/java/com/jnulocker/member/application/service/MemberQueryService.java
+++ b/src/main/java/com/jnulocker/member/application/service/MemberQueryService.java
@@ -1,11 +1,14 @@
 package com.jnulocker.member.application.service;
 
+import com.jnulocker.auth.security.SecurityUtils;
 import com.jnulocker.member.application.port.in.MemberQuery;
+import com.jnulocker.member.application.port.in.response.MemberInfoResponse;
 import com.jnulocker.member.application.port.out.MemberLoadPort;
 import com.jnulocker.member.domain.Member;
 import com.jnulocker.member.exception.MemberNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -35,5 +38,13 @@ public class MemberQueryService implements MemberQuery {
         return memberLoadPort
                 .findByIdWithDepartment(id)
                 .orElseThrow(() -> MemberNotFoundException.EXCEPTION);
+    }
+
+    @Override
+    @Transactional
+    public MemberInfoResponse getMemberInfo() {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        Member member = findByIdOrThrow(memberId);
+        return MemberInfoResponse.from(member);
     }
 }

--- a/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
@@ -84,15 +84,10 @@ class AuthControllerIntegrationTest {
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
-        clearData();
     }
 
     @AfterEach
     void tearDown() {
-        clearData();
-    }
-
-    private void clearData() {
         memberRepository.deleteAll();
         tokenRepository.deleteAll();
         redisUtil.deleteAll();

--- a/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
@@ -97,7 +97,7 @@ class AuthControllerIntegrationTest {
     @Test
     void USER_회원가입을_할_수_있다() {
         // given
-        Department department = organizationUtil.createDepartment();
+        Department department = organizationUtil.createCouncilDepartment();
         UserSignupRequest request =
                 userSignupRequestBuilder().withDepartmentId(department.getId()).build();
 
@@ -128,7 +128,7 @@ class AuthControllerIntegrationTest {
     @Test
     void USER_동일메일로_회원가입하면_User_Already_Exist_에러_응답을_받는다() {
         // given
-        Department department = organizationUtil.createDepartment();
+        Department department = organizationUtil.createCouncilDepartment();
         UserSignupRequest request =
                 userSignupRequestBuilder().withDepartmentId(department.getId()).build();
         signupUser(request).statusCode(HttpStatus.CREATED.value());
@@ -148,7 +148,7 @@ class AuthControllerIntegrationTest {
     @Test
     void USER_회원가입_시_이메일_인증이_완료되지_않았으면_Email_Not_Verified_에러_응답을_받는다() {
         // given
-        Department department = organizationUtil.createDepartment();
+        Department department = organizationUtil.createCouncilDepartment();
         UserSignupRequest request =
                 userSignupRequestBuilder().withDepartmentId(department.getId()).build();
         redisUtil.deleteVerifiedData(request.email());
@@ -168,7 +168,7 @@ class AuthControllerIntegrationTest {
     @Test
     void MANAGER_회원가입을_할_수_있다() {
         // given
-        Department department = organizationUtil.createDepartment();
+        Department department = organizationUtil.createCouncilDepartment();
         ManagerSignupRequest request =
                 managerSignupRequestBuilder().withDepartmentId(department.getId()).build();
 
@@ -179,7 +179,7 @@ class AuthControllerIntegrationTest {
     @Test
     void MANAGER_학생회_회원가입_시_학번이_null이면_Student_Number_Required_에러_응답을_받는다() {
         // given
-        Department department = organizationUtil.createDepartment();
+        Department department = organizationUtil.createCouncilDepartment();
         ManagerSignupRequest request =
                 managerSignupRequestBuilder()
                         .withDepartmentId(department.getId())
@@ -201,7 +201,7 @@ class AuthControllerIntegrationTest {
     @Test
     void MANAGER_학생회_회원가입_시_학번이_입력되면_정상적으로_회원가입된다() {
         // given
-        Department department = organizationUtil.createDepartment();
+        Department department = organizationUtil.createCouncilDepartment();
         ManagerSignupRequest request =
                 managerSignupRequestBuilder()
                         .withDepartmentId(department.getId())
@@ -255,7 +255,7 @@ class AuthControllerIntegrationTest {
     @Test
     void MANAGER_동일메일로_회원가입하면_User_Already_Exist_에러_응답을_받는다() {
         // given
-        Department department = organizationUtil.createDepartment();
+        Department department = organizationUtil.createCouncilDepartment();
         ManagerSignupRequest request =
                 managerSignupRequestBuilder().withDepartmentId(department.getId()).build();
         signupManager(request).statusCode(HttpStatus.CREATED.value());
@@ -275,7 +275,7 @@ class AuthControllerIntegrationTest {
     @Test
     void MANAGER_회원가입_시_이메일_인증이_완료되지_않았으면_Email_Not_Verified_에러_응답을_받는다() {
         // given
-        Department department = organizationUtil.createDepartment();
+        Department department = organizationUtil.createCouncilDepartment();
 
         ManagerSignupRequest request =
                 managerSignupRequestBuilder().withDepartmentId(department.getId()).build();
@@ -296,7 +296,7 @@ class AuthControllerIntegrationTest {
     @Test
     void 로그인_성공시_토큰을_반환한다() {
         // given
-        Department department = organizationUtil.createDepartment();
+        Department department = organizationUtil.createCouncilDepartment();
         UserSignupRequest signupRequest =
                 userSignupRequestBuilder().withDepartmentId(department.getId()).build();
         signupUser(signupRequest);
@@ -320,7 +320,7 @@ class AuthControllerIntegrationTest {
     @Test
     void 토큰_재발급_요청시_새로운_AccessToken을_받는다() {
         // given
-        Department department = organizationUtil.createDepartment();
+        Department department = organizationUtil.createCouncilDepartment();
         UserSignupRequest signupRequest =
                 userSignupRequestBuilder().withDepartmentId(department.getId()).build();
         signupUser(signupRequest);
@@ -423,7 +423,7 @@ class AuthControllerIntegrationTest {
     @Test
     void 올바르지_않은_이메일로_로그인하면_인증에_실패한다() {
         // given
-        Department department = organizationUtil.createDepartment();
+        Department department = organizationUtil.createCouncilDepartment();
         UserSignupRequest signupRequest =
                 userSignupRequestBuilder().withDepartmentId(department.getId()).build();
         signupUser(signupRequest);
@@ -445,7 +445,7 @@ class AuthControllerIntegrationTest {
     @Test
     void 올바르지_않은_비밀번호로_로그인하면_인증에_실패한다() {
         // given
-        Department department = organizationUtil.createDepartment();
+        Department department = organizationUtil.createCouncilDepartment();
         UserSignupRequest signupRequest =
                 userSignupRequestBuilder().withDepartmentId(department.getId()).build();
         signupUser(signupRequest);
@@ -479,7 +479,7 @@ class AuthControllerIntegrationTest {
     @Test
     void 이미_사용중인_이메일로_인증_요청_시_User_Already_Exist_에러_응답을_받는다() {
         // given
-        Department department = organizationUtil.createDepartment();
+        Department department = organizationUtil.createCouncilDepartment();
         UserSignupRequest signupRequest =
                 userSignupRequestBuilder().withDepartmentId(department.getId()).build();
         signupUser(signupRequest).statusCode(HttpStatus.CREATED.value());
@@ -560,7 +560,7 @@ class AuthControllerIntegrationTest {
     @Test
     void MANAGER는_새로_가입한_학생회_회원의_가입을_승인할_수_있다() {
         // given
-        Department department = organizationUtil.createDepartment();
+        Department department = organizationUtil.createCouncilDepartment();
         ManagerSignupRequest signupRequest =
                 managerSignupRequestBuilder().withDepartmentId(department.getId()).build();
         signupManager(signupRequest).statusCode(HttpStatus.CREATED.value());
@@ -579,7 +579,7 @@ class AuthControllerIntegrationTest {
     @Test
     void 이미_MANAGER인_회원은_가입을_승인할_수_없다() {
         // given
-        Department department = organizationUtil.createDepartment();
+        Department department = organizationUtil.createCouncilDepartment();
         ManagerSignupRequest signupRequest =
                 managerSignupRequestBuilder().withDepartmentId(department.getId()).build();
         signupManager(signupRequest).statusCode(HttpStatus.CREATED.value());
@@ -609,8 +609,8 @@ class AuthControllerIntegrationTest {
     @Test
     void MANAGER는_다른_학과의_학생회_회원의_가입을_승인할_수_없다() {
         // given
-        Department department1 = organizationUtil.createDepartment();
-        Department department2 = organizationUtil.createDepartment();
+        Department department1 = organizationUtil.createCouncilDepartment();
+        Department department2 = organizationUtil.createCouncilDepartment();
         ManagerSignupRequest signupRequest =
                 managerSignupRequestBuilder().withDepartmentId(department1.getId()).build();
         signupManager(signupRequest).statusCode(HttpStatus.CREATED.value());

--- a/src/test/java/com/jnulocker/auth/utils/AuthTestUtil.java
+++ b/src/test/java/com/jnulocker/auth/utils/AuthTestUtil.java
@@ -29,4 +29,8 @@ public class AuthTestUtil {
         Member member = memberTestUtil.createMemberFromRoleWithAnotherDepartment(role);
         return tokenProvider.generateAccessToken(member.getId(), member.getRole());
     }
+
+    public String generateAccessTokenFromMemberId(Long memberId, Role role) {
+        return tokenProvider.generateAccessToken(memberId, role);
+    }
 }

--- a/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
@@ -207,7 +207,7 @@ public class EventControllerIntegrationTest {
     }
 
     private void createEvent() {
-        Department department = organizationUtil.createDepartment();
+        Department department = organizationUtil.createCouncilDepartment();
 
         CreateEventRequest request =
                 createEventRequestBuilder()

--- a/src/test/java/com/jnulocker/member/adapter/in/MemberControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/member/adapter/in/MemberControllerIntegrationTest.java
@@ -1,0 +1,87 @@
+package com.jnulocker.member.adapter.in;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jnulocker.auth.utils.AuthTestUtil;
+import com.jnulocker.member.application.port.in.response.MemberInfoResponse;
+import com.jnulocker.member.domain.Member;
+import com.jnulocker.member.domain.Role;
+import com.jnulocker.member.utils.MemberTestUtil;
+import io.restassured.RestAssured;
+import io.restassured.http.Cookie;
+import io.restassured.response.ValidatableResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@Testcontainers
+@ActiveProfiles("test")
+@DisplayName("회원 통합 테스트")
+public class MemberControllerIntegrationTest {
+
+    private static final String MEMBER_URL = "/v1/members";
+    private static final String ACCESS_TOKEN = "access_token";
+
+    @LocalServerPort private int port;
+
+    @Autowired private MemberTestUtil memberTestUtil;
+
+    @Autowired private AuthTestUtil authTestUtil;
+
+    private static String accessToken;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+
+        // 토큰 생성
+        accessToken = authTestUtil.generateAccessToken(Role.USER);
+    }
+
+    @AfterEach
+    void tearDown() {
+        memberTestUtil.deleteAll();
+    }
+
+    @Test
+    void 회원_정보를_조회할_수_있다() {
+        // given
+        Member expected = memberTestUtil.createUser();
+
+        // when
+        MemberInfoResponse actual =
+                getMemberInfo(accessToken)
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .as(MemberInfoResponse.class);
+
+        // then
+        assertThat(actual).isNotNull();
+        assertThat(actual.name()).isEqualTo(expected.getName());
+        assertThat(actual.studentNumber()).isEqualTo(expected.getStudentNumber());
+        assertThat(actual.affiliation()).isEqualTo(expected.getDepartment().getName());
+        assertThat(actual.phoneNumber()).isEqualTo(expected.getPhoneNumber());
+        assertThat(actual.email()).isEqualTo(expected.getEmail());
+    }
+
+    public static ValidatableResponse getMemberInfo(String accessToken) {
+        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
+                .when()
+                .get(MEMBER_URL + "/info")
+                .then()
+                .log()
+                .all();
+    }
+}

--- a/src/test/java/com/jnulocker/member/adapter/in/MemberControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/member/adapter/in/MemberControllerIntegrationTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.jnulocker.auth.utils.AuthTestUtil;
 import com.jnulocker.member.application.port.in.response.MemberInfoResponse;
 import com.jnulocker.member.domain.Member;
-import com.jnulocker.member.domain.Role;
 import com.jnulocker.member.utils.MemberTestUtil;
 import io.restassured.RestAssured;
 import io.restassured.http.Cookie;
@@ -39,14 +38,9 @@ public class MemberControllerIntegrationTest {
 
     @Autowired private AuthTestUtil authTestUtil;
 
-    private static String accessToken;
-
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
-
-        // 토큰 생성
-        accessToken = authTestUtil.generateAccessToken(Role.USER);
     }
 
     @AfterEach
@@ -57,22 +51,27 @@ public class MemberControllerIntegrationTest {
     @Test
     void 회원_정보를_조회할_수_있다() {
         // given
-        Member expected = memberTestUtil.createUser();
+        Member expectedMember = memberTestUtil.createUser();
+        String accessToken =
+                authTestUtil.generateAccessTokenFromMemberId(
+                        expectedMember.getId(), expectedMember.getRole());
 
         // when
-        MemberInfoResponse actual =
+        MemberInfoResponse memberInfoResponse =
                 getMemberInfo(accessToken)
                         .statusCode(HttpStatus.OK.value())
                         .extract()
                         .as(MemberInfoResponse.class);
 
         // then
-        assertThat(actual).isNotNull();
-        assertThat(actual.name()).isEqualTo(expected.getName());
-        assertThat(actual.studentNumber()).isEqualTo(expected.getStudentNumber());
-        assertThat(actual.affiliation()).isEqualTo(expected.getDepartment().getName());
-        assertThat(actual.phoneNumber()).isEqualTo(expected.getPhoneNumber());
-        assertThat(actual.email()).isEqualTo(expected.getEmail());
+        assertThat(memberInfoResponse).isNotNull();
+        assertThat(memberInfoResponse.memberId()).isEqualTo(expectedMember.getId());
+        assertThat(memberInfoResponse.name()).isEqualTo(expectedMember.getName());
+        assertThat(memberInfoResponse.studentNumber()).isEqualTo(expectedMember.getStudentNumber());
+        assertThat(memberInfoResponse.affiliation())
+                .isEqualTo(expectedMember.getDepartment().getName());
+        assertThat(memberInfoResponse.phoneNumber()).isEqualTo(expectedMember.getPhoneNumber());
+        assertThat(memberInfoResponse.email()).isEqualTo(expectedMember.getEmail());
     }
 
     public static ValidatableResponse getMemberInfo(String accessToken) {

--- a/src/test/java/com/jnulocker/member/adapter/in/MemberControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/member/adapter/in/MemberControllerIntegrationTest.java
@@ -6,7 +6,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.jnulocker.auth.utils.AuthTestUtil;
 import com.jnulocker.member.application.port.in.response.MemberInfoResponse;
 import com.jnulocker.member.domain.Member;
+import com.jnulocker.member.domain.Role;
 import com.jnulocker.member.utils.MemberTestUtil;
+import com.jnulocker.organization.domain.Department;
+import com.jnulocker.organization.utils.OrganizationUtil;
 import io.restassured.RestAssured;
 import io.restassured.http.Cookie;
 import io.restassured.response.ValidatableResponse;
@@ -38,6 +41,8 @@ public class MemberControllerIntegrationTest {
 
     @Autowired private AuthTestUtil authTestUtil;
 
+    @Autowired private OrganizationUtil organizationUtil;
+
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
@@ -49,7 +54,7 @@ public class MemberControllerIntegrationTest {
     }
 
     @Test
-    void 회원_정보를_조회할_수_있다() {
+    void USER_회원_정보를_조회할_수_있다() {
         // given
         Member expectedMember = memberTestUtil.createUser();
         String accessToken =
@@ -70,6 +75,62 @@ public class MemberControllerIntegrationTest {
         assertThat(memberInfoResponse.studentNumber()).isEqualTo(expectedMember.getStudentNumber());
         assertThat(memberInfoResponse.affiliation())
                 .isEqualTo(expectedMember.getDepartment().getName());
+        assertThat(memberInfoResponse.phoneNumber()).isEqualTo(expectedMember.getPhoneNumber());
+        assertThat(memberInfoResponse.email()).isEqualTo(expectedMember.getEmail());
+    }
+
+    @Test
+    void MANAGER_COUNCIL_회원_정보를_조회할_수_있다() {
+        // given
+        Department council = organizationUtil.createCouncilDepartment();
+        Member expectedMember =
+                memberTestUtil.createMemberFromRoleWithDepartment(Role.MANAGER, council);
+        String accessToken =
+                authTestUtil.generateAccessTokenFromMemberId(
+                        expectedMember.getId(), expectedMember.getRole());
+
+        // when
+        MemberInfoResponse memberInfoResponse =
+                getMemberInfo(accessToken)
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .as(MemberInfoResponse.class);
+
+        // then
+        assertThat(memberInfoResponse).isNotNull();
+        assertThat(memberInfoResponse.memberId()).isEqualTo(expectedMember.getId());
+        assertThat(memberInfoResponse.name()).isEqualTo(expectedMember.getName());
+        assertThat(memberInfoResponse.studentNumber()).isEqualTo(expectedMember.getStudentNumber());
+        assertThat(memberInfoResponse.affiliation())
+                .isEqualTo(expectedMember.getDepartment().getNickname());
+        assertThat(memberInfoResponse.phoneNumber()).isEqualTo(expectedMember.getPhoneNumber());
+        assertThat(memberInfoResponse.email()).isEqualTo(expectedMember.getEmail());
+    }
+
+    @Test
+    void MANAGER_COMMITTEE_회원_정보를_조회할_수_있다() {
+        // given
+        Department committee = organizationUtil.createCommitteeDepartment();
+        Member expectedMember =
+                memberTestUtil.createMemberFromRoleWithDepartment(Role.MANAGER, committee);
+        String accessToken =
+                authTestUtil.generateAccessTokenFromMemberId(
+                        expectedMember.getId(), expectedMember.getRole());
+
+        // when
+        MemberInfoResponse memberInfoResponse =
+                getMemberInfo(accessToken)
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .as(MemberInfoResponse.class);
+
+        // then
+        assertThat(memberInfoResponse).isNotNull();
+        assertThat(memberInfoResponse.memberId()).isEqualTo(expectedMember.getId());
+        assertThat(memberInfoResponse.name()).isEqualTo(expectedMember.getName());
+        assertThat(memberInfoResponse.studentNumber()).isEqualTo(null);
+        assertThat(memberInfoResponse.affiliation())
+                .isEqualTo(expectedMember.getDepartment().getNickname());
         assertThat(memberInfoResponse.phoneNumber()).isEqualTo(expectedMember.getPhoneNumber());
         assertThat(memberInfoResponse.email()).isEqualTo(expectedMember.getEmail());
     }

--- a/src/test/java/com/jnulocker/organization/utils/OrganizationUtil.java
+++ b/src/test/java/com/jnulocker/organization/utils/OrganizationUtil.java
@@ -18,14 +18,14 @@ public class OrganizationUtil {
 
     @Autowired private DepartmentRepository departmentRepository;
 
-    public Department createDepartment() {
-        Organization organization = createOrganization();
+    public Department createCouncilDepartment() {
+        Organization organization = createCouncil();
         Department department = departmentBuilder().withOrganization(organization).build();
         departmentRepository.save(department);
         return department;
     }
 
-    public Organization createOrganization() {
+    public Organization createCouncil() {
         Organization organization = organizationBuilder().build();
         return organizationRepository.save(organization);
     }


### PR DESCRIPTION
### 개요
close #70 

### 작업사항
- 회원 정보 조회 API를 구현하였습니다.

### 테스트 결과
<img width="571" alt="image" src="https://github.com/user-attachments/assets/c2ac448f-9f76-46b6-b8af-0bee2feb8de8" />

</br>
</br>

**추가된 테스트케이스**

- 회원 정보를 조회할 수 있다.
<img width="330" alt="image" src="https://github.com/user-attachments/assets/056b381a-af3c-44af-af77-553939c55082" />

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
    - 인증된 사용자가 자신의 회원 정보를 조회할 수 있는 API 엔드포인트(`/v1/members/info`)가 추가되었습니다.
    - 회원 정보 조회 API에 역할 및 조직 유형에 따른 맞춤형 정보를 제공합니다.

- **버그 수정**
    - 테스트 데이터 정리 로직이 테스트 종료 시점으로 일원화되어 테스트 환경이 더욱 안정적으로 개선되었습니다.

- **문서화**
    - 회원 정보 조회 API에 대한 Swagger 문서가 추가되었습니다.

- **테스트**
    - 회원 정보 조회 기능에 대한 통합 테스트가 추가되었습니다.
    - 테스트용 액세스 토큰 생성 유틸리티 메서드가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->