### PR TITLE
[FEAT] MANAGER 가입 대기 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/jnulocker/auth/adapter/in/AuthController.java
+++ b/src/main/java/com/jnulocker/auth/adapter/in/AuthController.java
@@ -60,6 +60,7 @@ public class AuthController implements AuthApi {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
+    @Override
     @GetMapping("/managers/pending")
     public ResponseEntity<PendingManagerCustomPage> getPendingManagers(
             @Valid @ParameterObject PendingManagerPageable pendingManagerPageable) {

--- a/src/main/java/com/jnulocker/auth/adapter/in/AuthController.java
+++ b/src/main/java/com/jnulocker/auth/adapter/in/AuthController.java
@@ -5,6 +5,7 @@ import static com.jnulocker.auth.util.CookieUtil.getCookieValueFromRefreshToken;
 
 import com.jnulocker.auth.adapter.in.docs.AuthApi;
 import com.jnulocker.auth.application.port.in.LoginCommand;
+import com.jnulocker.auth.application.port.in.ManagerQuery;
 import com.jnulocker.auth.application.port.in.ManagerSignupCommand;
 import com.jnulocker.auth.application.port.in.ReissueCommand;
 import com.jnulocker.auth.application.port.in.SendEmailCommand;
@@ -17,12 +18,17 @@ import com.jnulocker.auth.application.port.in.request.SendEmailRequest;
 import com.jnulocker.auth.application.port.in.request.UserSignupRequest;
 import com.jnulocker.auth.application.port.in.request.VerifyCodeRequest;
 import com.jnulocker.auth.application.port.in.response.AuthToken;
+import com.jnulocker.auth.application.port.in.response.PendingManagerCustomPage;
+import com.jnulocker.auth.application.port.in.response.PendingManagerPageable;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,6 +39,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AuthController implements AuthApi {
     private final UserSignupCommand userSignupCommand;
+    private final ManagerQuery managerQuery;
     private final ManagerSignupCommand managerSignupCommand;
     private final LoginCommand loginCommand;
     private final ReissueCommand reissueCommand;
@@ -51,6 +58,13 @@ public class AuthController implements AuthApi {
     public ResponseEntity<Void> signupManager(@Valid @RequestBody ManagerSignupRequest request) {
         managerSignupCommand.signupManager(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping("/managers/pending")
+    public ResponseEntity<PendingManagerCustomPage> getPendingManagers(
+            @Valid @ParameterObject PendingManagerPageable pendingManagerPageable) {
+        Pageable pageable = pendingManagerPageable.toPageable();
+        return ResponseEntity.ok(managerQuery.getPendingManagers(pageable));
     }
 
     @Override

--- a/src/main/java/com/jnulocker/auth/adapter/in/docs/AuthApi.java
+++ b/src/main/java/com/jnulocker/auth/adapter/in/docs/AuthApi.java
@@ -6,13 +6,19 @@ import com.jnulocker.auth.application.port.in.request.ManagerSignupRequest;
 import com.jnulocker.auth.application.port.in.request.SendEmailRequest;
 import com.jnulocker.auth.application.port.in.request.UserSignupRequest;
 import com.jnulocker.auth.application.port.in.request.VerifyCodeRequest;
+import com.jnulocker.auth.application.port.in.response.PendingManagerCustomPage;
+import com.jnulocker.auth.application.port.in.response.PendingManagerPageable;
 import com.jnulocker.common.swagger.ApiExceptionExamples;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -28,6 +34,18 @@ public interface AuthApi {
     @Operation(summary = "MANAGER 회원가입", description = "사물함 신청 이벤트 관리자인 MANAGER에 대한 회원가입입니다.")
     @ApiResponse(responseCode = "201", description = "MANAGER 회원가입 성공")
     ResponseEntity<Void> signupManager(@Valid @RequestBody ManagerSignupRequest request);
+
+    @ApiExceptionExamples(GetPendingManagerExceptionDocs.class)
+    @Operation(summary = "가입 승인 대기중인 MANAGER 목록 조회", description = "가입 승인 대기중인 MANAGER 목록을 조회합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "가입 승인 대기중인 MANAGER 목록 조회 성공",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = PendingManagerCustomPage.class)))
+    ResponseEntity<PendingManagerCustomPage> getPendingManagers(
+            @Valid @ParameterObject PendingManagerPageable pendingManagerPageable);
 
     @ApiExceptionExamples(ApproveManagerExceptionDocs.class)
     @Operation(summary = "MANAGER 가입 승인", description = "MANAGER 가입을 승인합니다.")

--- a/src/main/java/com/jnulocker/auth/adapter/in/docs/GetPendingManagerExceptionDocs.java
+++ b/src/main/java/com/jnulocker/auth/adapter/in/docs/GetPendingManagerExceptionDocs.java
@@ -1,0 +1,17 @@
+package com.jnulocker.auth.adapter.in.docs;
+
+import com.jnulocker.common.exception.BusinessException;
+import com.jnulocker.common.swagger.ExceptionDoc;
+import com.jnulocker.common.swagger.ExplainError;
+import com.jnulocker.common.swagger.SwaggerExceptionDoc;
+import com.jnulocker.member.exception.MemberNotFoundException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@ExceptionDoc
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetPendingManagerExceptionDocs implements SwaggerExceptionDoc {
+
+    @ExplainError("회원 정보를 조회할 수 없을 때 발생하는 예외입니다")
+    public static final BusinessException 회원_정보를_조회할_수_없을_때 = MemberNotFoundException.EXCEPTION;
+}

--- a/src/main/java/com/jnulocker/auth/application/port/in/ManagerQuery.java
+++ b/src/main/java/com/jnulocker/auth/application/port/in/ManagerQuery.java
@@ -1,0 +1,9 @@
+package com.jnulocker.auth.application.port.in;
+
+import com.jnulocker.auth.application.port.in.response.PendingManagerCustomPage;
+import org.springframework.data.domain.Pageable;
+
+public interface ManagerQuery {
+
+    PendingManagerCustomPage getPendingManagers(Pageable pageable);
+}

--- a/src/main/java/com/jnulocker/auth/application/port/in/response/PendingManagerCustomPage.java
+++ b/src/main/java/com/jnulocker/auth/application/port/in/response/PendingManagerCustomPage.java
@@ -1,11 +1,14 @@
 package com.jnulocker.auth.application.port.in.response;
 
 import com.jnulocker.member.domain.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import org.springframework.data.domain.Page;
 
 public record PendingManagerCustomPage(
-        List<PendingManagerListItem> content, Long totalElements, Boolean last) {
+        @Schema(description = "대기 중인 관리자 목록") List<PendingManagerListItem> content,
+        @Schema(description = "전체 대기 관리자 수", example = "10") Long totalElements,
+        @Schema(description = "마지막 페이지 여부", example = "false") Boolean last) {
     public static PendingManagerCustomPage from(Page<Member> pendingManagers) {
         return new PendingManagerCustomPage(
                 pendingManagers.getContent().stream().map(PendingManagerListItem::from).toList(),

--- a/src/main/java/com/jnulocker/auth/application/port/in/response/PendingManagerCustomPage.java
+++ b/src/main/java/com/jnulocker/auth/application/port/in/response/PendingManagerCustomPage.java
@@ -1,0 +1,15 @@
+package com.jnulocker.auth.application.port.in.response;
+
+import com.jnulocker.member.domain.Member;
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record PendingManagerCustomPage(
+        List<PendingManagerListItem> content, Long totalElements, Boolean last) {
+    public static PendingManagerCustomPage from(Page<Member> pendingManagers) {
+        return new PendingManagerCustomPage(
+                pendingManagers.getContent().stream().map(PendingManagerListItem::from).toList(),
+                pendingManagers.getTotalElements(),
+                pendingManagers.isLast());
+    }
+}

--- a/src/main/java/com/jnulocker/auth/application/port/in/response/PendingManagerListItem.java
+++ b/src/main/java/com/jnulocker/auth/application/port/in/response/PendingManagerListItem.java
@@ -1,0 +1,17 @@
+package com.jnulocker.auth.application.port.in.response;
+
+import com.jnulocker.member.domain.Member;
+import java.time.LocalDateTime;
+
+public record PendingManagerListItem(
+        Long memberId, String studentNumber, String name, LocalDateTime createdAt, String email) {
+
+    public static PendingManagerListItem from(Member member) {
+        return new PendingManagerListItem(
+                member.getId(),
+                member.getStudentNumber(),
+                member.getName(),
+                member.getCreatedAt(),
+                member.getEmail());
+    }
+}

--- a/src/main/java/com/jnulocker/auth/application/port/in/response/PendingManagerListItem.java
+++ b/src/main/java/com/jnulocker/auth/application/port/in/response/PendingManagerListItem.java
@@ -1,10 +1,15 @@
 package com.jnulocker.auth.application.port.in.response;
 
 import com.jnulocker.member.domain.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
 public record PendingManagerListItem(
-        Long memberId, String studentNumber, String name, LocalDateTime createdAt, String email) {
+        @Schema(description = "회원 ID", example = "1") Long memberId,
+        @Schema(description = "학번", example = "225312") String studentNumber,
+        @Schema(description = "이름", example = "강명덕") String name,
+        @Schema(description = "가입일", example = "2025-08-01T15:00:00") LocalDateTime createdAt,
+        @Schema(description = "이메일", example = "test123@example.com") String email) {
 
     public static PendingManagerListItem from(Member member) {
         return new PendingManagerListItem(

--- a/src/main/java/com/jnulocker/auth/application/port/in/response/PendingManagerPageable.java
+++ b/src/main/java/com/jnulocker/auth/application/port/in/response/PendingManagerPageable.java
@@ -1,0 +1,31 @@
+package com.jnulocker.auth.application.port.in.response;
+
+import com.jnulocker.common.swagger.model.AbstractPageable;
+import jakarta.validation.constraints.AssertTrue;
+import java.util.Set;
+
+public class PendingManagerPageable extends AbstractPageable {
+
+    public static final String DEFAULT_SORT = "createdAt";
+
+    public static final String VALID_SORT_MESSAGE =
+            "정렬 기준은 다음 중 하나여야 합니다: [id, name, email, studentNumber].";
+
+    public static final Set<String> VALID_SORT_FIELDS =
+            Set.of("id", "name", "email", "studentNumber");
+
+    public PendingManagerPageable(Integer page, Integer size, String direction, String sort) {
+        super(page, size, direction, sort);
+    }
+
+    @Override
+    @AssertTrue(message = VALID_SORT_MESSAGE)
+    protected boolean isValidSort() {
+        return !getSort().isBlank() && VALID_SORT_FIELDS.contains(getSort());
+    }
+
+    @Override
+    protected String getDefaultSort() {
+        return DEFAULT_SORT;
+    }
+}

--- a/src/main/java/com/jnulocker/auth/application/port/in/response/PendingManagerPageable.java
+++ b/src/main/java/com/jnulocker/auth/application/port/in/response/PendingManagerPageable.java
@@ -9,10 +9,10 @@ public class PendingManagerPageable extends AbstractPageable {
     public static final String DEFAULT_SORT = "createdAt";
 
     public static final String VALID_SORT_MESSAGE =
-            "정렬 기준은 다음 중 하나여야 합니다: [id, name, email, studentNumber].";
+            "정렬 기준은 다음 중 하나여야 합니다: [id, name, email, studentNumber, createdAt].";
 
     public static final Set<String> VALID_SORT_FIELDS =
-            Set.of("id", "name", "email", "studentNumber");
+            Set.of("id", "name", "email", "studentNumber", "createdAt");
 
     public PendingManagerPageable(Integer page, Integer size, String direction, String sort) {
         super(page, size, direction, sort);

--- a/src/main/java/com/jnulocker/auth/application/service/AuthCommandService.java
+++ b/src/main/java/com/jnulocker/auth/application/service/AuthCommandService.java
@@ -95,6 +95,10 @@ public class AuthCommandService
         approver.validateManagerApproval(approvee.getDepartment());
 
         approvee.approveManager();
+
+        // refreshToken 삭제
+        tokenProvider.deleteRefreshTokenById(approvee.getId());
+
         memberCommand.save(approvee);
     }
 

--- a/src/main/java/com/jnulocker/auth/application/service/AuthCommandService.java
+++ b/src/main/java/com/jnulocker/auth/application/service/AuthCommandService.java
@@ -29,7 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class AuthService
+public class AuthCommandService
         implements UserSignupCommand, ManagerSignupCommand, LoginCommand, ReissueCommand {
     private final AuthenticationManager authenticationManager;
     private final PasswordEncoder passwordEncoder;

--- a/src/main/java/com/jnulocker/auth/application/service/AuthQueryService.java
+++ b/src/main/java/com/jnulocker/auth/application/service/AuthQueryService.java
@@ -1,0 +1,29 @@
+package com.jnulocker.auth.application.service;
+
+import com.jnulocker.auth.application.port.in.ManagerQuery;
+import com.jnulocker.auth.application.port.in.response.PendingManagerCustomPage;
+import com.jnulocker.auth.security.SecurityUtils;
+import com.jnulocker.member.application.port.in.MemberQuery;
+import com.jnulocker.member.domain.Member;
+import com.jnulocker.member.domain.Role;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthQueryService implements ManagerQuery {
+
+    private final MemberQuery memberQuery;
+
+    @Override
+    public PendingManagerCustomPage getPendingManagers(Pageable pageable) {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        Member member = memberQuery.findByIdWithDepartmentOrThrow(memberId);
+
+        Page<Member> pendingManagers =
+                memberQuery.getByRoleAndDepartment(Role.GUEST, member.getDepartment(), pageable);
+        return PendingManagerCustomPage.from(pendingManagers);
+    }
+}

--- a/src/main/java/com/jnulocker/auth/application/service/EmailService.java
+++ b/src/main/java/com/jnulocker/auth/application/service/EmailService.java
@@ -25,11 +25,11 @@ public class EmailService implements SendEmailCommand, VerifyCodeCommand {
     private final TemplateEngine templateEngine;
     private final JavaMailSender javaMailSender;
     private final RedisUtil redisUtil;
-    private final AuthService authService;
+    private final AuthCommandService authCommandService;
 
     @Override
     public void sendEmail(SendEmailRequest request) {
-        authService.validateDuplicateEmail(request.email());
+        authCommandService.validateDuplicateEmail(request.email());
 
         // 기존 이메일 인증 완료 기록이 있으면 삭제
         if (redisUtil.existsVerifiedEmail(request.email())) {

--- a/src/main/java/com/jnulocker/auth/application/service/EmailService.java
+++ b/src/main/java/com/jnulocker/auth/application/service/EmailService.java
@@ -5,17 +5,20 @@ import com.jnulocker.auth.application.port.in.VerifyCodeCommand;
 import com.jnulocker.auth.application.port.in.request.SendEmailRequest;
 import com.jnulocker.auth.application.port.in.request.VerifyCodeRequest;
 import com.jnulocker.auth.exception.CodeNotCorrectException;
+import com.jnulocker.auth.exception.FailedToCreateCodeException;
 import com.jnulocker.auth.exception.SendEmailException;
 import com.jnulocker.common.util.RedisUtil;
 import jakarta.mail.internet.MimeMessage;
-import java.util.Random;
+import java.security.SecureRandom;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class EmailService implements SendEmailCommand, VerifyCodeCommand {
@@ -62,12 +65,17 @@ public class EmailService implements SendEmailCommand, VerifyCodeCommand {
         redisUtil.deleteData(request.email());
     }
 
-    public int createCode() {
-        Random random = new Random();
-        return 100000 + random.nextInt(900000);
+    private int createCode() {
+        try {
+            SecureRandom random = SecureRandom.getInstanceStrong();
+            return 100000 + random.nextInt(900000);
+        } catch (Exception e) {
+            log.error("Error generating verification code", e);
+            throw FailedToCreateCodeException.EXCEPTION;
+        }
     }
 
-    public String generateHtml(int code) {
+    private String generateHtml(int code) {
         Context context = new Context();
         context.setVariable("code", code);
         return templateEngine.process("email-verification", context);

--- a/src/main/java/com/jnulocker/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/jnulocker/auth/exception/AuthErrorCode.java
@@ -19,6 +19,7 @@ public enum AuthErrorCode implements ErrorCode {
     ONLY_MANAGER_CAN_APPROVE("A009", HttpStatus.FORBIDDEN, "관리자만 승인할 수 있습니다."),
     ONLY_SAME_DEPARTMENT_CAN_APPROVE("A010", HttpStatus.FORBIDDEN, "같은 학과의 관리자만 승인할 수 있습니다."),
     ONLY_GUEST_CAN_BE_MANAGER("A011", HttpStatus.FORBIDDEN, "게스트만 매니저로 승인될 수 있습니다"),
+    FAILED_TO_CREATE_CODE("A012", HttpStatus.INTERNAL_SERVER_ERROR, "인증 코드 생성에 실패했습니다."),
     ;
 
     private final String code;

--- a/src/main/java/com/jnulocker/auth/exception/FailedToCreateCodeException.java
+++ b/src/main/java/com/jnulocker/auth/exception/FailedToCreateCodeException.java
@@ -1,0 +1,12 @@
+package com.jnulocker.auth.exception;
+
+import com.jnulocker.common.exception.BusinessException;
+
+public class FailedToCreateCodeException extends BusinessException {
+
+    public static final BusinessException EXCEPTION = new FailedToCreateCodeException();
+
+    private FailedToCreateCodeException() {
+        super(AuthErrorCode.FAILED_TO_CREATE_CODE);
+    }
+}

--- a/src/main/java/com/jnulocker/auth/jwt/TokenProvider.java
+++ b/src/main/java/com/jnulocker/auth/jwt/TokenProvider.java
@@ -154,6 +154,9 @@ public class TokenProvider {
     }
 
     public void deleteRefreshTokenById(Long memberId) {
+        if (!tokenRepository.existsById(memberId)) {
+            return;
+        }
         tokenRepository.deleteById(memberId);
     }
 }

--- a/src/main/java/com/jnulocker/auth/jwt/TokenProvider.java
+++ b/src/main/java/com/jnulocker/auth/jwt/TokenProvider.java
@@ -47,9 +47,9 @@ public class TokenProvider {
     }
 
     public AuthToken createAuthTokenByAuthentication(Authentication authentication, Role role) {
-        Long userId = Long.valueOf(authentication.getName());
-        String accessToken = generateAccessToken(userId, role);
-        String refreshToken = generateRefreshToken(userId);
+        Long memberId = Long.valueOf(authentication.getName());
+        String accessToken = generateAccessToken(memberId, role);
+        String refreshToken = generateRefreshToken(memberId);
 
         return AuthToken.of(
                 accessToken,
@@ -70,10 +70,10 @@ public class TokenProvider {
                 refreshTokenExpireTime);
     }
 
-    public String generateAccessToken(Long userId, Role role) {
+    public String generateAccessToken(Long memberId, Role role) {
         Date now = new Date();
         return Jwts.builder()
-                .claim("id", userId)
+                .claim("id", memberId)
                 .claim("role", role.getRole())
                 .issuedAt(now)
                 .expiration(
@@ -84,11 +84,11 @@ public class TokenProvider {
                 .compact();
     }
 
-    public String generateRefreshToken(Long userId) {
+    public String generateRefreshToken(Long memberId) {
         Date now = new Date();
         String refreshToken =
                 Jwts.builder()
-                        .claim("id", userId)
+                        .claim("id", memberId)
                         .issuedAt(now)
                         .expiration(
                                 new Date(
@@ -98,7 +98,7 @@ public class TokenProvider {
                         .signWith(refreshSecretKey)
                         .compact();
 
-        RefreshToken token = new RefreshToken(userId, refreshToken, refreshTokenExpireTime);
+        RefreshToken token = new RefreshToken(memberId, refreshToken, refreshTokenExpireTime);
         tokenRepository.save(token);
 
         return refreshToken;
@@ -107,11 +107,11 @@ public class TokenProvider {
     // 토큰 복호화
     public Authentication getAuthentication(String accessToken) {
         Claims claims = parseClaims(accessToken, TokenType.ACCESS);
-        String userId = claims.get("id").toString();
+        String memberId = claims.get("id").toString();
         String role = claims.get("role").toString();
         Set<SimpleGrantedAuthority> authorities =
                 Collections.singleton(new SimpleGrantedAuthority(role));
-        UserDetails principal = new User(userId, "", authorities);
+        UserDetails principal = new User(memberId, "", authorities);
         return new UsernamePasswordAuthenticationToken(principal, "", authorities);
     }
 
@@ -151,5 +151,9 @@ public class TokenProvider {
             }
             throw InvalidRefreshTokenException.EXCEPTION;
         }
+    }
+
+    public void deleteRefreshTokenById(Long memberId) {
+        tokenRepository.deleteById(memberId);
     }
 }

--- a/src/main/java/com/jnulocker/config/SecurityConfig.java
+++ b/src/main/java/com/jnulocker/config/SecurityConfig.java
@@ -76,6 +76,8 @@ public class SecurityConfig {
                                 .hasAuthority(Role.USER.getRole())
                                 .requestMatchers(HttpMethod.GET, "/v1/events/*/registrations")
                                 .hasAuthority(Role.MANAGER.getRole())
+                                .requestMatchers(HttpMethod.GET, "/v1/auth/managers/pending")
+                                .hasAuthority(Role.MANAGER.getRole())
                                 .requestMatchers(
                                         HttpMethod.POST, "/v1/events", "/v1/auth/managers/approve")
                                 .hasAuthority(Role.MANAGER.getRole())

--- a/src/main/java/com/jnulocker/member/adapter/out/MemberPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/member/adapter/out/MemberPersistenceAdapter.java
@@ -4,8 +4,12 @@ import com.jnulocker.auth.application.port.out.MemberRecordPort;
 import com.jnulocker.common.annotation.PersistenceAdapter;
 import com.jnulocker.member.application.port.out.MemberLoadPort;
 import com.jnulocker.member.domain.Member;
+import com.jnulocker.member.domain.Role;
+import com.jnulocker.organization.domain.Department;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
@@ -35,5 +39,11 @@ public class MemberPersistenceAdapter implements MemberLoadPort, MemberRecordPor
     @Override
     public Optional<Member> findByIdWithDepartment(Long memberId) {
         return memberRepository.findByIdWithDepartment(memberId);
+    }
+
+    @Override
+    public Page<Member> getByRoleAndDepartment(
+            Role role, Department department, Pageable pageable) {
+        return memberRepository.findAllByRoleAndDepartment(role, department, pageable);
     }
 }

--- a/src/main/java/com/jnulocker/member/adapter/out/MemberRepository.java
+++ b/src/main/java/com/jnulocker/member/adapter/out/MemberRepository.java
@@ -1,7 +1,11 @@
 package com.jnulocker.member.adapter.out;
 
 import com.jnulocker.member.domain.Member;
+import com.jnulocker.member.domain.Role;
+import com.jnulocker.organization.domain.Department;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -12,4 +16,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     @Query("SELECT m FROM Member m JOIN FETCH m.department WHERE m.id = :memberId")
     Optional<Member> findByIdWithDepartment(Long memberId);
+
+    Page<Member> findAllByRoleAndDepartment(Role role, Department department, Pageable pageable);
 }

--- a/src/main/java/com/jnulocker/member/application/port/in/MemberQuery.java
+++ b/src/main/java/com/jnulocker/member/application/port/in/MemberQuery.java
@@ -2,6 +2,10 @@ package com.jnulocker.member.application.port.in;
 
 import com.jnulocker.member.application.port.in.response.MemberInfoResponse;
 import com.jnulocker.member.domain.Member;
+import com.jnulocker.member.domain.Role;
+import com.jnulocker.organization.domain.Department;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface MemberQuery {
 
@@ -14,4 +18,6 @@ public interface MemberQuery {
     Member findByIdWithDepartmentOrThrow(Long memberId);
 
     MemberInfoResponse getMemberInfo();
+
+    Page<Member> getByRoleAndDepartment(Role role, Department department, Pageable pageable);
 }

--- a/src/main/java/com/jnulocker/member/application/port/out/MemberLoadPort.java
+++ b/src/main/java/com/jnulocker/member/application/port/out/MemberLoadPort.java
@@ -1,8 +1,13 @@
 package com.jnulocker.member.application.port.out;
 
 import com.jnulocker.member.domain.Member;
+import com.jnulocker.member.domain.Role;
+import com.jnulocker.organization.domain.Department;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
+// TODO: get 으로 시작하도록 변경
 public interface MemberLoadPort {
     boolean existsByEmail(String email);
 
@@ -11,4 +16,6 @@ public interface MemberLoadPort {
     Optional<Member> findById(Long id);
 
     Optional<Member> findByIdWithDepartment(Long memberId);
+
+    Page<Member> getByRoleAndDepartment(Role role, Department department, Pageable pageable);
 }

--- a/src/main/java/com/jnulocker/member/application/service/MemberQueryService.java
+++ b/src/main/java/com/jnulocker/member/application/service/MemberQueryService.java
@@ -7,8 +7,11 @@ import com.jnulocker.member.application.port.out.MemberLoadPort;
 import com.jnulocker.member.domain.Member;
 import com.jnulocker.member.domain.Role;
 import com.jnulocker.member.exception.MemberNotFoundException;
+import com.jnulocker.organization.domain.Department;
 import com.jnulocker.organization.domain.OrganizationType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -71,5 +74,10 @@ public class MemberQueryService implements MemberQuery {
                 affiliation,
                 member.getPhoneNumber(),
                 member.getEmail());
+    }
+
+    public Page<Member> getByRoleAndDepartment(
+            Role role, Department department, Pageable pageable) {
+        return memberLoadPort.getByRoleAndDepartment(role, department, pageable);
     }
 }

--- a/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
@@ -6,6 +6,7 @@ import static auth.application.port.in.request.UserSignupRequestTestDataBuilder.
 import static auth.application.port.in.request.VerifyCodeRequestTestDataBuilder.verifyCodeRequestBuilder;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThatList;
 
 import com.jnulocker.auth.adapter.out.TokenRepository;
 import com.jnulocker.auth.application.port.in.request.LoginRequest;
@@ -14,6 +15,7 @@ import com.jnulocker.auth.application.port.in.request.ManagerSignupRequest;
 import com.jnulocker.auth.application.port.in.request.SendEmailRequest;
 import com.jnulocker.auth.application.port.in.request.UserSignupRequest;
 import com.jnulocker.auth.application.port.in.request.VerifyCodeRequest;
+import com.jnulocker.auth.application.port.in.response.PendingManagerCustomPage;
 import com.jnulocker.auth.exception.AuthErrorCode;
 import com.jnulocker.auth.jwt.RefreshToken;
 import com.jnulocker.auth.jwt.exception.JwtErrorCode;
@@ -558,6 +560,55 @@ class AuthControllerIntegrationTest {
     }
 
     @Test
+    void MANAGER는_가입_승인_요청을_조회할_수_있다() {
+        // given
+        Department department = organizationUtil.createCouncilDepartment();
+        ManagerSignupRequest signupRequest =
+                managerSignupRequestBuilder().withDepartmentId(department.getId()).build();
+        signupManager(signupRequest).statusCode(HttpStatus.CREATED.value());
+
+        String accessToken =
+                authTestUtil.generateAccessTokenWithDepartment(Role.MANAGER, department);
+        // when
+        PendingManagerCustomPage pendingManagerCustomPage =
+                getPendingManagerSignups(accessToken)
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .as(PendingManagerCustomPage.class);
+
+        // then
+        assertThat(pendingManagerCustomPage).isNotNull();
+        assertThat(pendingManagerCustomPage.totalElements()).isEqualTo(1);
+        assertThat(pendingManagerCustomPage.content().getFirst().email())
+                .isEqualTo(signupRequest.email());
+    }
+
+    @Test
+    void 학과가_다른_회원의_가입_승인_요청은_조회할_수_없다() {
+        // given
+        Department department1 = organizationUtil.createCouncilDepartment();
+        Department department2 = organizationUtil.createCouncilDepartment();
+        ManagerSignupRequest signupRequest =
+                managerSignupRequestBuilder().withDepartmentId(department1.getId()).build();
+        signupManager(signupRequest).statusCode(HttpStatus.CREATED.value());
+
+        String accessToken =
+                authTestUtil.generateAccessTokenWithDepartment(Role.MANAGER, department2);
+        // when
+        PendingManagerCustomPage pendingManagerCustomPage =
+                getPendingManagerSignups(accessToken)
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .as(PendingManagerCustomPage.class);
+
+        // then
+        assertThat(pendingManagerCustomPage).isNotNull();
+        assertThat(pendingManagerCustomPage.totalElements()).isZero();
+        assertThat(pendingManagerCustomPage.last()).isTrue();
+        assertThatList(pendingManagerCustomPage.content()).isEmpty();
+    }
+
+    @Test
     void MANAGER는_새로_가입한_학생회_회원의_가입을_승인할_수_있다() {
         // given
         Department department = organizationUtil.createCouncilDepartment();
@@ -735,5 +786,15 @@ class AuthControllerIntegrationTest {
                 .expiration(expiredAt)
                 .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
                 .compact();
+    }
+
+    private ValidatableResponse getPendingManagerSignups(String accessToken) {
+        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
+                .when()
+                .get(AUTH_URL + "/managers/pending")
+                .then()
+                .log()
+                .all();
     }
 }


### PR DESCRIPTION
### 개요
close #78 

### 작업사항
- MANAGER 가입 대기 목록 조회 API 구현

### 변경로직
- MANAGER 가입 대기 목록 조회 API 구현
- 테스트코드 작성

### 테스트 결과

  <img width="389" alt="image" src="https://github.com/user-attachments/assets/24454525-5622-4e7a-b087-e3130585415f" />

#### 추가된 테스트케이스

  <img width="312" alt="image" src="https://github.com/user-attachments/assets/e357cbc2-6f2c-4989-bd7a-537d52264111" />
  <img width="315" alt="image" src="https://github.com/user-attachments/assets/4d6691f1-78d1-4913-b0d9-f1edf5670316" />


### reference

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 관리자가 자신의 학과에 대한 가입 승인 대기 관리자 목록을 페이지네이션하여 조회할 수 있는 엔드포인트가 추가되었습니다.
  - 인증 코드 생성에 SecureRandom 기반 보안 강화 및 관련 예외 처리가 도입되었습니다.
  - 토큰 관련 기능에 회원 ID 기반 리프레시 토큰 삭제 기능이 추가되었습니다.

- **버그 수정**
  - 인증 코드 생성 실패 시 명확한 예외 및 에러 코드가 추가되어 안내가 개선되었습니다.

- **테스트**
  - 관리자가 승인 대기 관리자 목록을 정상적으로 조회하는 경우와, 다른 학과의 요청을 조회할 수 없는 경우에 대한 통합 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->