### PR TITLE
[FIX] 사물함 신청은 참여한 소속학과의 USER만 가능하도록 수정

### DIFF
--- a/src/main/java/com/jnulocker/config/SecurityConfig.java
+++ b/src/main/java/com/jnulocker/config/SecurityConfig.java
@@ -27,7 +27,7 @@ public class SecurityConfig {
 
     private final JwtFilter jwtFilter;
 
-    @Value(("${management.endpoints.web.base-path}"))
+    @Value("${management.endpoints.web.base-path}")
     private String actuatorBasePath;
 
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
@@ -76,6 +76,8 @@ public class SecurityConfig {
                                 .hasAuthority(Role.USER.getRole())
                                 .requestMatchers(HttpMethod.GET, "/v1/events/*/registrations")
                                 .hasAuthority(Role.MANAGER.getRole())
+                                .requestMatchers(HttpMethod.POST, "/v1/events/*/registrations")
+                                .hasAuthority(Role.USER.getRole())
                                 .requestMatchers(
                                         HttpMethod.POST, "/v1/events", "/v1/auth/managers/approve")
                                 .hasAuthority(Role.MANAGER.getRole())

--- a/src/main/java/com/jnulocker/events/domain/Event.java
+++ b/src/main/java/com/jnulocker/events/domain/Event.java
@@ -3,8 +3,8 @@ package com.jnulocker.events.domain;
 import com.jnulocker.common.persistence.BaseEntity;
 import com.jnulocker.events.exception.EventNotOpenException;
 import com.jnulocker.events.exception.OnlyManagerCanDeleteException;
+import com.jnulocker.events.exception.OnlyParticipationDepartmentCanRegisterException;
 import com.jnulocker.events.exception.OpenEventCannotBeDeletedException;
-import com.jnulocker.member.domain.Role;
 import com.jnulocker.organization.domain.Department;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -83,13 +83,27 @@ public class Event extends BaseEntity {
                 .build();
     }
 
-    public void validateRegistration(Role role) {
-        validatePublishStatus(role);
+    public void validateRegistration(Department department) {
+        validateParticipationDepartment(department);
+        validatePublishStatus();
         validateEventStatus();
     }
 
-    private void validatePublishStatus(Role role) {
-        if (Boolean.FALSE.equals(publish) && role != Role.MANAGER) {
+    private void validateParticipationDepartment(Department department) {
+        if (!isParticipationDepartment(department)) {
+            throw OnlyParticipationDepartmentCanRegisterException.EXCEPTION;
+        }
+    }
+
+    private boolean isParticipationDepartment(Department department) {
+        return eventParticipations.stream()
+                .anyMatch(
+                        eventParticipation ->
+                                eventParticipation.getDepartment().equals(department));
+    }
+
+    private void validatePublishStatus() {
+        if (Boolean.FALSE.equals(publish)) {
             throw EventNotOpenException.EXCEPTION;
         }
     }

--- a/src/main/java/com/jnulocker/events/domain/Locker.java
+++ b/src/main/java/com/jnulocker/events/domain/Locker.java
@@ -2,7 +2,6 @@ package com.jnulocker.events.domain;
 
 import com.jnulocker.common.persistence.BaseEntity;
 import com.jnulocker.events.exception.LockerUnavailableException;
-import com.jnulocker.member.domain.Role;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -41,9 +40,7 @@ public class Locker extends BaseEntity {
         return Locker.builder().floor(floor).code(code).available(available).build();
     }
 
-    public void validateRegistration(Role role) {
-        Event event = floor.getEvent();
-        event.validateRegistration(role);
+    public void validateRegistration() {
         checkAvailability();
     }
 

--- a/src/main/java/com/jnulocker/events/exception/EventErrorCode.java
+++ b/src/main/java/com/jnulocker/events/exception/EventErrorCode.java
@@ -15,6 +15,7 @@ public enum EventErrorCode implements ErrorCode {
     INVALID_LOCKER_FOR_EVENT("E005", HttpStatus.BAD_REQUEST, "이벤트에 해당하지 않는 사물함입니다"),
     ONLY_MANAGER_CAN_DELETE("E006", HttpStatus.FORBIDDEN, "이벤트 관리자만 삭제할 수 있습니다"),
     OPEN_EVENT_CAN_NOT_BE_DELETED("E007", HttpStatus.BAD_REQUEST, "진행중인 이벤트는 삭제할 수 없습니다"),
+    ONLY_PARTICIPATION_DEPARTMENT_CAN_REGISTER("E008", HttpStatus.BAD_REQUEST, "참여학과만 신청할 수 있습니다"),
     ;
 
     private final String code;

--- a/src/main/java/com/jnulocker/events/exception/OnlyParticipationDepartmentCanRegisterException.java
+++ b/src/main/java/com/jnulocker/events/exception/OnlyParticipationDepartmentCanRegisterException.java
@@ -1,0 +1,13 @@
+package com.jnulocker.events.exception;
+
+import com.jnulocker.common.exception.BusinessException;
+
+public class OnlyParticipationDepartmentCanRegisterException extends BusinessException {
+
+    public static final BusinessException EXCEPTION =
+            new OnlyParticipationDepartmentCanRegisterException();
+
+    private OnlyParticipationDepartmentCanRegisterException() {
+        super(EventErrorCode.ONLY_PARTICIPATION_DEPARTMENT_CAN_REGISTER);
+    }
+}

--- a/src/main/java/com/jnulocker/registration/adapter/in/docs/RegistrationForEventExceptionDocs.java
+++ b/src/main/java/com/jnulocker/registration/adapter/in/docs/RegistrationForEventExceptionDocs.java
@@ -9,6 +9,7 @@ import com.jnulocker.events.exception.EventNotOpenException;
 import com.jnulocker.events.exception.InvalidLockerForEventException;
 import com.jnulocker.events.exception.LockerNotFoundException;
 import com.jnulocker.events.exception.LockerUnavailableException;
+import com.jnulocker.events.exception.OnlyParticipationDepartmentCanRegisterException;
 import com.jnulocker.member.exception.MemberNotFoundException;
 import com.jnulocker.registration.exception.RegistrationAlreadyExistsException;
 import lombok.AccessLevel;
@@ -41,4 +42,8 @@ public class RegistrationForEventExceptionDocs implements SwaggerExceptionDoc {
 
     @ExplainError("사물함이 사용중(available == false)일 때 발생하는 예외입니다.")
     public static final BusinessException 사물함이_사용중일_때 = LockerUnavailableException.EXCEPTION;
+
+    @ExplainError("신청자의 소속학과가 이벤트 대상이 아닐 때 발생하는 예외입니다.")
+    public static final BusinessException 신청자의_소속학과가_이벤트_대상이_아닐_때 =
+            OnlyParticipationDepartmentCanRegisterException.EXCEPTION;
 }

--- a/src/main/java/com/jnulocker/registration/domain/Registration.java
+++ b/src/main/java/com/jnulocker/registration/domain/Registration.java
@@ -1,6 +1,7 @@
 package com.jnulocker.registration.domain;
 
 import com.jnulocker.common.persistence.BaseEntity;
+import com.jnulocker.events.domain.Event;
 import com.jnulocker.events.domain.Locker;
 import com.jnulocker.member.domain.Member;
 import jakarta.persistence.Column;
@@ -38,8 +39,12 @@ public class Registration extends BaseEntity {
     private Locker locker;
 
     public static Registration create(Member member, Locker locker) {
-        locker.validateRegistration(member.getRole());
+        Event event = locker.getFloor().getEvent();
+        event.validateRegistration(member.getDepartment());
+
+        locker.validateRegistration();
         locker.markAsUnavailable();
+
         return Registration.builder().member(member).locker(locker).build();
     }
 }

--- a/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
@@ -27,7 +27,7 @@ import com.jnulocker.member.exception.MemberErrorCode;
 import com.jnulocker.member.utils.MemberTestUtil;
 import com.jnulocker.organization.domain.Department;
 import com.jnulocker.organization.exception.DepartmentErrorCode;
-import com.jnulocker.organization.utils.OrganizationUtil;
+import com.jnulocker.organization.utils.OrganizationTestUtil;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import io.restassured.RestAssured;
@@ -69,7 +69,7 @@ class AuthControllerIntegrationTest {
 
     @Autowired private MemberTestUtil memberTestUtil;
 
-    @Autowired private OrganizationUtil organizationUtil;
+    @Autowired private OrganizationTestUtil organizationTestUtil;
 
     @Autowired private RedisUtil redisUtil;
 
@@ -97,7 +97,7 @@ class AuthControllerIntegrationTest {
     @Test
     void USER_회원가입을_할_수_있다() {
         // given
-        Department department = organizationUtil.createCouncilDepartment();
+        Department department = organizationTestUtil.createCouncilDepartment();
         UserSignupRequest request =
                 userSignupRequestBuilder().withDepartmentId(department.getId()).build();
 
@@ -128,7 +128,7 @@ class AuthControllerIntegrationTest {
     @Test
     void USER_동일메일로_회원가입하면_User_Already_Exist_에러_응답을_받는다() {
         // given
-        Department department = organizationUtil.createCouncilDepartment();
+        Department department = organizationTestUtil.createCouncilDepartment();
         UserSignupRequest request =
                 userSignupRequestBuilder().withDepartmentId(department.getId()).build();
         signupUser(request).statusCode(HttpStatus.CREATED.value());
@@ -148,7 +148,7 @@ class AuthControllerIntegrationTest {
     @Test
     void USER_회원가입_시_이메일_인증이_완료되지_않았으면_Email_Not_Verified_에러_응답을_받는다() {
         // given
-        Department department = organizationUtil.createCouncilDepartment();
+        Department department = organizationTestUtil.createCouncilDepartment();
         UserSignupRequest request =
                 userSignupRequestBuilder().withDepartmentId(department.getId()).build();
         redisUtil.deleteVerifiedData(request.email());
@@ -168,7 +168,7 @@ class AuthControllerIntegrationTest {
     @Test
     void MANAGER_회원가입을_할_수_있다() {
         // given
-        Department department = organizationUtil.createCouncilDepartment();
+        Department department = organizationTestUtil.createCouncilDepartment();
         ManagerSignupRequest request =
                 managerSignupRequestBuilder().withDepartmentId(department.getId()).build();
 
@@ -179,7 +179,7 @@ class AuthControllerIntegrationTest {
     @Test
     void MANAGER_학생회_회원가입_시_학번이_null이면_Student_Number_Required_에러_응답을_받는다() {
         // given
-        Department department = organizationUtil.createCouncilDepartment();
+        Department department = organizationTestUtil.createCouncilDepartment();
         ManagerSignupRequest request =
                 managerSignupRequestBuilder()
                         .withDepartmentId(department.getId())
@@ -201,7 +201,7 @@ class AuthControllerIntegrationTest {
     @Test
     void MANAGER_학생회_회원가입_시_학번이_입력되면_정상적으로_회원가입된다() {
         // given
-        Department department = organizationUtil.createCouncilDepartment();
+        Department department = organizationTestUtil.createCouncilDepartment();
         ManagerSignupRequest request =
                 managerSignupRequestBuilder()
                         .withDepartmentId(department.getId())
@@ -218,7 +218,7 @@ class AuthControllerIntegrationTest {
     @Test
     void MANAGER_자치회_회원가입_시_학번이_입력되지_않으면_정상적으로_회원가입된다() {
         // given
-        Department department = organizationUtil.createCommitteeDepartment();
+        Department department = organizationTestUtil.createCommitteeDepartment();
         ManagerSignupRequest request =
                 managerSignupRequestBuilder()
                         .withDepartmentId(department.getId())
@@ -255,7 +255,7 @@ class AuthControllerIntegrationTest {
     @Test
     void MANAGER_동일메일로_회원가입하면_User_Already_Exist_에러_응답을_받는다() {
         // given
-        Department department = organizationUtil.createCouncilDepartment();
+        Department department = organizationTestUtil.createCouncilDepartment();
         ManagerSignupRequest request =
                 managerSignupRequestBuilder().withDepartmentId(department.getId()).build();
         signupManager(request).statusCode(HttpStatus.CREATED.value());
@@ -275,7 +275,7 @@ class AuthControllerIntegrationTest {
     @Test
     void MANAGER_회원가입_시_이메일_인증이_완료되지_않았으면_Email_Not_Verified_에러_응답을_받는다() {
         // given
-        Department department = organizationUtil.createCouncilDepartment();
+        Department department = organizationTestUtil.createCouncilDepartment();
 
         ManagerSignupRequest request =
                 managerSignupRequestBuilder().withDepartmentId(department.getId()).build();
@@ -296,7 +296,7 @@ class AuthControllerIntegrationTest {
     @Test
     void 로그인_성공시_토큰을_반환한다() {
         // given
-        Department department = organizationUtil.createCouncilDepartment();
+        Department department = organizationTestUtil.createCouncilDepartment();
         UserSignupRequest signupRequest =
                 userSignupRequestBuilder().withDepartmentId(department.getId()).build();
         signupUser(signupRequest);
@@ -320,7 +320,7 @@ class AuthControllerIntegrationTest {
     @Test
     void 토큰_재발급_요청시_새로운_AccessToken을_받는다() {
         // given
-        Department department = organizationUtil.createCouncilDepartment();
+        Department department = organizationTestUtil.createCouncilDepartment();
         UserSignupRequest signupRequest =
                 userSignupRequestBuilder().withDepartmentId(department.getId()).build();
         signupUser(signupRequest);
@@ -423,7 +423,7 @@ class AuthControllerIntegrationTest {
     @Test
     void 올바르지_않은_이메일로_로그인하면_인증에_실패한다() {
         // given
-        Department department = organizationUtil.createCouncilDepartment();
+        Department department = organizationTestUtil.createCouncilDepartment();
         UserSignupRequest signupRequest =
                 userSignupRequestBuilder().withDepartmentId(department.getId()).build();
         signupUser(signupRequest);
@@ -445,7 +445,7 @@ class AuthControllerIntegrationTest {
     @Test
     void 올바르지_않은_비밀번호로_로그인하면_인증에_실패한다() {
         // given
-        Department department = organizationUtil.createCouncilDepartment();
+        Department department = organizationTestUtil.createCouncilDepartment();
         UserSignupRequest signupRequest =
                 userSignupRequestBuilder().withDepartmentId(department.getId()).build();
         signupUser(signupRequest);
@@ -479,7 +479,7 @@ class AuthControllerIntegrationTest {
     @Test
     void 이미_사용중인_이메일로_인증_요청_시_User_Already_Exist_에러_응답을_받는다() {
         // given
-        Department department = organizationUtil.createCouncilDepartment();
+        Department department = organizationTestUtil.createCouncilDepartment();
         UserSignupRequest signupRequest =
                 userSignupRequestBuilder().withDepartmentId(department.getId()).build();
         signupUser(signupRequest).statusCode(HttpStatus.CREATED.value());
@@ -560,7 +560,7 @@ class AuthControllerIntegrationTest {
     @Test
     void MANAGER는_새로_가입한_학생회_회원의_가입을_승인할_수_있다() {
         // given
-        Department department = organizationUtil.createCouncilDepartment();
+        Department department = organizationTestUtil.createCouncilDepartment();
         ManagerSignupRequest signupRequest =
                 managerSignupRequestBuilder().withDepartmentId(department.getId()).build();
         signupManager(signupRequest).statusCode(HttpStatus.CREATED.value());
@@ -579,7 +579,7 @@ class AuthControllerIntegrationTest {
     @Test
     void 이미_MANAGER인_회원은_가입을_승인할_수_없다() {
         // given
-        Department department = organizationUtil.createCouncilDepartment();
+        Department department = organizationTestUtil.createCouncilDepartment();
         ManagerSignupRequest signupRequest =
                 managerSignupRequestBuilder().withDepartmentId(department.getId()).build();
         signupManager(signupRequest).statusCode(HttpStatus.CREATED.value());
@@ -609,8 +609,8 @@ class AuthControllerIntegrationTest {
     @Test
     void MANAGER는_다른_학과의_학생회_회원의_가입을_승인할_수_없다() {
         // given
-        Department department1 = organizationUtil.createCouncilDepartment();
-        Department department2 = organizationUtil.createCouncilDepartment();
+        Department department1 = organizationTestUtil.createCouncilDepartment();
+        Department department2 = organizationTestUtil.createCouncilDepartment();
         ManagerSignupRequest signupRequest =
                 managerSignupRequestBuilder().withDepartmentId(department1.getId()).build();
         signupManager(signupRequest).statusCode(HttpStatus.CREATED.value());

--- a/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
@@ -19,7 +19,7 @@ import com.jnulocker.member.domain.Member;
 import com.jnulocker.member.domain.Role;
 import com.jnulocker.member.utils.MemberTestUtil;
 import com.jnulocker.organization.domain.Department;
-import com.jnulocker.organization.utils.OrganizationUtil;
+import com.jnulocker.organization.utils.OrganizationTestUtil;
 import io.restassured.RestAssured;
 import io.restassured.http.Cookie;
 import io.restassured.response.ValidatableResponse;
@@ -59,7 +59,7 @@ public class EventControllerIntegrationTest {
 
     @Autowired private AuthTestUtil authTestUtil;
 
-    @Autowired private OrganizationUtil organizationUtil;
+    @Autowired private OrganizationTestUtil organizationTestUtil;
 
     private static String accessToken;
 
@@ -285,7 +285,7 @@ public class EventControllerIntegrationTest {
     @Test
     void 자신이_속한_학과가_참여하는_이벤트를_조회할_수_있다() {
         // given
-        Department department = organizationUtil.createCouncilDepartment();
+        Department department = organizationTestUtil.createCouncilDepartment();
         Member member = memberTestUtil.createMemberFromRoleWithDepartment(Role.USER, department);
 
         // 이벤트 생성: 짝수번 사물함은 사용 가능, 홀수번 사물함은 사용 불가능
@@ -312,7 +312,7 @@ public class EventControllerIntegrationTest {
     @Test
     void publish되지_않은_이벤트는_조회할_수_없다() {
         // given
-        Department department = organizationUtil.createCouncilDepartment();
+        Department department = organizationTestUtil.createCouncilDepartment();
         Member member = memberTestUtil.createMemberFromRoleWithDepartment(Role.USER, department);
 
         // 이벤트 생성: 짝수번 사물함은 사용 가능, 홀수번 사물함은 사용 불가능
@@ -378,7 +378,7 @@ public class EventControllerIntegrationTest {
 
     // 이벤트 생성 메서드들
     private void createEvent() {
-        Department department = organizationUtil.createCouncilDepartment();
+        Department department = organizationTestUtil.createCouncilDepartment();
         createEventWithDepartment(department);
     }
 

--- a/src/test/java/com/jnulocker/events/utils/EventTestUtil.java
+++ b/src/test/java/com/jnulocker/events/utils/EventTestUtil.java
@@ -4,6 +4,7 @@ import static events.domain.EventTestDataBuilder.*;
 import static organization.domain.DepartmentTestDataBuilder.*;
 import static organization.domain.OrganizationTestDataBuilder.*;
 
+import com.jnulocker.auth.utils.AuthTestUtil;
 import com.jnulocker.events.adapter.out.EventParticipationRepository;
 import com.jnulocker.events.adapter.out.EventRepository;
 import com.jnulocker.events.adapter.out.FloorRepository;
@@ -13,10 +14,14 @@ import com.jnulocker.events.domain.EventParticipation;
 import com.jnulocker.events.domain.EventStatus;
 import com.jnulocker.events.domain.Floor;
 import com.jnulocker.events.domain.Locker;
+import com.jnulocker.member.domain.Member;
+import com.jnulocker.member.domain.Role;
+import com.jnulocker.member.utils.MemberTestUtil;
 import com.jnulocker.organization.adapter.out.DepartmentRepository;
 import com.jnulocker.organization.adapter.out.OrganizationRepository;
 import com.jnulocker.organization.domain.Department;
 import com.jnulocker.organization.domain.Organization;
+import com.jnulocker.organization.utils.OrganizationUtil;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,6 +42,62 @@ public class EventTestUtil {
 
     @Autowired private LockerRepository lockerRepository;
 
+    @Autowired private OrganizationUtil organizationUtil; // TODO: OrganizationTestUtil로 변경
+
+    @Autowired private MemberTestUtil memberTestUtil;
+
+    @Autowired private AuthTestUtil authTestUtil;
+
+    public LockerEventContext setUpLockerEventForRegistration(
+            List<Integer> lockersPerFloor, Role role, EventStatus eventStatus, boolean publish) {
+        // Department 생성
+        Department department = organizationUtil.createCouncilDepartment();
+
+        // Member 생성
+        Member member = memberTestUtil.createMemberFromRoleWithDepartment(role, department);
+
+        // AccessToken 생성
+        String accessToken = authTestUtil.generateAccessTokenWithMember(member);
+
+        // Event 생성 및 Department를 EventParticipation에 추가
+        Event event =
+                createEventWithParticipationDepartment(
+                        lockersPerFloor, department, eventStatus, publish);
+
+        return new LockerEventContext(department, member, accessToken, event);
+    }
+
+    public LockerEventContext setupLockerEventWithParticipatingDepartment(
+            List<Integer> lockersPerFloor,
+            Role role,
+            EventStatus eventStatus,
+            boolean publish,
+            List<Department> participationDepartments) {
+        // Department 생성 (사용자의 Department)
+        Department userDepartment = organizationUtil.createCouncilDepartment();
+
+        // Member 생성
+        Member member = memberTestUtil.createMemberFromRoleWithDepartment(role, userDepartment);
+
+        // AccessToken 생성
+        String accessToken = authTestUtil.generateAccessTokenWithMember(member);
+
+        // Event 생성
+        Event event = createEventWithFloorAndLockers(lockersPerFloor, eventStatus, publish);
+
+        // 지정된 Department들만 EventParticipation에 추가: 사용자의 Department는 제외
+        for (Department dept : participationDepartments) {
+            addParticipationDepartment(event, dept);
+        }
+
+        return new LockerEventContext(userDepartment, member, accessToken, event);
+    }
+
+    private void addParticipationDepartment(Event event, Department department) {
+        EventParticipation participation = EventParticipation.create(event, department);
+        eventParticipationRepository.save(participation);
+    }
+
     public Event createEventWithParticipationDepartment(
             List<Integer> lockersPerFloor,
             Department department,
@@ -53,17 +114,6 @@ public class EventTestUtil {
         // 층 생성 및 저장
         createFloorsWithEvent(lockersPerFloor, savedEvent);
         return savedEvent;
-    }
-
-    private Event createAndSaveEvent(
-            Department department, EventStatus eventStatus, boolean publish) {
-        Event event =
-                eventBuilder()
-                        .withDepartment(department)
-                        .withEventStatus(eventStatus)
-                        .withPublish(publish)
-                        .build();
-        return eventRepository.save(event);
     }
 
     public Event createEventWithFloorAndLockers(
@@ -83,6 +133,17 @@ public class EventTestUtil {
         createFloorsWithEvent(lockersPerFloor, savedEvent);
 
         return savedEvent;
+    }
+
+    private Event createAndSaveEvent(
+            Department department, EventStatus eventStatus, boolean publish) {
+        Event event =
+                eventBuilder()
+                        .withDepartment(department)
+                        .withEventStatus(eventStatus)
+                        .withPublish(publish)
+                        .build();
+        return eventRepository.save(event);
     }
 
     private void createFloorsWithEvent(List<Integer> lockersPerFloor, Event savedEvent) {

--- a/src/test/java/com/jnulocker/events/utils/EventTestUtil.java
+++ b/src/test/java/com/jnulocker/events/utils/EventTestUtil.java
@@ -21,7 +21,7 @@ import com.jnulocker.organization.adapter.out.DepartmentRepository;
 import com.jnulocker.organization.adapter.out.OrganizationRepository;
 import com.jnulocker.organization.domain.Department;
 import com.jnulocker.organization.domain.Organization;
-import com.jnulocker.organization.utils.OrganizationUtil;
+import com.jnulocker.organization.utils.OrganizationTestUtil;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,7 +42,7 @@ public class EventTestUtil {
 
     @Autowired private LockerRepository lockerRepository;
 
-    @Autowired private OrganizationUtil organizationUtil; // TODO: OrganizationTestUtil로 변경
+    @Autowired private OrganizationTestUtil organizationTestUtil;
 
     @Autowired private MemberTestUtil memberTestUtil;
 
@@ -51,7 +51,7 @@ public class EventTestUtil {
     public LockerEventContext setUpLockerEventForRegistration(
             List<Integer> lockersPerFloor, Role role, EventStatus eventStatus, boolean publish) {
         // Department 생성
-        Department department = organizationUtil.createCouncilDepartment();
+        Department department = organizationTestUtil.createCouncilDepartment();
 
         // Member 생성
         Member member = memberTestUtil.createMemberFromRoleWithDepartment(role, department);
@@ -74,7 +74,7 @@ public class EventTestUtil {
             boolean publish,
             List<Department> participationDepartments) {
         // Department 생성 (사용자의 Department)
-        Department userDepartment = organizationUtil.createCouncilDepartment();
+        Department userDepartment = organizationTestUtil.createCouncilDepartment();
 
         // Member 생성
         Member member = memberTestUtil.createMemberFromRoleWithDepartment(role, userDepartment);

--- a/src/test/java/com/jnulocker/events/utils/LockerEventContext.java
+++ b/src/test/java/com/jnulocker/events/utils/LockerEventContext.java
@@ -1,0 +1,8 @@
+package com.jnulocker.events.utils;
+
+import com.jnulocker.events.domain.Event;
+import com.jnulocker.member.domain.Member;
+import com.jnulocker.organization.domain.Department;
+
+public record LockerEventContext(
+        Department department, Member member, String accessToken, Event event) {}

--- a/src/test/java/com/jnulocker/member/adapter/in/MemberControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/member/adapter/in/MemberControllerIntegrationTest.java
@@ -9,7 +9,7 @@ import com.jnulocker.member.domain.Member;
 import com.jnulocker.member.domain.Role;
 import com.jnulocker.member.utils.MemberTestUtil;
 import com.jnulocker.organization.domain.Department;
-import com.jnulocker.organization.utils.OrganizationUtil;
+import com.jnulocker.organization.utils.OrganizationTestUtil;
 import io.restassured.RestAssured;
 import io.restassured.http.Cookie;
 import io.restassured.response.ValidatableResponse;
@@ -41,7 +41,7 @@ public class MemberControllerIntegrationTest {
 
     @Autowired private AuthTestUtil authTestUtil;
 
-    @Autowired private OrganizationUtil organizationUtil;
+    @Autowired private OrganizationTestUtil organizationTestUtil;
 
     @BeforeEach
     void setUp() {
@@ -80,7 +80,7 @@ public class MemberControllerIntegrationTest {
     @Test
     void MANAGER_COUNCIL_회원_정보를_조회할_수_있다() {
         // given
-        Department council = organizationUtil.createCouncilDepartment();
+        Department council = organizationTestUtil.createCouncilDepartment();
         Member expectedMember =
                 memberTestUtil.createMemberFromRoleWithDepartment(Role.MANAGER, council);
         String accessToken = authTestUtil.generateAccessTokenWithMember(expectedMember);
@@ -106,7 +106,7 @@ public class MemberControllerIntegrationTest {
     @Test
     void MANAGER_COMMITTEE_회원_정보를_조회할_수_있다() {
         // given
-        Department committee = organizationUtil.createCommitteeDepartment();
+        Department committee = organizationTestUtil.createCommitteeDepartment();
         Member expectedMember =
                 memberTestUtil.createMemberFromRoleWithDepartment(Role.MANAGER, committee);
         String accessToken =
@@ -124,7 +124,7 @@ public class MemberControllerIntegrationTest {
         assertThat(memberInfoResponse).isNotNull();
         assertThat(memberInfoResponse.memberId()).isEqualTo(expectedMember.getId());
         assertThat(memberInfoResponse.name()).isEqualTo(expectedMember.getName());
-        assertThat(memberInfoResponse.studentNumber()).isEqualTo(null);
+        assertThat(memberInfoResponse.studentNumber()).isNull();
         assertThat(memberInfoResponse.affiliation())
                 .isEqualTo(expectedMember.getDepartment().getNickname());
         assertThat(memberInfoResponse.phoneNumber()).isEqualTo(expectedMember.getPhoneNumber());

--- a/src/test/java/com/jnulocker/organization/utils/OrganizationTestUtil.java
+++ b/src/test/java/com/jnulocker/organization/utils/OrganizationTestUtil.java
@@ -12,7 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
-public class OrganizationUtil {
+public class OrganizationTestUtil {
 
     @Autowired private OrganizationRepository organizationRepository;
 

--- a/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
@@ -17,7 +17,7 @@ import com.jnulocker.events.utils.EventTestUtil;
 import com.jnulocker.events.utils.LockerEventContext;
 import com.jnulocker.member.domain.Role;
 import com.jnulocker.member.utils.MemberTestUtil;
-import com.jnulocker.organization.utils.OrganizationUtil;
+import com.jnulocker.organization.utils.OrganizationTestUtil;
 import com.jnulocker.registration.application.port.in.request.RegisterForEventRequest;
 import com.jnulocker.registration.application.port.in.response.RegistrationCustomPage;
 import com.jnulocker.registration.application.port.in.response.RegistrationListItem;
@@ -59,7 +59,7 @@ class RegistrationControllerIntegrationTest {
 
     @Autowired private AuthTestUtil authTestUtil;
 
-    @Autowired private OrganizationUtil organizationUtil;
+    @Autowired private OrganizationTestUtil organizationTestUtil;
 
     @Autowired private RegistrationTestUtil registrationTestUtil;
 

--- a/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
@@ -14,10 +14,9 @@ import com.jnulocker.events.domain.Event;
 import com.jnulocker.events.domain.EventStatus;
 import com.jnulocker.events.exception.EventErrorCode;
 import com.jnulocker.events.utils.EventTestUtil;
-import com.jnulocker.member.domain.Member;
+import com.jnulocker.events.utils.LockerEventContext;
 import com.jnulocker.member.domain.Role;
 import com.jnulocker.member.utils.MemberTestUtil;
-import com.jnulocker.organization.domain.Department;
 import com.jnulocker.organization.utils.OrganizationUtil;
 import com.jnulocker.registration.application.port.in.request.RegisterForEventRequest;
 import com.jnulocker.registration.application.port.in.response.RegistrationCustomPage;
@@ -69,7 +68,6 @@ class RegistrationControllerIntegrationTest {
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
-        accessToken = authTestUtil.generateAccessToken(Role.USER);
     }
 
     @AfterEach
@@ -82,7 +80,13 @@ class RegistrationControllerIntegrationTest {
     @Test
     void 사물함_신청을_할_수_있다() {
         // given
-        Event event = createEventWithLockers(EventStatus.OPEN, true);
+        LockerEventContext context =
+                eventTestUtil.setUpLockerEventForRegistration(
+                        List.of(5, 10), Role.USER, EventStatus.OPEN, true);
+
+        accessToken = context.accessToken();
+
+        Event event = context.event();
         RegisterForEventRequest request = createRequestForAvailableLocker(event);
 
         // when, then
@@ -92,7 +96,13 @@ class RegistrationControllerIntegrationTest {
     @Test
     void 신청된_사물함_목록을_조회할_수_있다() {
         // given
-        Event event = createEventWithLockers(EventStatus.OPEN, true);
+        LockerEventContext context =
+                eventTestUtil.setUpLockerEventForRegistration(
+                        List.of(5, 10), Role.USER, EventStatus.OPEN, true);
+
+        accessToken = context.accessToken();
+
+        Event event = context.event();
         RegisterForEventRequest request = createRequestForAvailableLocker(event);
 
         registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
@@ -109,22 +119,28 @@ class RegistrationControllerIntegrationTest {
         // then
         List<RegistrationListItem> content = registrationCustomPage.content();
         RegistrationListItem listItem = content.getFirst();
-        RegistrationMemberInfo member = listItem.member();
+        RegistrationMemberInfo memberInfo = listItem.member();
 
         assertThat(registrationCustomPage.totalElements()).isEqualTo(1);
         assertThat(listItem.floorNumber()).isEqualTo(1);
         assertThat(listItem.lockerCode()).isEqualTo("A-002");
-        assertThat(member.name()).isEqualTo("테스트 이름");
-        assertThat(member.studentNumber()).isEqualTo("221965");
-        assertThat(member.organization()).isEqualTo("테스트 조직명");
-        assertThat(member.department()).isEqualTo("테스트 학과명");
-        assertThat(member.email()).isEqualTo("test@email.com");
+        assertThat(memberInfo.name()).isEqualTo("테스트 이름");
+        assertThat(memberInfo.studentNumber()).isEqualTo("221965");
+        assertThat(memberInfo.organization()).isEqualTo("테스트 조직명");
+        assertThat(memberInfo.department()).isEqualTo("테스트 학과명");
+        assertThat(memberInfo.email()).isEqualTo("test@email.com");
     }
 
     @Test
     void 자신이_신청한_사물함을_조회할_수_있다() {
         // given
-        Event event = createEventWithLockers(EventStatus.OPEN, true);
+        LockerEventContext context =
+                eventTestUtil.setUpLockerEventForRegistration(
+                        List.of(5, 10), Role.USER, EventStatus.OPEN, true);
+
+        accessToken = context.accessToken();
+
+        Event event = context.event();
         RegisterForEventRequest request = createRequestForAvailableLocker(event);
 
         registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
@@ -142,7 +158,13 @@ class RegistrationControllerIntegrationTest {
     @Test
     void 자신의_사물함_내역이_존재하지_않으면_예외가_발생한다() {
         // given
-        Event event = createEventWithLockers(EventStatus.OPEN, true);
+        LockerEventContext context =
+                eventTestUtil.setUpLockerEventForRegistration(
+                        List.of(5, 10), Role.USER, EventStatus.OPEN, true);
+
+        accessToken = context.accessToken();
+
+        Event event = context.event();
 
         // when : 신청 없이 신청 내역 조회
         ErrorResponse errorResponse =
@@ -162,12 +184,19 @@ class RegistrationControllerIntegrationTest {
     @Test
     void 인증되지_않은_사용자는_신청할_수_없다() {
         // given
-        Event event = createEventWithLockers(EventStatus.OPEN, true);
+        LockerEventContext context =
+                eventTestUtil.setUpLockerEventForRegistration(
+                        List.of(5, 10), Role.USER, EventStatus.OPEN, true);
+
+        accessToken = context.accessToken();
+
+        Event event = context.event();
         RegisterForEventRequest request = createRequestForAvailableLocker(event);
 
         // when
+        accessToken = null;
         ErrorResponse errorResponse =
-                registerForEventWithoutLoggedUser(event.getId(), request)
+                registerForEvent(event.getId(), request)
                         .statusCode(JwtErrorCode.INVALID_ACCESS_TOKEN.getHttpStatus().value())
                         .extract()
                         .as(ErrorResponse.class);
@@ -180,7 +209,14 @@ class RegistrationControllerIntegrationTest {
     @Test
     void 사용중인_사물함은_신청할_수_없다() {
         // given
-        Event event = createEventWithLockers(EventStatus.OPEN, true);
+        LockerEventContext context =
+                eventTestUtil.setUpLockerEventForRegistration(
+                        List.of(5, 10), Role.USER, EventStatus.OPEN, true);
+
+        accessToken = context.accessToken();
+
+        Event event = context.event();
+
         RegisterForEventRequest request = createRequestForUnavailableLocker(event);
 
         // when
@@ -198,7 +234,13 @@ class RegistrationControllerIntegrationTest {
     @Test
     void 동일한_이벤트에_대해_중복으로_신청할_수_없다() {
         // given
-        Event event = createEventWithLockers(EventStatus.OPEN, true);
+        LockerEventContext context =
+                eventTestUtil.setUpLockerEventForRegistration(
+                        List.of(5, 10), Role.USER, EventStatus.OPEN, true);
+
+        accessToken = context.accessToken();
+
+        Event event = context.event();
         RegisterForEventRequest request = createRequestForAvailableLocker(event);
 
         // when
@@ -221,7 +263,13 @@ class RegistrationControllerIntegrationTest {
     @Test
     void 존재하지_않는_이벤트는_신청할_수_없다() {
         // given
-        Event event = createEventWithLockers(EventStatus.OPEN, true);
+        LockerEventContext context =
+                eventTestUtil.setUpLockerEventForRegistration(
+                        List.of(5, 10), Role.USER, EventStatus.OPEN, true);
+
+        accessToken = context.accessToken();
+
+        Event event = context.event();
 
         // when
         ErrorResponse errorResponse =
@@ -237,7 +285,14 @@ class RegistrationControllerIntegrationTest {
     @Test
     void 이벤트에_해당하지_않는_사물함은_신청할_수_없다() {
         // given
-        Event event = createEventWithLockers(EventStatus.OPEN, true);
+        LockerEventContext context =
+                eventTestUtil.setUpLockerEventForRegistration(
+                        List.of(5, 10), Role.USER, EventStatus.OPEN, true);
+
+        accessToken = context.accessToken();
+
+        Event event = context.event();
+
         Event anotherEvent = createEventWithLockers(EventStatus.OPEN, true);
         RegisterForEventRequest request = createRequestForAvailableLocker(anotherEvent);
 
@@ -256,7 +311,13 @@ class RegistrationControllerIntegrationTest {
     @Test
     void 이벤트가_준비중인_경우_신청할_수_없다() {
         // given
-        Event event = createEventWithLockers(EventStatus.READY, true);
+        LockerEventContext context =
+                eventTestUtil.setUpLockerEventForRegistration(
+                        List.of(5, 10), Role.USER, EventStatus.READY, true);
+
+        accessToken = context.accessToken();
+
+        Event event = context.event();
         RegisterForEventRequest request = createRequestForAvailableLocker(event);
 
         // when
@@ -273,7 +334,13 @@ class RegistrationControllerIntegrationTest {
     @Test
     void 이벤트가_종료된_경우_신청할_수_없다() {
         // given
-        Event event = createEventWithLockers(EventStatus.CLOSED, true);
+        LockerEventContext context =
+                eventTestUtil.setUpLockerEventForRegistration(
+                        List.of(5, 10), Role.USER, EventStatus.CLOSED, true);
+
+        accessToken = context.accessToken();
+
+        Event event = context.event();
         RegisterForEventRequest request = createRequestForAvailableLocker(event);
 
         // when
@@ -290,7 +357,13 @@ class RegistrationControllerIntegrationTest {
     @Test
     void USER는_publish_false인_이벤트를_신청할_수_없다() {
         // given
-        Event event = createEventWithLockers(EventStatus.OPEN, false);
+        LockerEventContext context =
+                eventTestUtil.setUpLockerEventForRegistration(
+                        List.of(5, 10), Role.USER, EventStatus.OPEN, false);
+
+        accessToken = context.accessToken();
+
+        Event event = context.event();
         RegisterForEventRequest request = createRequestForAvailableLocker(event);
 
         // when
@@ -305,9 +378,42 @@ class RegistrationControllerIntegrationTest {
     }
 
     @Test
+    void 소속학과가_아닌_사용자는_신청할_수_없다() {
+        // given
+        LockerEventContext context =
+                eventTestUtil.setupLockerEventWithParticipatingDepartment(
+                        List.of(5, 10), Role.USER, EventStatus.OPEN, true, List.of());
+
+        accessToken = context.accessToken();
+
+        Event event = context.event();
+        RegisterForEventRequest request = createRequestForAvailableLocker(event);
+
+        // when
+        ErrorResponse errorResponse =
+                registerForEvent(event.getId(), request)
+                        .statusCode(
+                                EventErrorCode.ONLY_PARTICIPATION_DEPARTMENT_CAN_REGISTER
+                                        .getHttpStatus()
+                                        .value())
+                        .extract()
+                        .as(ErrorResponse.class);
+
+        // then
+        assertThat(errorResponse.message())
+                .isEqualTo(EventErrorCode.ONLY_PARTICIPATION_DEPARTMENT_CAN_REGISTER.getMessage());
+    }
+
+    @Test
     void 신청한_사물함을_취소할_수_있다() {
         // given
-        Event event = createEventWithLockers(EventStatus.OPEN, true);
+        LockerEventContext context =
+                eventTestUtil.setUpLockerEventForRegistration(
+                        List.of(5, 10), Role.USER, EventStatus.OPEN, true);
+
+        accessToken = context.accessToken();
+
+        Event event = context.event();
         RegisterForEventRequest request = createRequestForAvailableLocker(event);
 
         registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
@@ -332,7 +438,13 @@ class RegistrationControllerIntegrationTest {
     @Test
     void 취소한_사물함을_다시_신청할_수_있다() {
         // given
-        Event event = createEventWithLockers(EventStatus.OPEN, true);
+        LockerEventContext context =
+                eventTestUtil.setUpLockerEventForRegistration(
+                        List.of(5, 10), Role.USER, EventStatus.OPEN, true);
+
+        accessToken = context.accessToken();
+
+        Event event = context.event();
         RegisterForEventRequest request = createRequestForAvailableLocker(event);
 
         registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
@@ -345,7 +457,13 @@ class RegistrationControllerIntegrationTest {
     @Test
     void 존재하지_않는_이벤트의_사물함_신청을_취소할_수_없다() {
         // given
-        Event event = createEventWithLockers(EventStatus.OPEN, true);
+        LockerEventContext context =
+                eventTestUtil.setUpLockerEventForRegistration(
+                        List.of(5, 10), Role.USER, EventStatus.OPEN, true);
+
+        accessToken = context.accessToken();
+
+        Event event = context.event();
         RegisterForEventRequest request = createRequestForAvailableLocker(event);
 
         registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
@@ -363,17 +481,18 @@ class RegistrationControllerIntegrationTest {
     @Test
     void 신청한_이벤트는_잔여여석이_1개_줄어든다() {
         // given
-        Department department = organizationUtil.createCouncilDepartment();
-        Member member = memberTestUtil.createMemberFromRoleWithDepartment(Role.USER, department);
+        LockerEventContext context =
+                eventTestUtil.setUpLockerEventForRegistration(
+                        List.of(5, 10), Role.USER, EventStatus.OPEN, true);
 
-        Event event =
-                eventTestUtil.createEventWithParticipationDepartment(
-                        List.of(5, 10), department, EventStatus.OPEN, true);
+        accessToken = context.accessToken();
+
+        Event event = context.event();
         RegisterForEventRequest request = createRequestForAvailableLocker(event);
 
         // 신청 전 조회
         List<MyEventResponse> myEventsBeforeRegistration =
-                getMyEvents(authTestUtil.generateAccessTokenWithMember(member))
+                getMyEvents(accessToken)
                         .statusCode(HttpStatus.OK.value())
                         .extract()
                         .jsonPath()
@@ -382,10 +501,10 @@ class RegistrationControllerIntegrationTest {
         Integer availableLockerCountBefore =
                 myEventsBeforeRegistration.getFirst().availableLockerCount();
 
+        // 신청
         registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
 
         // when
-        accessToken = authTestUtil.generateAccessTokenWithMember(member);
         List<MyEventResponse> myEventsAfterRegistration =
                 getMyEvents(accessToken)
                         .statusCode(HttpStatus.OK.value())
@@ -422,17 +541,6 @@ class RegistrationControllerIntegrationTest {
     private ValidatableResponse registerForEvent(Long eventId, RegisterForEventRequest request) {
         return given().contentType(MediaType.APPLICATION_JSON_VALUE)
                 .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
-                .body(request)
-                .when()
-                .post(REGISTRATION_URL, eventId)
-                .then()
-                .log()
-                .ifError();
-    }
-
-    private ValidatableResponse registerForEventWithoutLoggedUser(
-            Long eventId, RegisterForEventRequest request) {
-        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(request)
                 .when()
                 .post(REGISTRATION_URL, eventId)

--- a/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
@@ -305,17 +305,6 @@ class RegistrationControllerIntegrationTest {
     }
 
     @Test
-    void MANAGER는_publish_false인_이벤트도_신청할_수_있다() {
-        // given
-        accessToken = authTestUtil.generateAccessToken(Role.MANAGER);
-        Event event = createEventWithLockers(EventStatus.OPEN, false);
-        RegisterForEventRequest request = createRequestForAvailableLocker(event);
-
-        // when, then
-        registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
-    }
-
-    @Test
     void 신청한_사물함을_취소할_수_있다() {
         // given
         Event event = createEventWithLockers(EventStatus.OPEN, true);


### PR DESCRIPTION
### 개요
close #76 

### 작업사항
#### AS-IS 
- 참여하지 않은 소속학과인 사용자도 이벤트에서 사물함 신청 가능한 상황.`MANAGER` 권한도 신청 가능

#### TO-BE
- 참여하지 않은 소속학과면 신청 불가. `USER`만 신청 가능

### 변경로직
- `Security` 설정으로 `USER`만 신청 가능하도록 인가 로직 수정
- 소속학과가 해당 이벤트 대상인지 검증하는 로직 추가

### 테스트 결과
  <img width="388" alt="image" src="https://github.com/user-attachments/assets/0c6b08d1-4c64-4234-ba45-b98c2d2f9049" />

#### 추가된 테스트케이스
  <img width="329" alt="image" src="https://github.com/user-attachments/assets/20543c36-94dc-4cd8-940a-829da2cfc4a3" />

### reference

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 이벤트 신청 시 참여 학과 소속 여부를 검증하고, 참여 학과가 아닌 경우 신청이 불가하도록 예외 및 에러 메시지를 추가하였습니다.

- **버그 수정**
    - 이벤트 등록 및 사물함 신청 시 역할 기반 검증을 학과 기반 검증으로 변경하여, 권한과 무관하게 참여 학과 소속만 신청 가능하도록 개선하였습니다.

- **테스트**
    - 테스트 유틸리티 클래스명을 OrganizationUtil에서 OrganizationTestUtil로 일괄 변경하였습니다.
    - 이벤트 및 사물함 신청 테스트에서 학과 기반 검증 로직을 반영하고, 테스트 코드의 중복을 줄이기 위해 공통 세팅 메서드를 도입하였습니다.
    - 참여 학과가 아닌 사용자의 신청 시도에 대한 실패 케이스 테스트가 추가되었습니다.

- **리팩터**
    - 테스트 코드 내 이벤트 및 멤버, 학과, 토큰 생성 과정을 컨텍스트 객체로 통합하여 코드의 가독성과 재사용성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->