### PR TITLE
[FEAT] USER의 소속학과에 해당하는 이벤트 목록 조회

### DIFF
--- a/src/main/java/com/jnulocker/config/SecurityConfig.java
+++ b/src/main/java/com/jnulocker/config/SecurityConfig.java
@@ -72,9 +72,6 @@ public class SecurityConfig {
                                         "/v1/auth/send-email",
                                         "/v1/auth/verify")
                                 .permitAll()
-                                .requestMatchers(
-                                        HttpMethod.GET, "/v1/events", "/v1/events/*/lockers")
-                                .authenticated()
                                 .requestMatchers(HttpMethod.GET, "/v1/events/*/registrations/me")
                                 .hasAuthority(Role.USER.getRole())
                                 .requestMatchers(HttpMethod.GET, "/v1/events/*/registrations")
@@ -82,8 +79,6 @@ public class SecurityConfig {
                                 .requestMatchers(
                                         HttpMethod.POST, "/v1/events", "/v1/auth/managers/approve")
                                 .hasAuthority(Role.MANAGER.getRole())
-                                .requestMatchers(HttpMethod.GET, "/v1/members/*")
-                                .authenticated()
                                 .requestMatchers(HttpMethod.DELETE, "/v1/events/*")
                                 .hasAuthority(Role.MANAGER.getRole())
                                 .requestMatchers(HttpMethod.PUT, "/v1/events/*/publish")

--- a/src/main/java/com/jnulocker/events/adapter/in/EventController.java
+++ b/src/main/java/com/jnulocker/events/adapter/in/EventController.java
@@ -41,6 +41,7 @@ public class EventController implements EventApi {
         return ResponseEntity.ok(eventQuery.getAllEvents(pageable));
     }
 
+    @Override
     @GetMapping("/me")
     public ResponseEntity<List<MyEventResponse>> getMyEvents() {
         return ResponseEntity.ok(eventQuery.getMyEvents());

--- a/src/main/java/com/jnulocker/events/adapter/in/EventController.java
+++ b/src/main/java/com/jnulocker/events/adapter/in/EventController.java
@@ -8,6 +8,7 @@ import com.jnulocker.events.application.port.in.request.PublishEventRequest;
 import com.jnulocker.events.application.port.in.response.EventCustomPage;
 import com.jnulocker.events.application.port.in.response.EventPageable;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
+import com.jnulocker.events.application.port.in.response.MyEventResponse;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +39,11 @@ public class EventController implements EventApi {
             @Valid @ParameterObject EventPageable eventPageable) {
         Pageable pageable = eventPageable.toPageable();
         return ResponseEntity.ok(eventQuery.getAllEvents(pageable));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<List<MyEventResponse>> getMyEvents() {
+        return ResponseEntity.ok(eventQuery.getMyEvents());
     }
 
     @Override

--- a/src/main/java/com/jnulocker/events/adapter/in/docs/EventApi.java
+++ b/src/main/java/com/jnulocker/events/adapter/in/docs/EventApi.java
@@ -6,6 +6,7 @@ import com.jnulocker.events.application.port.in.request.PublishEventRequest;
 import com.jnulocker.events.application.port.in.response.EventCustomPage;
 import com.jnulocker.events.application.port.in.response.EventPageable;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
+import com.jnulocker.events.application.port.in.response.MyEventResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -32,6 +33,22 @@ public interface EventApi {
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = EventCustomPage.class)))
     ResponseEntity<EventCustomPage> getEvents(@Valid @ParameterObject EventPageable eventPageable);
+
+    @ApiExceptionExamples(GetMyEventsExceptionDocs.class)
+    @Operation(summary = "자신의 소속학과 대상 이벤트 목록 조회", description = "자신의 소속학과가 참여한 이벤트 목록을 조회합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "자신의 소속학과 대상 이벤트 목록 조회 성공",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            array =
+                                    @ArraySchema(
+                                            schema =
+                                                    @Schema(
+                                                            implementation =
+                                                                    MyEventResponse.class))))
+    ResponseEntity<List<MyEventResponse>> getMyEvents();
 
     @ApiExceptionExamples(CreateEventExceptionDocs.class)
     @Operation(

--- a/src/main/java/com/jnulocker/events/adapter/in/docs/GetMyEventsExceptionDocs.java
+++ b/src/main/java/com/jnulocker/events/adapter/in/docs/GetMyEventsExceptionDocs.java
@@ -1,0 +1,17 @@
+package com.jnulocker.events.adapter.in.docs;
+
+import com.jnulocker.common.exception.BusinessException;
+import com.jnulocker.common.swagger.ExceptionDoc;
+import com.jnulocker.common.swagger.ExplainError;
+import com.jnulocker.common.swagger.SwaggerExceptionDoc;
+import com.jnulocker.member.exception.MemberNotFoundException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@ExceptionDoc
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetMyEventsExceptionDocs implements SwaggerExceptionDoc {
+
+    @ExplainError("회원 정보를 조회할 수 없을 때 발생하는 예외입니다")
+    public static final BusinessException 회원_정보를_조회할_수_없을_때 = MemberNotFoundException.EXCEPTION;
+}

--- a/src/main/java/com/jnulocker/events/adapter/out/EventPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/EventPersistenceAdapter.java
@@ -40,7 +40,7 @@ public class EventPersistenceAdapter implements EventLoadPort, EventRecordPort {
 
     @Override
     public List<Event> getEventsByParticipationDepartment(Department department) {
-        return eventRepository.findAllByEventParticipations_Department(department);
+        return eventRepository.findAllByPublishTrueAndEventParticipations_Department(department);
     }
 
     @Override

--- a/src/main/java/com/jnulocker/events/adapter/out/EventPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/EventPersistenceAdapter.java
@@ -7,6 +7,7 @@ import com.jnulocker.events.domain.Event;
 import com.jnulocker.events.domain.EventParticipation;
 import com.jnulocker.events.domain.Floor;
 import com.jnulocker.events.domain.Locker;
+import com.jnulocker.organization.domain.Department;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +36,11 @@ public class EventPersistenceAdapter implements EventLoadPort, EventRecordPort {
     @Override
     public Page<Event> getAllEvents(Pageable pageable) {
         return eventRepository.findAll(pageable);
+    }
+
+    @Override
+    public List<Event> getEventsByParticipationDepartment(Department department) {
+        return eventRepository.findAllByEventParticipations_Department(department);
     }
 
     @Override

--- a/src/main/java/com/jnulocker/events/adapter/out/EventRepository.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/EventRepository.java
@@ -9,5 +9,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface EventRepository extends JpaRepository<Event, Long> {
 
     @EntityGraph(attributePaths = {"department"})
-    List<Event> findAllByEventParticipations_Department(Department department);
+    List<Event> findAllByPublishTrueAndEventParticipations_Department(Department department);
 }

--- a/src/main/java/com/jnulocker/events/adapter/out/EventRepository.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/EventRepository.java
@@ -1,6 +1,13 @@
 package com.jnulocker.events.adapter.out;
 
 import com.jnulocker.events.domain.Event;
+import com.jnulocker.organization.domain.Department;
+import java.util.List;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface EventRepository extends JpaRepository<Event, Long> {}
+public interface EventRepository extends JpaRepository<Event, Long> {
+
+    @EntityGraph(attributePaths = {"department"})
+    List<Event> findAllByEventParticipations_Department(Department department);
+}

--- a/src/main/java/com/jnulocker/events/adapter/out/LockerPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/LockerPersistenceAdapter.java
@@ -2,6 +2,7 @@ package com.jnulocker.events.adapter.out;
 
 import com.jnulocker.common.annotation.PersistenceAdapter;
 import com.jnulocker.events.application.port.out.LockerLoadPort;
+import com.jnulocker.events.domain.Event;
 import com.jnulocker.events.domain.Locker;
 import java.util.List;
 import java.util.Optional;
@@ -21,5 +22,10 @@ public class LockerPersistenceAdapter implements LockerLoadPort {
     @Override
     public List<Locker> getLockersByFloorId(Long floorId) {
         return lockerRepository.findAllByFloorId(floorId);
+    }
+
+    @Override
+    public Integer getAvailableLockerCountOfEvent(Event event) {
+        return lockerRepository.countAvailableLockersByAvailableTrueAndFloor_Event(event);
     }
 }

--- a/src/main/java/com/jnulocker/events/adapter/out/LockerRepository.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/LockerRepository.java
@@ -15,4 +15,6 @@ public interface LockerRepository extends JpaRepository<Locker, Long> {
     Optional<Locker> findByIdWithFloorAndEvent(Long lockerId);
 
     void deleteAllByFloor_Event(Event event);
+
+    Integer countAvailableLockersByAvailableTrueAndFloor_Event(Event event);
 }

--- a/src/main/java/com/jnulocker/events/application/port/in/EventQuery.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/EventQuery.java
@@ -2,6 +2,7 @@ package com.jnulocker.events.application.port.in;
 
 import com.jnulocker.events.application.port.in.response.EventCustomPage;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
+import com.jnulocker.events.application.port.in.response.MyEventResponse;
 import com.jnulocker.events.domain.Event;
 import com.jnulocker.events.domain.Locker;
 import java.util.List;
@@ -10,6 +11,8 @@ import org.springframework.data.domain.Pageable;
 public interface EventQuery {
 
     Event getByIdOrThrow(Long eventId);
+
+    List<MyEventResponse> getMyEvents();
 
     EventCustomPage getAllEvents(Pageable pageable);
 

--- a/src/main/java/com/jnulocker/events/application/port/in/response/MyEventResponse.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/response/MyEventResponse.java
@@ -1,0 +1,23 @@
+package com.jnulocker.events.application.port.in.response;
+
+import com.jnulocker.events.domain.Event;
+import java.time.LocalDateTime;
+
+public record MyEventResponse(
+        Long eventId,
+        String title,
+        String departmentNickname,
+        LocalDateTime startAt,
+        LocalDateTime endAt,
+        Integer availableLockerCount) {
+
+    public static MyEventResponse of(Event event, Integer availableLockerCount) {
+        return new MyEventResponse(
+                event.getId(),
+                event.getTitle(),
+                event.getDepartment().getNickname(),
+                event.getEventSchedule().getStartAt(),
+                event.getEventSchedule().getEndAt(),
+                availableLockerCount);
+    }
+}

--- a/src/main/java/com/jnulocker/events/application/port/in/response/MyEventResponse.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/response/MyEventResponse.java
@@ -1,15 +1,16 @@
 package com.jnulocker.events.application.port.in.response;
 
 import com.jnulocker.events.domain.Event;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
 public record MyEventResponse(
-        Long eventId,
-        String title,
-        String departmentNickname,
-        LocalDateTime startAt,
-        LocalDateTime endAt,
-        Integer availableLockerCount) {
+        @Schema(description = "이벤트 ID", example = "1") Long eventId,
+        @Schema(description = "이벤트 제목", example = "전자컴퓨터공학부 2025-2 사물함 신청") String title,
+        @Schema(description = "이벤트 주최 조직이름", example = "전자컴퓨터공학부 학생회") String departmentNickname,
+        @Schema(description = "이벤트 시작 시간", example = "2025-08-01T15:00:00") LocalDateTime startAt,
+        @Schema(description = "이벤트 종료 시간", example = "2025-08-01T16:00:00") LocalDateTime endAt,
+        @Schema(description = "신청 가능한 사물함 개수", example = "5") Integer availableLockerCount) {
 
     public static MyEventResponse of(Event event, Integer availableLockerCount) {
         return new MyEventResponse(

--- a/src/main/java/com/jnulocker/events/application/port/out/EventLoadPort.java
+++ b/src/main/java/com/jnulocker/events/application/port/out/EventLoadPort.java
@@ -1,6 +1,8 @@
 package com.jnulocker.events.application.port.out;
 
 import com.jnulocker.events.domain.Event;
+import com.jnulocker.organization.domain.Department;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,4 +14,6 @@ public interface EventLoadPort {
     Optional<Event> getById(Long eventId);
 
     Page<Event> getAllEvents(Pageable pageable);
+
+    List<Event> getEventsByParticipationDepartment(Department department);
 }

--- a/src/main/java/com/jnulocker/events/application/port/out/LockerLoadPort.java
+++ b/src/main/java/com/jnulocker/events/application/port/out/LockerLoadPort.java
@@ -1,5 +1,6 @@
 package com.jnulocker.events.application.port.out;
 
+import com.jnulocker.events.domain.Event;
 import com.jnulocker.events.domain.Locker;
 import java.util.List;
 import java.util.Optional;
@@ -9,4 +10,6 @@ public interface LockerLoadPort {
     Optional<Locker> getById(Long lockerId);
 
     List<Locker> getLockersByFloorId(Long floorId);
+
+    Integer getAvailableLockerCountOfEvent(Event event);
 }

--- a/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
+++ b/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
@@ -1,9 +1,11 @@
 package com.jnulocker.events.application.service;
 
+import com.jnulocker.auth.security.SecurityUtils;
 import com.jnulocker.events.application.port.in.EventQuery;
 import com.jnulocker.events.application.port.in.response.EventCustomPage;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
 import com.jnulocker.events.application.port.in.response.LockerResponse;
+import com.jnulocker.events.application.port.in.response.MyEventResponse;
 import com.jnulocker.events.application.port.out.EventLoadPort;
 import com.jnulocker.events.application.port.out.FloorLoadPort;
 import com.jnulocker.events.application.port.out.LockerLoadPort;
@@ -12,6 +14,8 @@ import com.jnulocker.events.domain.Floor;
 import com.jnulocker.events.domain.Locker;
 import com.jnulocker.events.exception.EventNotFoundException;
 import com.jnulocker.events.exception.LockerNotFoundException;
+import com.jnulocker.member.application.port.in.MemberQuery;
+import com.jnulocker.member.domain.Member;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -25,6 +29,7 @@ public class EventQueryService implements EventQuery {
     private final EventLoadPort eventLoadPort;
     private final FloorLoadPort floorLoadPort;
     private final LockerLoadPort lockerLoadPort;
+    private final MemberQuery memberQuery;
 
     @Override
     public Event getByIdOrThrow(Long eventId) {
@@ -36,6 +41,26 @@ public class EventQueryService implements EventQuery {
         // TODO: MANAGER가 조회하는 경우 자신이 소속된 조직의 이벤트만 조회할 수 있도록 수정
         Page<Event> events = eventLoadPort.getAllEvents(pageable);
         return EventCustomPage.from(events);
+    }
+
+    @Override
+    public List<MyEventResponse> getMyEvents() {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        Member member = memberQuery.findByIdOrThrow(memberId);
+
+        // 사용자의 소속학과가 참여하는 이벤트 조회
+        List<Event> events =
+                eventLoadPort.getEventsByParticipationDepartment(member.getDepartment());
+
+        // 각 이벤트에 대해 사용 가능한 사물함 개수 조회
+        return events.stream()
+                .map(
+                        event -> {
+                            Integer availableLockerCount =
+                                    lockerLoadPort.getAvailableLockerCountOfEvent(event);
+                            return MyEventResponse.of(event, availableLockerCount);
+                        })
+                .toList();
     }
 
     @Override

--- a/src/main/java/com/jnulocker/events/domain/Event.java
+++ b/src/main/java/com/jnulocker/events/domain/Event.java
@@ -6,6 +6,7 @@ import com.jnulocker.events.exception.OnlyManagerCanDeleteException;
 import com.jnulocker.events.exception.OpenEventCannotBeDeletedException;
 import com.jnulocker.member.domain.Role;
 import com.jnulocker.organization.domain.Department;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -17,7 +18,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -41,6 +45,9 @@ public class Event extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "department_id")
     private Department department;
+
+    @OneToMany(mappedBy = "event", orphanRemoval = true, cascade = CascadeType.ALL)
+    private final List<EventParticipation> eventParticipations = new ArrayList<>();
 
     @Embedded private EventSchedule eventSchedule;
 

--- a/src/main/java/com/jnulocker/member/adapter/in/docs/GetMemberInfoExceptionDocs.java
+++ b/src/main/java/com/jnulocker/member/adapter/in/docs/GetMemberInfoExceptionDocs.java
@@ -1,0 +1,17 @@
+package com.jnulocker.member.adapter.in.docs;
+
+import com.jnulocker.common.exception.BusinessException;
+import com.jnulocker.common.swagger.ExceptionDoc;
+import com.jnulocker.common.swagger.ExplainError;
+import com.jnulocker.common.swagger.SwaggerExceptionDoc;
+import com.jnulocker.member.exception.MemberNotFoundException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@ExceptionDoc
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetMemberInfoExceptionDocs implements SwaggerExceptionDoc {
+
+    @ExplainError("회원 정보를 조회할 수 없을 때 발생하는 예외입니다")
+    public static final BusinessException 회원_정보를_조회할_수_없을_때 = MemberNotFoundException.EXCEPTION;
+}

--- a/src/main/java/com/jnulocker/member/adapter/in/docs/MemberApi.java
+++ b/src/main/java/com/jnulocker/member/adapter/in/docs/MemberApi.java
@@ -1,5 +1,6 @@
 package com.jnulocker.member.adapter.in.docs;
 
+import com.jnulocker.common.swagger.ApiExceptionExamples;
 import com.jnulocker.member.application.port.in.response.MemberInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -12,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 @Tag(name = "회원 API", description = "회원 관련 API")
 public interface MemberApi {
 
+    @ApiExceptionExamples(GetMemberInfoExceptionDocs.class)
     @Operation(summary = "회원 정보 조회", description = "회원 정보를 조회합니다.")
     @ApiResponse(
             responseCode = "200",

--- a/src/test/java/com/jnulocker/auth/utils/AuthTestUtil.java
+++ b/src/test/java/com/jnulocker/auth/utils/AuthTestUtil.java
@@ -15,6 +15,10 @@ public class AuthTestUtil {
 
     @Autowired private TokenProvider tokenProvider;
 
+    public String generateAccessTokenWithMember(Member member) {
+        return tokenProvider.generateAccessToken(member.getId(), member.getRole());
+    }
+
     public String generateAccessToken(Role role) {
         Member member = memberTestUtil.createMemberFromRole(role);
         return tokenProvider.generateAccessToken(member.getId(), member.getRole());

--- a/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
@@ -10,10 +10,12 @@ import com.jnulocker.events.application.port.in.request.CreateEventRequest;
 import com.jnulocker.events.application.port.in.request.PublishEventRequest;
 import com.jnulocker.events.application.port.in.response.EventCustomPage;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
+import com.jnulocker.events.application.port.in.response.MyEventResponse;
 import com.jnulocker.events.domain.Event;
 import com.jnulocker.events.domain.EventStatus;
 import com.jnulocker.events.exception.EventErrorCode;
 import com.jnulocker.events.utils.EventTestUtil;
+import com.jnulocker.member.domain.Member;
 import com.jnulocker.member.domain.Role;
 import com.jnulocker.member.utils.MemberTestUtil;
 import com.jnulocker.organization.domain.Department;
@@ -208,7 +210,10 @@ public class EventControllerIntegrationTest {
 
     private void createEvent() {
         Department department = organizationUtil.createCouncilDepartment();
+        createEventWithDepartment(department);
+    }
 
+    private void createEventWithDepartment(Department department) {
         CreateEventRequest request =
                 createEventRequestBuilder()
                         .withParticipationDepartmentIds(List.of(department.getId()))
@@ -364,6 +369,41 @@ public class EventControllerIntegrationTest {
                 .body(request)
                 .when()
                 .put(EVENT_URL + "/{event-id}/publish", eventId)
+                .then()
+                .log()
+                .all();
+    }
+
+    @Test
+    void 자신이_속한_학과가_참여하는_이벤트를_조회할_수_있다() {
+        // given
+        Department department = organizationUtil.createCouncilDepartment();
+        Member member = memberTestUtil.createMemberFromRoleWithDepartment(Role.USER, department);
+
+        // 이벤트 생성
+        createEventWithDepartment(member.getDepartment());
+
+        // when
+        accessToken = authTestUtil.generateAccessTokenWithMember(member);
+        List<MyEventResponse> myEvents =
+                getMyEvents(accessToken)
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .jsonPath()
+                        .getList(".", MyEventResponse.class);
+
+        MyEventResponse myEventResponse = myEvents.getFirst();
+
+        // then
+        assertThat(myEvents).hasSize(1);
+        assertThat(myEventResponse.availableLockerCount()).isEqualTo(20);
+    }
+
+    public static ValidatableResponse getMyEvents(String accessToken) {
+        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
+                .when()
+                .get(EVENT_URL + "/me")
                 .then()
                 .log()
                 .all();

--- a/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
@@ -106,29 +106,6 @@ public class EventControllerIntegrationTest {
         assertThat(eventCustomPage.last()).isEqualTo(expectedLast);
     }
 
-    private int calculateExpectedSize(int totalCount, int pageSize, int page) {
-        int startIndex = page * pageSize;
-        if (startIndex >= totalCount) {
-            return 0; // 페이지가 범위를 벗어나면 빈 리스트
-        }
-        int remainingItems = totalCount - startIndex;
-        return Math.min(remainingItems, pageSize);
-    }
-
-    public static ValidatableResponse getEvents(int page, int size, String accessToken) {
-        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
-                .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
-                .queryParam("page", page)
-                .queryParam("size", size)
-                .queryParam("direction", "DESC")
-                .queryParam("sort", "createdAt")
-                .when()
-                .get(EVENT_URL)
-                .then()
-                .log()
-                .all();
-    }
-
     @ParameterizedTest(name = "층별 사물함 수: {0}")
     @MethodSource("provideLockersPerFloor")
     void 이벤트에_해당하는_층과_사물함_목록을_조회할_수_있다(List<Integer> lockersPerFloor) {
@@ -157,14 +134,6 @@ public class EventControllerIntegrationTest {
                 .containsExactlyElementsOf(lockersPerFloor);
     }
 
-    // 파라미터 제공 메서드
-    private static Stream<Arguments> provideLockersPerFloor() {
-        return Stream.of(
-                Arguments.of(List.of(2, 2)), // 첫 번째 테스트 케이스: 층별 2개 사물함
-                Arguments.of(List.of(3, 5)) // 두 번째 테스트 케이스: 1층 3개, 2층 5개
-                );
-    }
-
     @Test
     void 존재하지_않는_이벤트_ID로_조회하면_Event_Not_Found_에러_응답을_받는다() {
         // given
@@ -179,16 +148,6 @@ public class EventControllerIntegrationTest {
 
         // then
         assertThat(errorResponse.message()).isEqualTo(EventErrorCode.EVENT_NOT_FOUND.getMessage());
-    }
-
-    public static ValidatableResponse getEventLockers(Long eventId, String accessToken) {
-        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
-                .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
-                .when()
-                .get(EVENT_URL + "/{event-id}/lockers", eventId)
-                .then()
-                .log()
-                .all();
     }
 
     @Test
@@ -206,26 +165,6 @@ public class EventControllerIntegrationTest {
 
         // 생성된 이벤트가 목록에 포함되어 있는지 확인
         assertThat(eventCustomPage.content()).hasSize(1);
-    }
-
-    private void createEvent() {
-        Department department = organizationUtil.createCouncilDepartment();
-        createEventWithDepartment(department);
-    }
-
-    private void createEventWithDepartment(Department department) {
-        CreateEventRequest request =
-                createEventRequestBuilder()
-                        .withParticipationDepartmentIds(List.of(department.getId()))
-                        .build();
-
-        given().contentType(MediaType.APPLICATION_JSON_VALUE)
-                .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
-                .body(request)
-                .when()
-                .post(EVENT_URL)
-                .then()
-                .statusCode(HttpStatus.CREATED.value());
     }
 
     @Test
@@ -248,26 +187,6 @@ public class EventControllerIntegrationTest {
                         .as(ErrorResponse.class);
 
         assertThat(errorResponse.message()).isEqualTo(EventErrorCode.EVENT_NOT_FOUND.getMessage());
-    }
-
-    private Long getLastEventId() {
-        return getEvents(0, 10, accessToken)
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .as(EventCustomPage.class)
-                .content()
-                .getLast()
-                .id();
-    }
-
-    private ValidatableResponse deleteEvent(Long eventId) {
-        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
-                .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
-                .when()
-                .delete(EVENT_URL + "/{event-id}", eventId)
-                .then()
-                .log()
-                .all();
     }
 
     @Test
@@ -363,17 +282,6 @@ public class EventControllerIntegrationTest {
         assertThat(errorResponse.message()).isEqualTo(EventErrorCode.EVENT_NOT_FOUND.getMessage());
     }
 
-    private ValidatableResponse publishEvent(Long eventId, PublishEventRequest request) {
-        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
-                .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
-                .body(request)
-                .when()
-                .put(EVENT_URL + "/{event-id}/publish", eventId)
-                .then()
-                .log()
-                .all();
-    }
-
     @Test
     void 자신이_속한_학과가_참여하는_이벤트를_조회할_수_있다() {
         // given
@@ -425,11 +333,107 @@ public class EventControllerIntegrationTest {
         assertThat(myEvents).isEmpty();
     }
 
+    // 파라미터 제공 메서드
+    private static Stream<Arguments> provideLockersPerFloor() {
+        return Stream.of(
+                Arguments.of(List.of(2, 2)), // 첫 번째 테스트 케이스: 층별 2개 사물함
+                Arguments.of(List.of(3, 5)) // 두 번째 테스트 케이스: 1층 3개, 2층 5개
+                );
+    }
+
+    // 이벤트 검색 메서드들
+    public static ValidatableResponse getEventLockers(Long eventId, String accessToken) {
+        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
+                .when()
+                .get(EVENT_URL + "/{event-id}/lockers", eventId)
+                .then()
+                .log()
+                .all();
+    }
+
+    public static ValidatableResponse getEvents(int page, int size, String accessToken) {
+        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
+                .queryParam("page", page)
+                .queryParam("size", size)
+                .queryParam("direction", "DESC")
+                .queryParam("sort", "createdAt")
+                .when()
+                .get(EVENT_URL)
+                .then()
+                .log()
+                .all();
+    }
+
     public static ValidatableResponse getMyEvents(String accessToken) {
         return given().contentType(MediaType.APPLICATION_JSON_VALUE)
                 .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
                 .when()
                 .get(EVENT_URL + "/me")
+                .then()
+                .log()
+                .all();
+    }
+
+    // 이벤트 생성 메서드들
+    private void createEvent() {
+        Department department = organizationUtil.createCouncilDepartment();
+        createEventWithDepartment(department);
+    }
+
+    private void createEventWithDepartment(Department department) {
+        CreateEventRequest request =
+                createEventRequestBuilder()
+                        .withParticipationDepartmentIds(List.of(department.getId()))
+                        .build();
+
+        given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
+                .body(request)
+                .when()
+                .post(EVENT_URL)
+                .then()
+                .statusCode(HttpStatus.CREATED.value());
+    }
+
+    // 유틸 메서드들
+    private int calculateExpectedSize(int totalCount, int pageSize, int page) {
+        int startIndex = page * pageSize;
+        if (startIndex >= totalCount) {
+            return 0; // 페이지가 범위를 벗어나면 빈 리스트
+        }
+        int remainingItems = totalCount - startIndex;
+        return Math.min(remainingItems, pageSize);
+    }
+
+    private Long getLastEventId() {
+        return getEvents(0, 10, accessToken)
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(EventCustomPage.class)
+                .content()
+                .getLast()
+                .id();
+    }
+
+    // 이벤트 수정 메서드들
+    private ValidatableResponse deleteEvent(Long eventId) {
+        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
+                .when()
+                .delete(EVENT_URL + "/{event-id}", eventId)
+                .then()
+                .log()
+                .all();
+    }
+
+    private ValidatableResponse publishEvent(Long eventId, PublishEventRequest request) {
+        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
+                .body(request)
+                .when()
+                .put(EVENT_URL + "/{event-id}/publish", eventId)
                 .then()
                 .log()
                 .all();

--- a/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
@@ -380,8 +380,10 @@ public class EventControllerIntegrationTest {
         Department department = organizationUtil.createCouncilDepartment();
         Member member = memberTestUtil.createMemberFromRoleWithDepartment(Role.USER, department);
 
-        // 이벤트 생성
-        createEventWithDepartment(member.getDepartment());
+        // 이벤트 생성: 짝수번 사물함은 사용 가능, 홀수번 사물함은 사용 불가능
+        // 15개 중 가능한 사물함 수는 2, 4, 6, 8, 10, 12, 14 (총 7개)
+        eventTestUtil.createEventWithParticipationDepartment(
+                List.of(5, 10), department, EventStatus.OPEN, true);
 
         // when
         accessToken = authTestUtil.generateAccessTokenWithMember(member);
@@ -396,7 +398,31 @@ public class EventControllerIntegrationTest {
 
         // then
         assertThat(myEvents).hasSize(1);
-        assertThat(myEventResponse.availableLockerCount()).isEqualTo(20);
+        assertThat(myEventResponse.availableLockerCount()).isEqualTo(7);
+    }
+
+    @Test
+    void publish되지_않은_이벤트는_조회할_수_없다() {
+        // given
+        Department department = organizationUtil.createCouncilDepartment();
+        Member member = memberTestUtil.createMemberFromRoleWithDepartment(Role.USER, department);
+
+        // 이벤트 생성: 짝수번 사물함은 사용 가능, 홀수번 사물함은 사용 불가능
+        // 15개 중 가능한 사물함 수는 2, 4, 6, 8, 10, 12, 14 (총 7개)
+        eventTestUtil.createEventWithParticipationDepartment(
+                List.of(5, 10), department, EventStatus.OPEN, false);
+
+        // when
+        accessToken = authTestUtil.generateAccessTokenWithMember(member);
+        List<MyEventResponse> myEvents =
+                getMyEvents(accessToken)
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .jsonPath()
+                        .getList(".", MyEventResponse.class);
+
+        // then
+        assertThat(myEvents).isEmpty();
     }
 
     public static ValidatableResponse getMyEvents(String accessToken) {

--- a/src/test/java/com/jnulocker/events/utils/EventTestUtil.java
+++ b/src/test/java/com/jnulocker/events/utils/EventTestUtil.java
@@ -19,7 +19,6 @@ import com.jnulocker.organization.domain.Department;
 import com.jnulocker.organization.domain.Organization;
 import java.util.ArrayList;
 import java.util.List;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -56,7 +55,8 @@ public class EventTestUtil {
         return savedEvent;
     }
 
-    private Event createAndSaveEvent(Department department, EventStatus eventStatus, boolean publish) {
+    private Event createAndSaveEvent(
+            Department department, EventStatus eventStatus, boolean publish) {
         Event event =
                 eventBuilder()
                         .withDepartment(department)

--- a/src/test/java/com/jnulocker/events/utils/EventTestUtil.java
+++ b/src/test/java/com/jnulocker/events/utils/EventTestUtil.java
@@ -9,6 +9,7 @@ import com.jnulocker.events.adapter.out.EventRepository;
 import com.jnulocker.events.adapter.out.FloorRepository;
 import com.jnulocker.events.adapter.out.LockerRepository;
 import com.jnulocker.events.domain.Event;
+import com.jnulocker.events.domain.EventParticipation;
 import com.jnulocker.events.domain.EventStatus;
 import com.jnulocker.events.domain.Floor;
 import com.jnulocker.events.domain.Locker;
@@ -35,6 +36,29 @@ public class EventTestUtil {
     @Autowired private FloorRepository floorRepository;
 
     @Autowired private LockerRepository lockerRepository;
+
+    public Event createEventWithParticipationDepartment(
+            List<Integer> lockersPerFloor,
+            Department department,
+            EventStatus eventStatus,
+            boolean publish) {
+
+        // 이벤트 생성 및 저장
+        Event event =
+                eventBuilder()
+                        .withDepartment(department)
+                        .withEventStatus(eventStatus)
+                        .withPublish(publish)
+                        .build();
+        Event savedEvent = eventRepository.save(event);
+
+        EventParticipation eventParticipation = EventParticipation.create(savedEvent, department);
+        eventParticipationRepository.save(eventParticipation);
+
+        // 층 생성 및 저장
+        createFloorsWithEvent(lockersPerFloor, savedEvent);
+        return savedEvent;
+    }
 
     public Event createEventWithFloorAndLockers(
             List<Integer> lockersPerFloor, EventStatus eventStatus, boolean publish) {

--- a/src/test/java/com/jnulocker/events/utils/EventTestUtil.java
+++ b/src/test/java/com/jnulocker/events/utils/EventTestUtil.java
@@ -19,6 +19,7 @@ import com.jnulocker.organization.domain.Department;
 import com.jnulocker.organization.domain.Organization;
 import java.util.ArrayList;
 import java.util.List;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -44,20 +45,25 @@ public class EventTestUtil {
             boolean publish) {
 
         // 이벤트 생성 및 저장
-        Event event =
-                eventBuilder()
-                        .withDepartment(department)
-                        .withEventStatus(eventStatus)
-                        .withPublish(publish)
-                        .build();
-        Event savedEvent = eventRepository.save(event);
+        Event savedEvent = createAndSaveEvent(department, eventStatus, publish);
 
+        // 이벤트 참여 학과 정보 생성 및 저장
         EventParticipation eventParticipation = EventParticipation.create(savedEvent, department);
         eventParticipationRepository.save(eventParticipation);
 
         // 층 생성 및 저장
         createFloorsWithEvent(lockersPerFloor, savedEvent);
         return savedEvent;
+    }
+
+    private Event createAndSaveEvent(Department department, EventStatus eventStatus, boolean publish) {
+        Event event =
+                eventBuilder()
+                        .withDepartment(department)
+                        .withEventStatus(eventStatus)
+                        .withPublish(publish)
+                        .build();
+        return eventRepository.save(event);
     }
 
     public Event createEventWithFloorAndLockers(
@@ -71,13 +77,7 @@ public class EventTestUtil {
         Department savedDepartment = departmentRepository.save(department);
 
         // 이벤트 생성 및 저장
-        Event event =
-                eventBuilder()
-                        .withDepartment(savedDepartment)
-                        .withEventStatus(eventStatus)
-                        .withPublish(publish)
-                        .build();
-        Event savedEvent = eventRepository.save(event);
+        Event savedEvent = createAndSaveEvent(savedDepartment, eventStatus, publish);
 
         // 층 생성 및 저장
         createFloorsWithEvent(lockersPerFloor, savedEvent);

--- a/src/test/java/com/jnulocker/member/adapter/in/MemberControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/member/adapter/in/MemberControllerIntegrationTest.java
@@ -57,9 +57,7 @@ public class MemberControllerIntegrationTest {
     void USER_회원_정보를_조회할_수_있다() {
         // given
         Member expectedMember = memberTestUtil.createUser();
-        String accessToken =
-                authTestUtil.generateAccessTokenFromMemberId(
-                        expectedMember.getId(), expectedMember.getRole());
+        String accessToken = authTestUtil.generateAccessTokenWithMember(expectedMember);
 
         // when
         MemberInfoResponse memberInfoResponse =
@@ -85,9 +83,7 @@ public class MemberControllerIntegrationTest {
         Department council = organizationUtil.createCouncilDepartment();
         Member expectedMember =
                 memberTestUtil.createMemberFromRoleWithDepartment(Role.MANAGER, council);
-        String accessToken =
-                authTestUtil.generateAccessTokenFromMemberId(
-                        expectedMember.getId(), expectedMember.getRole());
+        String accessToken = authTestUtil.generateAccessTokenWithMember(expectedMember);
 
         // when
         MemberInfoResponse memberInfoResponse =

--- a/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.jnulocker.registration.adapter.in;
 
 import static com.jnulocker.events.adapter.in.EventControllerIntegrationTest.getEventLockers;
+import static com.jnulocker.events.adapter.in.EventControllerIntegrationTest.getMyEvents;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -8,12 +9,16 @@ import com.jnulocker.auth.jwt.exception.JwtErrorCode;
 import com.jnulocker.auth.utils.AuthTestUtil;
 import com.jnulocker.common.exception.ErrorResponse;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
+import com.jnulocker.events.application.port.in.response.MyEventResponse;
 import com.jnulocker.events.domain.Event;
 import com.jnulocker.events.domain.EventStatus;
 import com.jnulocker.events.exception.EventErrorCode;
 import com.jnulocker.events.utils.EventTestUtil;
+import com.jnulocker.member.domain.Member;
 import com.jnulocker.member.domain.Role;
 import com.jnulocker.member.utils.MemberTestUtil;
+import com.jnulocker.organization.domain.Department;
+import com.jnulocker.organization.utils.OrganizationUtil;
 import com.jnulocker.registration.application.port.in.request.RegisterForEventRequest;
 import com.jnulocker.registration.application.port.in.response.RegistrationCustomPage;
 import com.jnulocker.registration.application.port.in.response.RegistrationListItem;
@@ -54,6 +59,8 @@ class RegistrationControllerIntegrationTest {
     @Autowired private MemberTestUtil memberTestUtil;
 
     @Autowired private AuthTestUtil authTestUtil;
+
+    @Autowired private OrganizationUtil organizationUtil;
 
     @Autowired private RegistrationTestUtil registrationTestUtil;
 
@@ -362,6 +369,47 @@ class RegistrationControllerIntegrationTest {
                         .as(ErrorResponse.class);
 
         assertThat(errorResponse.message()).isEqualTo(EventErrorCode.EVENT_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 신청한_이벤트는_잔여여석이_1개_줄어든다() {
+        // given
+        Department department = organizationUtil.createCouncilDepartment();
+        Member member = memberTestUtil.createMemberFromRoleWithDepartment(Role.USER, department);
+
+        Event event =
+                eventTestUtil.createEventWithParticipationDepartment(
+                        List.of(5, 10), department, EventStatus.OPEN, true);
+        RegisterForEventRequest request = createRequestForAvailableLocker(event);
+
+        // 신청 전 조회
+        List<MyEventResponse> myEventsBeforeRegistration =
+                getMyEvents(authTestUtil.generateAccessTokenWithMember(member))
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .jsonPath()
+                        .getList(".", MyEventResponse.class);
+
+        Integer availableLockerCountBefore =
+                myEventsBeforeRegistration.getFirst().availableLockerCount();
+
+        registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
+
+        // when
+        accessToken = authTestUtil.generateAccessTokenWithMember(member);
+        List<MyEventResponse> myEventsAfterRegistration =
+                getMyEvents(accessToken)
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .jsonPath()
+                        .getList(".", MyEventResponse.class);
+
+        MyEventResponse myEventResponse = myEventsAfterRegistration.getFirst();
+
+        // then
+        assertThat(myEventsAfterRegistration).hasSize(1);
+        assertThat(myEventResponse.availableLockerCount())
+                .isEqualTo(availableLockerCountBefore - 1);
     }
 
     private ValidatableResponse getRegistrations(Long eventId) {


### PR DESCRIPTION
### 개요
close #74 

### 작업사항
- 사용자(USER)의 소속학과를 대상으로 한 사물함 이벤트 목록을 확인할 수 있는 API 구현

### 변경로직
- 사용자의 소속학과를 대상으로 한 이벤트 중 publish인 이벤트들 목록 반환
- 테스트코드 작성
- `SecurityConfig` 내부 불필요한 `authenticated()` 설정 제거

### 테스트 결과

  <img width="319" alt="image" src="https://github.com/user-attachments/assets/63cba107-c740-4ae1-8ca5-88ac284a1f1b" />

#### 추가된 테스트케이스

  <img width="329" alt="image" src="https://github.com/user-attachments/assets/ec1531af-7c79-47c1-91f2-fb4cfbdfde23" />
  <img width="331" alt="image" src="https://github.com/user-attachments/assets/b833b9f1-02a9-41c0-bbb5-dbdb0ac5dac3" />


### reference

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 사용자가 소속 학과가 참여하는 이벤트 목록을 조회할 수 있는 새로운 API 엔드포인트(`/v1/events/me`)가 추가되었습니다.
	- 각 이벤트별로 남은 사물함 수를 함께 확인할 수 있습니다.

- **버그 수정**
	- 일부 GET 엔드포인트에 대한 인증 요구가 제거되었습니다.

- **문서화**
	- 신규 엔드포인트 및 예외 상황에 대한 Swagger 문서가 추가되었습니다.

- **테스트**
	- 사용자의 학과별 이벤트 조회 및 이벤트 신청 시 사물함 잔여 수 감소에 대한 통합 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->