### PR TITLE
[FIX] 사물함 신청 취소 시 사물함이 available 되도록 수정

### DIFF
--- a/src/main/java/com/jnulocker/events/domain/Locker.java
+++ b/src/main/java/com/jnulocker/events/domain/Locker.java
@@ -47,10 +47,13 @@ public class Locker extends BaseEntity {
         checkAvailability();
     }
 
-    // 새로 추가: 사물함을 사용 불가 상태로 변경
     public void markAsUnavailable() {
         checkAvailability();
         this.available = false;
+    }
+
+    public void markAsAvailable() {
+        this.available = true;
     }
 
     private void checkAvailability() {

--- a/src/main/java/com/jnulocker/registration/application/service/RegistrationCommandService.java
+++ b/src/main/java/com/jnulocker/registration/application/service/RegistrationCommandService.java
@@ -58,6 +58,10 @@ public class RegistrationCommandService implements RegistrationCommand {
                 registrationLoadPort
                         .getRegistrationByMemberIdAndEventId(memberId, event.getId())
                         .orElseThrow(() -> RegistrationNotFoundException.EXCEPTION);
+
+        Locker locker = registration.getLocker();
+        locker.markAsAvailable();
+
         registrationRecordPort.delete(registration);
     }
 }

--- a/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
@@ -318,6 +318,32 @@ class RegistrationControllerIntegrationTest {
 
         // when, then
         cancelMyRegistration(event.getId()).statusCode(HttpStatus.NO_CONTENT.value());
+
+        // 신청 내역이 삭제되었는지 확인
+        ErrorResponse errorResponse =
+                getMyRegistration(event.getId())
+                        .statusCode(
+                                RegistrationErrorCode.REGISTRATION_NOT_FOUND
+                                        .getHttpStatus()
+                                        .value())
+                        .extract()
+                        .as(ErrorResponse.class);
+
+        assertThat(errorResponse.message())
+                .isEqualTo(RegistrationErrorCode.REGISTRATION_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 취소한_사물함을_다시_신청할_수_있다() {
+        // given
+        Event event = createEventWithLockers(EventStatus.OPEN, true);
+        RegisterForEventRequest request = createRequestForAvailableLocker(event);
+
+        registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
+        cancelMyRegistration(event.getId()).statusCode(HttpStatus.NO_CONTENT.value());
+
+        // when, then
+        registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
     }
 
     @Test


### PR DESCRIPTION
### 개요
close #72 

### 작업사항
- 사물함 신청 취소 시 사물함이 available 되도록 수정

### 변경로직
- `locker.markAsAvailable()` 메서드 작성 후 사물함 취소 시 호출
- 사물함 취소 시 신청정보 확인 테스트케이스 추가
- 사물함 취소 후 재신청 테스트케이스 추가

### 테스트 결과
  <img width="335" alt="image" src="https://github.com/user-attachments/assets/04ecc33f-5968-4bd7-b7c2-dc934953098c" />

#### 추가된 테스트케이스
  <img width="287" alt="image" src="https://github.com/user-attachments/assets/51db15d4-41ab-40e3-876e-631224dfc82f" />
  <img width="284" alt="image" src="https://github.com/user-attachments/assets/4b06836e-e5a8-48dc-aad1-8eb53d744062" />


### reference

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 사물함을 명시적으로 사용 가능 상태로 변경하는 기능이 추가되었습니다.

- **버그 수정**
  - 사물함 등록 취소 시, 해당 사물함이 즉시 사용 가능 상태로 전환됩니다.

- **테스트**
  - 사물함 등록 취소 후, 등록 정보가 정상적으로 삭제되는지 검증하는 테스트가 추가되었습니다.
  - 취소한 사물함을 다시 신청할 수 있는지 확인하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->