### PR TITLE
[FEAT] 이벤트 ID를 Long에서 UUID로 변경

### DIFF
--- a/src/main/java/com/jnulocker/events/adapter/in/EventController.java
+++ b/src/main/java/com/jnulocker/events/adapter/in/EventController.java
@@ -11,6 +11,7 @@ import com.jnulocker.events.application.port.in.response.FloorWithLockersRespons
 import com.jnulocker.events.application.port.in.response.MyEventResponse;
 import jakarta.validation.Valid;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
@@ -57,13 +58,13 @@ public class EventController implements EventApi {
     @Override
     @GetMapping("/{event-id}/lockers")
     public ResponseEntity<List<FloorWithLockersResponse>> getLockers(
-            @PathVariable("event-id") Long eventId) {
+            @PathVariable("event-id") UUID eventId) {
         return ResponseEntity.ok(eventQuery.getLockersByEventId(eventId));
     }
 
     @Override
     @DeleteMapping("/{event-id}")
-    public ResponseEntity<Void> deleteEvent(@PathVariable("event-id") Long eventId) {
+    public ResponseEntity<Void> deleteEvent(@PathVariable("event-id") UUID eventId) {
         eventCommand.deleteEvent(eventId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
@@ -71,7 +72,7 @@ public class EventController implements EventApi {
     @Override
     @PutMapping("/{event-id}/publish")
     public ResponseEntity<Void> publishEvent(
-            @PathVariable("event-id") Long eventId,
+            @PathVariable("event-id") UUID eventId,
             @RequestBody @Valid PublishEventRequest request) {
         eventCommand.publishEvent(eventId, request);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();

--- a/src/main/java/com/jnulocker/events/adapter/in/docs/EventApi.java
+++ b/src/main/java/com/jnulocker/events/adapter/in/docs/EventApi.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
+import java.util.UUID;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -73,16 +74,16 @@ public interface EventApi {
                                                                     FloorWithLockersResponse
                                                                             .class))))
     ResponseEntity<List<FloorWithLockersResponse>> getLockers(
-            @PathVariable("event-id") Long eventId);
+            @PathVariable("event-id") UUID eventId);
 
     @ApiExceptionExamples(DeleteEventExceptionDocs.class)
     @Operation(summary = "이벤트 삭제", description = "이벤트를 삭제합니다. 이벤트가 진행 중인 경우에는 삭제할 수 없습니다.")
     @ApiResponse(responseCode = "204", description = "이벤트 삭제 성공")
-    ResponseEntity<Void> deleteEvent(@PathVariable("event-id") Long eventId);
+    ResponseEntity<Void> deleteEvent(@PathVariable("event-id") UUID eventId);
 
     @Operation(summary = "이벤트 publish", description = "이벤트를 publish 또는 unpublish합니다.")
     @ApiExceptionExamples(PublishEventExceptionDocs.class)
     ResponseEntity<Void> publishEvent(
-            @PathVariable("event-id") Long eventId,
+            @PathVariable("event-id") UUID eventId,
             @RequestBody @Valid PublishEventRequest request);
 }

--- a/src/main/java/com/jnulocker/events/adapter/out/EventPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/EventPersistenceAdapter.java
@@ -10,6 +10,7 @@ import com.jnulocker.events.domain.Locker;
 import com.jnulocker.organization.domain.Department;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -24,12 +25,12 @@ public class EventPersistenceAdapter implements EventLoadPort, EventRecordPort {
     private final LockerRepository lockerRepository;
 
     @Override
-    public boolean existsById(Long eventId) {
+    public boolean existsById(UUID eventId) {
         return eventRepository.existsById(eventId);
     }
 
     @Override
-    public Optional<Event> getById(Long eventId) {
+    public Optional<Event> getById(UUID eventId) {
         return eventRepository.findById(eventId);
     }
 

--- a/src/main/java/com/jnulocker/events/adapter/out/EventRepository.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/EventRepository.java
@@ -3,10 +3,11 @@ package com.jnulocker.events.adapter.out;
 import com.jnulocker.events.domain.Event;
 import com.jnulocker.organization.domain.Department;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface EventRepository extends JpaRepository<Event, Long> {
+public interface EventRepository extends JpaRepository<Event, UUID> {
 
     @EntityGraph(attributePaths = {"department"})
     List<Event> findAllByPublishTrueAndEventParticipations_Department(Department department);

--- a/src/main/java/com/jnulocker/events/adapter/out/FloorPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/FloorPersistenceAdapter.java
@@ -4,6 +4,7 @@ import com.jnulocker.common.annotation.PersistenceAdapter;
 import com.jnulocker.events.application.port.out.FloorLoadPort;
 import com.jnulocker.events.domain.Floor;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 
 @PersistenceAdapter
@@ -13,7 +14,7 @@ public class FloorPersistenceAdapter implements FloorLoadPort {
     private final FloorRepository floorRepository;
 
     @Override
-    public List<Floor> getFloorsByEventId(Long eventId) {
+    public List<Floor> getFloorsByEventId(UUID eventId) {
         return floorRepository.findAllByEventId(eventId);
     }
 }

--- a/src/main/java/com/jnulocker/events/adapter/out/FloorRepository.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/FloorRepository.java
@@ -3,11 +3,12 @@ package com.jnulocker.events.adapter.out;
 import com.jnulocker.events.domain.Event;
 import com.jnulocker.events.domain.Floor;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FloorRepository extends JpaRepository<Floor, Long> {
 
-    List<Floor> findAllByEventId(Long eventId);
+    List<Floor> findAllByEventId(UUID eventId);
 
     void deleteAllByEvent(Event event);
 }

--- a/src/main/java/com/jnulocker/events/application/port/in/EventCommand.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/EventCommand.java
@@ -3,13 +3,14 @@ package com.jnulocker.events.application.port.in;
 import com.jnulocker.events.application.port.in.request.CreateEventRequest;
 import com.jnulocker.events.application.port.in.request.PublishEventRequest;
 import com.jnulocker.events.domain.Event;
+import java.util.UUID;
 
 public interface EventCommand {
     void createEvent(CreateEventRequest request);
 
-    void deleteEvent(Long eventId);
+    void deleteEvent(UUID eventId);
 
     void save(Event event);
 
-    void publishEvent(Long eventId, PublishEventRequest request);
+    void publishEvent(UUID eventId, PublishEventRequest request);
 }

--- a/src/main/java/com/jnulocker/events/application/port/in/EventQuery.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/EventQuery.java
@@ -6,11 +6,12 @@ import com.jnulocker.events.application.port.in.response.MyEventResponse;
 import com.jnulocker.events.domain.Event;
 import com.jnulocker.events.domain.Locker;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 
 public interface EventQuery {
 
-    Event getByIdOrThrow(Long eventId);
+    Event getByIdOrThrow(UUID eventId);
 
     List<MyEventResponse> getMyEvents();
 
@@ -18,5 +19,5 @@ public interface EventQuery {
 
     Locker getLockerByIdOrThrow(Long lockerId);
 
-    List<FloorWithLockersResponse> getLockersByEventId(Long eventId);
+    List<FloorWithLockersResponse> getLockersByEventId(UUID eventId);
 }

--- a/src/main/java/com/jnulocker/events/application/port/in/response/EventListItem.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/response/EventListItem.java
@@ -4,9 +4,10 @@ import com.jnulocker.events.domain.Event;
 import com.jnulocker.events.domain.EventStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 public record EventListItem(
-        @Schema(description = "이벤트 ID", example = "1") Long id,
+        @Schema(description = "이벤트 ID", example = "2b0c4f8e-3d2a-4f5b-8c1e-6f7a2d3e4b5a") UUID id,
         @Schema(description = "이벤트 제목", example = "전자컴퓨터공학부 2025-2 사물함 신청") String title,
         @Schema(description = "이벤트 시작 시간", example = "2025-08-01T15:00:00") LocalDateTime startAt,
         @Schema(description = "이벤트 종료 시간", example = "2025-08-01T16:00:00") LocalDateTime endAt,

--- a/src/main/java/com/jnulocker/events/application/port/in/response/MyEventResponse.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/response/MyEventResponse.java
@@ -3,9 +3,10 @@ package com.jnulocker.events.application.port.in.response;
 import com.jnulocker.events.domain.Event;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 public record MyEventResponse(
-        @Schema(description = "이벤트 ID", example = "1") Long eventId,
+        @Schema(description = "이벤트 ID", example = "2b0c4f8e-3d2a-4f5b-8c1e-6f7a2d3e4b5a") UUID id,
         @Schema(description = "이벤트 제목", example = "전자컴퓨터공학부 2025-2 사물함 신청") String title,
         @Schema(description = "이벤트 주최 조직이름", example = "전자컴퓨터공학부 학생회") String departmentNickname,
         @Schema(description = "이벤트 시작 시간", example = "2025-08-01T15:00:00") LocalDateTime startAt,

--- a/src/main/java/com/jnulocker/events/application/port/out/EventLoadPort.java
+++ b/src/main/java/com/jnulocker/events/application/port/out/EventLoadPort.java
@@ -4,14 +4,15 @@ import com.jnulocker.events.domain.Event;
 import com.jnulocker.organization.domain.Department;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface EventLoadPort {
 
-    boolean existsById(Long eventId);
+    boolean existsById(UUID eventId);
 
-    Optional<Event> getById(Long eventId);
+    Optional<Event> getById(UUID eventId);
 
     Page<Event> getAllEvents(Pageable pageable);
 

--- a/src/main/java/com/jnulocker/events/application/port/out/FloorLoadPort.java
+++ b/src/main/java/com/jnulocker/events/application/port/out/FloorLoadPort.java
@@ -2,8 +2,9 @@ package com.jnulocker.events.application.port.out;
 
 import com.jnulocker.events.domain.Floor;
 import java.util.List;
+import java.util.UUID;
 
 public interface FloorLoadPort {
 
-    List<Floor> getFloorsByEventId(Long eventId);
+    List<Floor> getFloorsByEventId(UUID eventId);
 }

--- a/src/main/java/com/jnulocker/events/application/service/EventCommandService.java
+++ b/src/main/java/com/jnulocker/events/application/service/EventCommandService.java
@@ -23,6 +23,7 @@ import com.jnulocker.organization.exception.DepartmentNotFoundException;
 import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -45,7 +46,7 @@ public class EventCommandService implements EventCommand {
 
     @Override
     @Transactional
-    public void deleteEvent(Long eventId) {
+    public void deleteEvent(UUID eventId) {
         Long memberId = SecurityUtils.getCurrentMemberId();
         Member member = memberQuery.findByIdOrThrow(memberId);
 
@@ -76,7 +77,7 @@ public class EventCommandService implements EventCommand {
 
     @Override
     @Transactional
-    public void publishEvent(Long eventId, PublishEventRequest request) {
+    public void publishEvent(UUID eventId, PublishEventRequest request) {
         Event event = eventQuery.getByIdOrThrow(eventId);
         event.updatePublishStatus(request.isPublish());
     }

--- a/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
+++ b/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
@@ -17,6 +17,7 @@ import com.jnulocker.events.exception.LockerNotFoundException;
 import com.jnulocker.member.application.port.in.MemberQuery;
 import com.jnulocker.member.domain.Member;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -32,7 +33,7 @@ public class EventQueryService implements EventQuery {
     private final MemberQuery memberQuery;
 
     @Override
-    public Event getByIdOrThrow(Long eventId) {
+    public Event getByIdOrThrow(UUID eventId) {
         return eventLoadPort.getById(eventId).orElseThrow(() -> EventNotFoundException.EXCEPTION);
     }
 
@@ -71,7 +72,7 @@ public class EventQueryService implements EventQuery {
     }
 
     @Override
-    public List<FloorWithLockersResponse> getLockersByEventId(Long eventId) {
+    public List<FloorWithLockersResponse> getLockersByEventId(UUID eventId) {
         if (!eventLoadPort.existsById(eventId)) {
             throw EventNotFoundException.EXCEPTION;
         }

--- a/src/main/java/com/jnulocker/events/domain/Event.java
+++ b/src/main/java/com/jnulocker/events/domain/Event.java
@@ -22,6 +22,7 @@ import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -36,9 +37,9 @@ import lombok.NoArgsConstructor;
 public class Event extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "event_id")
-    private Long id;
+    private UUID id;
 
     private String title;
 

--- a/src/main/java/com/jnulocker/events/event/LockerEventCreatedEvent.java
+++ b/src/main/java/com/jnulocker/events/event/LockerEventCreatedEvent.java
@@ -2,6 +2,7 @@ package com.jnulocker.events.event;
 
 import com.jnulocker.common.event.DomainEvent;
 import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -10,12 +11,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class LockerEventCreatedEvent extends DomainEvent {
 
-    private final Long eventId;
+    private final UUID eventId;
     private final LocalDateTime startAt;
     private final LocalDateTime endAt;
 
     public static LockerEventCreatedEvent of(
-            Long eventId, LocalDateTime startAt, LocalDateTime endAt) {
+            UUID eventId, LocalDateTime startAt, LocalDateTime endAt) {
         return new LockerEventCreatedEvent(eventId, startAt, endAt);
     }
 }

--- a/src/main/java/com/jnulocker/events/event/LockerEventCreatedEventHandler.java
+++ b/src/main/java/com/jnulocker/events/event/LockerEventCreatedEventHandler.java
@@ -10,6 +10,7 @@ import com.jnulocker.events.quartz.job.EventUnpublishJob;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.quartz.JobBuilder;
 import org.quartz.JobDetail;
@@ -52,7 +53,7 @@ public class LockerEventCreatedEventHandler {
             phase = TransactionPhase.BEFORE_COMMIT)
     public void handle(LockerEventCreatedEvent lockerEventCreatedEvent) throws SchedulerException {
 
-        Long eventId = lockerEventCreatedEvent.getEventId();
+        UUID eventId = lockerEventCreatedEvent.getEventId();
 
         scheduleEventJob( // Event Publish Job 등록: OPEN 2시간 전에 publish를 true로 변경
                 lockerEventCreatedEvent.getStartAt().minusHours(TWO_HOURS),
@@ -87,14 +88,14 @@ public class LockerEventCreatedEventHandler {
             LocalDateTime localDateTime,
             JobBuilder newJob,
             String jobName,
-            Long eventId,
+            UUID eventId,
             String triggerName)
             throws SchedulerException {
         Date startAt = Date.from(localDateTime.atZone(ZoneId.of(ASIA_SEOUL)).toInstant());
 
         JobDetail jobDetail =
                 newJob.withIdentity(jobName + eventId, EVENT_JOB_GROUP)
-                        .usingJobData(EVENT_ID, eventId)
+                        .usingJobData(EVENT_ID, eventId.toString())
                         .build();
 
         Trigger eventOpenTrigger =

--- a/src/main/java/com/jnulocker/events/event/LockerEventDeletedEvent.java
+++ b/src/main/java/com/jnulocker/events/event/LockerEventDeletedEvent.java
@@ -1,6 +1,7 @@
 package com.jnulocker.events.event;
 
 import com.jnulocker.common.event.DomainEvent;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -9,9 +10,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class LockerEventDeletedEvent extends DomainEvent {
 
-    private final Long eventId;
+    private final UUID eventId;
 
-    public static LockerEventDeletedEvent of(Long eventId) {
+    public static LockerEventDeletedEvent of(UUID eventId) {
         return new LockerEventDeletedEvent(eventId);
     }
 }

--- a/src/main/java/com/jnulocker/events/event/LockerEventDeletedEventHandler.java
+++ b/src/main/java/com/jnulocker/events/event/LockerEventDeletedEventHandler.java
@@ -1,5 +1,6 @@
 package com.jnulocker.events.event;
 
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.quartz.JobKey;
 import org.quartz.Scheduler;
@@ -24,7 +25,7 @@ public class LockerEventDeletedEventHandler {
             classes = LockerEventDeletedEvent.class,
             phase = TransactionPhase.BEFORE_COMMIT)
     public void handle(LockerEventDeletedEvent lockerEventDeletedEvent) throws SchedulerException {
-        Long eventId = lockerEventDeletedEvent.getEventId();
+        UUID eventId = lockerEventDeletedEvent.getEventId();
 
         // Event Publish Job 삭제
         deleteJob(PUBLISH_JOB_NAME, eventId);
@@ -39,7 +40,7 @@ public class LockerEventDeletedEventHandler {
         deleteJob(UNPUBLISH_JOB_NAME, eventId);
     }
 
-    private void deleteJob(String jobName, Long eventId) throws SchedulerException {
+    private void deleteJob(String jobName, UUID eventId) throws SchedulerException {
         JobKey jobKey = new JobKey(jobName + eventId, EVENT_JOB_GROUP);
         if (scheduler.checkExists(jobKey)) {
             scheduler.deleteJob(jobKey);

--- a/src/main/java/com/jnulocker/events/quartz/job/EventCloseJob.java
+++ b/src/main/java/com/jnulocker/events/quartz/job/EventCloseJob.java
@@ -3,6 +3,7 @@ package com.jnulocker.events.quartz.job;
 import com.jnulocker.events.application.port.in.EventCommand;
 import com.jnulocker.events.application.port.in.EventQuery;
 import com.jnulocker.events.domain.Event;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.quartz.Job;
@@ -14,7 +15,7 @@ public class EventCloseJob implements Job {
     private final EventQuery eventQuery;
     private final EventCommand eventCommand;
 
-    @Setter private Long eventId; // JobDataMap에서 eventId를 가져오기 위해 Setter 사용
+    @Setter private UUID eventId; // JobDataMap에서 eventId를 가져오기 위해 Setter 사용
 
     @Override
     public void execute(JobExecutionContext context) {

--- a/src/main/java/com/jnulocker/events/quartz/job/EventOpenJob.java
+++ b/src/main/java/com/jnulocker/events/quartz/job/EventOpenJob.java
@@ -3,6 +3,7 @@ package com.jnulocker.events.quartz.job;
 import com.jnulocker.events.application.port.in.EventCommand;
 import com.jnulocker.events.application.port.in.EventQuery;
 import com.jnulocker.events.domain.Event;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.quartz.Job;
@@ -14,7 +15,7 @@ public class EventOpenJob implements Job {
     private final EventQuery eventQuery;
     private final EventCommand eventCommand;
 
-    @Setter private Long eventId; // JobDataMap에서 eventId를 가져오기 위해 Setter 사용
+    @Setter private UUID eventId; // JobDataMap에서 eventId를 가져오기 위해 Setter 사용
 
     @Override
     public void execute(JobExecutionContext context) {

--- a/src/main/java/com/jnulocker/events/quartz/job/EventPublishJob.java
+++ b/src/main/java/com/jnulocker/events/quartz/job/EventPublishJob.java
@@ -3,6 +3,7 @@ package com.jnulocker.events.quartz.job;
 import com.jnulocker.events.application.port.in.EventCommand;
 import com.jnulocker.events.application.port.in.EventQuery;
 import com.jnulocker.events.domain.Event;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.quartz.Job;
@@ -14,7 +15,7 @@ public class EventPublishJob implements Job {
     private final EventQuery eventQuery;
     private final EventCommand eventCommand;
 
-    @Setter private Long eventId;
+    @Setter private UUID eventId;
 
     @Override
     public void execute(JobExecutionContext jobExecutionContext) {

--- a/src/main/java/com/jnulocker/events/quartz/job/EventUnpublishJob.java
+++ b/src/main/java/com/jnulocker/events/quartz/job/EventUnpublishJob.java
@@ -3,6 +3,7 @@ package com.jnulocker.events.quartz.job;
 import com.jnulocker.events.application.port.in.EventCommand;
 import com.jnulocker.events.application.port.in.EventQuery;
 import com.jnulocker.events.domain.Event;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.quartz.Job;
@@ -14,7 +15,7 @@ public class EventUnpublishJob implements Job {
     private final EventQuery eventQuery;
     private final EventCommand eventCommand;
 
-    @Setter private Long eventId;
+    @Setter private UUID eventId;
 
     @Override
     public void execute(JobExecutionContext jobExecutionContext) {

--- a/src/main/java/com/jnulocker/registration/adapter/in/RegistrationController.java
+++ b/src/main/java/com/jnulocker/registration/adapter/in/RegistrationController.java
@@ -8,6 +8,7 @@ import com.jnulocker.registration.application.port.in.response.RegistrationCusto
 import com.jnulocker.registration.application.port.in.response.RegistrationPageable;
 import com.jnulocker.registration.application.port.in.response.RegistrationResponse;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
@@ -32,7 +33,7 @@ public class RegistrationController implements RegistrationApi {
     @Override
     @GetMapping
     public ResponseEntity<RegistrationCustomPage> getRegistrations(
-            @PathVariable("event-id") Long eventId,
+            @PathVariable("event-id") UUID eventId,
             @Valid @ParameterObject RegistrationPageable registrationPageable) {
         Pageable pageable = registrationPageable.toPageable();
         return ResponseEntity.ok(registrationQuery.getRegistrations(eventId, pageable));
@@ -41,14 +42,14 @@ public class RegistrationController implements RegistrationApi {
     @Override
     @GetMapping("/me")
     public ResponseEntity<RegistrationResponse> getMyRegistration(
-            @PathVariable("event-id") Long eventId) {
+            @PathVariable("event-id") UUID eventId) {
         return ResponseEntity.ok(registrationQuery.getMyRegistration(eventId));
     }
 
     @Override
     @PostMapping
     public ResponseEntity<Void> registerForEvent(
-            @PathVariable("event-id") Long eventId,
+            @PathVariable("event-id") UUID eventId,
             @Valid @RequestBody RegisterForEventRequest request) {
         registrationCommand.registerForEvent(eventId, request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
@@ -56,7 +57,7 @@ public class RegistrationController implements RegistrationApi {
 
     @Override
     @DeleteMapping("/me")
-    public ResponseEntity<Void> cancelMyRegistration(@PathVariable("event-id") Long eventId) {
+    public ResponseEntity<Void> cancelMyRegistration(@PathVariable("event-id") UUID eventId) {
         registrationCommand.cancelMyRegistration(eventId);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/jnulocker/registration/adapter/in/docs/RegistrationApi.java
+++ b/src/main/java/com/jnulocker/registration/adapter/in/docs/RegistrationApi.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -30,7 +31,7 @@ public interface RegistrationApi {
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = RegistrationCustomPage.class)))
     ResponseEntity<RegistrationCustomPage> getRegistrations(
-            @PathVariable("event-id") Long eventId,
+            @PathVariable("event-id") UUID eventId,
             @Valid @ParameterObject RegistrationPageable registrationPageable);
 
     @ApiExceptionExamples(GetMyRegistrationExceptionDocs.class)
@@ -42,17 +43,17 @@ public interface RegistrationApi {
                     @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = RegistrationResponse.class)))
-    ResponseEntity<RegistrationResponse> getMyRegistration(@PathVariable("event-id") Long eventId);
+    ResponseEntity<RegistrationResponse> getMyRegistration(@PathVariable("event-id") UUID eventId);
 
     @ApiExceptionExamples(RegistrationForEventExceptionDocs.class)
     @Operation(summary = "사물함 신청", description = "이벤트에 신청합니다. 사물함을 선택할 수 있습니다.")
     @ApiResponse(responseCode = "201", description = "사물함 신청 성공")
     ResponseEntity<Void> registerForEvent(
-            @PathVariable("event-id") Long eventId,
+            @PathVariable("event-id") UUID eventId,
             @Valid @RequestBody RegisterForEventRequest request);
 
     @ApiExceptionExamples(CancelMyRegistrationExceptionDocs.class)
     @Operation(summary = "사물함 신청 취소", description = "해당 이벤트에 대한 사물함 신청을 취소합니다.")
     @ApiResponse(responseCode = "204", description = "사물함 신청 취소 성공")
-    ResponseEntity<Void> cancelMyRegistration(@PathVariable("event-id") Long eventId);
+    ResponseEntity<Void> cancelMyRegistration(@PathVariable("event-id") UUID eventId);
 }

--- a/src/main/java/com/jnulocker/registration/adapter/out/RegistrationPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/registration/adapter/out/RegistrationPersistenceAdapter.java
@@ -5,6 +5,7 @@ import com.jnulocker.registration.application.port.out.RegistrationLoadPort;
 import com.jnulocker.registration.application.port.out.RegistrationRecordPort;
 import com.jnulocker.registration.domain.Registration;
 import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -27,17 +28,17 @@ public class RegistrationPersistenceAdapter
     }
 
     @Override
-    public boolean existsByMemberIdAndEventId(Long memberId, Long eventId) {
+    public boolean existsByMemberIdAndEventId(Long memberId, UUID eventId) {
         return registrationRepository.existsByMemberIdAndLocker_Floor_EventId(memberId, eventId);
     }
 
     @Override
-    public Page<Registration> getRegistrationsByEventId(Long eventId, Pageable pageable) {
+    public Page<Registration> getRegistrationsByEventId(UUID eventId, Pageable pageable) {
         return registrationRepository.findAllByLocker_Floor_EventId(eventId, pageable);
     }
 
     @Override
-    public Optional<Registration> getRegistrationByMemberIdAndEventId(Long memberId, Long eventId) {
+    public Optional<Registration> getRegistrationByMemberIdAndEventId(Long memberId, UUID eventId) {
         return registrationRepository.findByMemberIdAndLocker_Floor_EventId(memberId, eventId);
     }
 }

--- a/src/main/java/com/jnulocker/registration/adapter/out/RegistrationRepository.java
+++ b/src/main/java/com/jnulocker/registration/adapter/out/RegistrationRepository.java
@@ -2,13 +2,14 @@ package com.jnulocker.registration.adapter.out;
 
 import com.jnulocker.registration.domain.Registration;
 import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RegistrationRepository extends JpaRepository<Registration, Long> {
-    boolean existsByMemberIdAndLocker_Floor_EventId(Long memberId, Long eventId);
+    boolean existsByMemberIdAndLocker_Floor_EventId(Long memberId, UUID eventId);
 
     @EntityGraph(
             attributePaths = {
@@ -18,8 +19,8 @@ public interface RegistrationRepository extends JpaRepository<Registration, Long
                 "locker",
                 "locker.floor"
             })
-    Page<Registration> findAllByLocker_Floor_EventId(Long eventId, Pageable pageable);
+    Page<Registration> findAllByLocker_Floor_EventId(UUID eventId, Pageable pageable);
 
     @EntityGraph(attributePaths = {"member", "member.department", "locker", "locker.floor"})
-    Optional<Registration> findByMemberIdAndLocker_Floor_EventId(Long memberId, Long eventId);
+    Optional<Registration> findByMemberIdAndLocker_Floor_EventId(Long memberId, UUID eventId);
 }

--- a/src/main/java/com/jnulocker/registration/application/port/in/RegistrationCommand.java
+++ b/src/main/java/com/jnulocker/registration/application/port/in/RegistrationCommand.java
@@ -1,9 +1,10 @@
 package com.jnulocker.registration.application.port.in;
 
 import com.jnulocker.registration.application.port.in.request.RegisterForEventRequest;
+import java.util.UUID;
 
 public interface RegistrationCommand {
-    void registerForEvent(Long eventId, RegisterForEventRequest request);
+    void registerForEvent(UUID eventId, RegisterForEventRequest request);
 
-    void cancelMyRegistration(Long eventId);
+    void cancelMyRegistration(UUID eventId);
 }

--- a/src/main/java/com/jnulocker/registration/application/port/in/RegistrationQuery.java
+++ b/src/main/java/com/jnulocker/registration/application/port/in/RegistrationQuery.java
@@ -2,10 +2,11 @@ package com.jnulocker.registration.application.port.in;
 
 import com.jnulocker.registration.application.port.in.response.RegistrationCustomPage;
 import com.jnulocker.registration.application.port.in.response.RegistrationResponse;
+import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 
 public interface RegistrationQuery {
-    RegistrationCustomPage getRegistrations(Long eventId, Pageable pageable);
+    RegistrationCustomPage getRegistrations(UUID eventId, Pageable pageable);
 
-    RegistrationResponse getMyRegistration(Long eventId);
+    RegistrationResponse getMyRegistration(UUID eventId);
 }

--- a/src/main/java/com/jnulocker/registration/application/port/out/RegistrationLoadPort.java
+++ b/src/main/java/com/jnulocker/registration/application/port/out/RegistrationLoadPort.java
@@ -2,14 +2,15 @@ package com.jnulocker.registration.application.port.out;
 
 import com.jnulocker.registration.domain.Registration;
 import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface RegistrationLoadPort {
 
-    boolean existsByMemberIdAndEventId(Long memberId, Long eventId);
+    boolean existsByMemberIdAndEventId(Long memberId, UUID eventId);
 
-    Page<Registration> getRegistrationsByEventId(Long eventId, Pageable pageable);
+    Page<Registration> getRegistrationsByEventId(UUID eventId, Pageable pageable);
 
-    Optional<Registration> getRegistrationByMemberIdAndEventId(Long memberId, Long eventId);
+    Optional<Registration> getRegistrationByMemberIdAndEventId(Long memberId, UUID eventId);
 }

--- a/src/main/java/com/jnulocker/registration/application/service/RegistrationCommandService.java
+++ b/src/main/java/com/jnulocker/registration/application/service/RegistrationCommandService.java
@@ -14,6 +14,7 @@ import com.jnulocker.registration.application.port.out.RegistrationRecordPort;
 import com.jnulocker.registration.domain.Registration;
 import com.jnulocker.registration.exception.RegistrationAlreadyExistsException;
 import com.jnulocker.registration.exception.RegistrationNotFoundException;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,7 +30,7 @@ public class RegistrationCommandService implements RegistrationCommand {
 
     @Override
     @Transactional
-    public void registerForEvent(Long eventId, RegisterForEventRequest request) {
+    public void registerForEvent(UUID eventId, RegisterForEventRequest request) {
         Long memberId = SecurityUtils.getCurrentMemberId();
         Member member = memberQuery.findByIdOrThrow(memberId);
 
@@ -51,7 +52,7 @@ public class RegistrationCommandService implements RegistrationCommand {
 
     @Override
     @Transactional
-    public void cancelMyRegistration(Long eventId) {
+    public void cancelMyRegistration(UUID eventId) {
         Long memberId = SecurityUtils.getCurrentMemberId();
         Event event = eventQuery.getByIdOrThrow(eventId);
         Registration registration =

--- a/src/main/java/com/jnulocker/registration/application/service/RegistrationQueryService.java
+++ b/src/main/java/com/jnulocker/registration/application/service/RegistrationQueryService.java
@@ -9,6 +9,7 @@ import com.jnulocker.registration.application.port.in.response.RegistrationRespo
 import com.jnulocker.registration.application.port.out.RegistrationLoadPort;
 import com.jnulocker.registration.domain.Registration;
 import com.jnulocker.registration.exception.RegistrationNotFoundException;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -22,7 +23,7 @@ public class RegistrationQueryService implements RegistrationQuery {
     private final RegistrationLoadPort registrationLoadPort;
 
     @Override
-    public RegistrationCustomPage getRegistrations(Long eventId, Pageable pageable) {
+    public RegistrationCustomPage getRegistrations(UUID eventId, Pageable pageable) {
         Event event = eventQuery.getByIdOrThrow(eventId);
         Page<Registration> registrations =
                 registrationLoadPort.getRegistrationsByEventId(event.getId(), pageable);
@@ -30,7 +31,7 @@ public class RegistrationQueryService implements RegistrationQuery {
     }
 
     @Override
-    public RegistrationResponse getMyRegistration(Long eventId) {
+    public RegistrationResponse getMyRegistration(UUID eventId) {
         Long memberId = SecurityUtils.getCurrentMemberId();
         Registration registration =
                 registrationLoadPort

--- a/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
@@ -24,6 +24,7 @@ import io.restassured.RestAssured;
 import io.restassured.http.Cookie;
 import io.restassured.response.ValidatableResponse;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -137,7 +138,7 @@ public class EventControllerIntegrationTest {
     @Test
     void 존재하지_않는_이벤트_ID로_조회하면_Event_Not_Found_에러_응답을_받는다() {
         // given
-        Long nonExistentEventId = -1L;
+        UUID nonExistentEventId = UUID.randomUUID();
 
         // when
         ErrorResponse errorResponse =
@@ -173,7 +174,7 @@ public class EventControllerIntegrationTest {
         createEvent();
 
         // 생성된 이벤트 조회
-        Long eventId = getLastEventId();
+        UUID eventId = getLastEventId();
 
         // when
         deleteEvent(eventId).statusCode(HttpStatus.NO_CONTENT.value());
@@ -192,7 +193,7 @@ public class EventControllerIntegrationTest {
     @Test
     void 존재하지_않는_이벤트는_삭제할_수_없다() {
         // given
-        Long nonExistentEventId = Long.MAX_VALUE;
+        UUID nonExistentEventId = UUID.randomUUID();
 
         // when
         ErrorResponse errorResponse =
@@ -211,7 +212,7 @@ public class EventControllerIntegrationTest {
         createEvent();
 
         // 생성된 이벤트 조회
-        Long eventId = getLastEventId();
+        UUID eventId = getLastEventId();
 
         // 비조직원으로 로그인
         accessToken = authTestUtil.generateAccessTokenWithAnotherDepartment(Role.MANAGER);
@@ -234,7 +235,7 @@ public class EventControllerIntegrationTest {
         createEvent();
 
         // 생성된 이벤트 조회
-        Long eventId = getLastEventId();
+        UUID eventId = getLastEventId();
 
         PublishEventRequest request = new PublishEventRequest(true);
 
@@ -252,7 +253,7 @@ public class EventControllerIntegrationTest {
         createEvent();
 
         // 생성된 이벤트 조회
-        Long eventId = getLastEventId();
+        UUID eventId = getLastEventId();
 
         PublishEventRequest request = new PublishEventRequest(false);
 
@@ -267,7 +268,7 @@ public class EventControllerIntegrationTest {
     @Test
     void 존재하지_않는_이벤트는_publish_상태로_변경할_수_없다() {
         // given
-        Long nonExistentEventId = Long.MAX_VALUE;
+        UUID nonExistentEventId = UUID.randomUUID();
 
         PublishEventRequest request = new PublishEventRequest(true);
 
@@ -342,7 +343,7 @@ public class EventControllerIntegrationTest {
     }
 
     // 이벤트 검색 메서드들
-    public static ValidatableResponse getEventLockers(Long eventId, String accessToken) {
+    public static ValidatableResponse getEventLockers(UUID eventId, String accessToken) {
         return given().contentType(MediaType.APPLICATION_JSON_VALUE)
                 .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
                 .when()
@@ -407,7 +408,7 @@ public class EventControllerIntegrationTest {
         return Math.min(remainingItems, pageSize);
     }
 
-    private Long getLastEventId() {
+    private UUID getLastEventId() {
         return getEvents(0, 10, accessToken)
                 .statusCode(HttpStatus.OK.value())
                 .extract()
@@ -418,7 +419,7 @@ public class EventControllerIntegrationTest {
     }
 
     // 이벤트 수정 메서드들
-    private ValidatableResponse deleteEvent(Long eventId) {
+    private ValidatableResponse deleteEvent(UUID eventId) {
         return given().contentType(MediaType.APPLICATION_JSON_VALUE)
                 .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
                 .when()
@@ -428,7 +429,7 @@ public class EventControllerIntegrationTest {
                 .all();
     }
 
-    private ValidatableResponse publishEvent(Long eventId, PublishEventRequest request) {
+    private ValidatableResponse publishEvent(UUID eventId, PublishEventRequest request) {
         return given().contentType(MediaType.APPLICATION_JSON_VALUE)
                 .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
                 .body(request)

--- a/src/test/java/com/jnulocker/events/utils/EventTestUtil.java
+++ b/src/test/java/com/jnulocker/events/utils/EventTestUtil.java
@@ -24,6 +24,7 @@ import com.jnulocker.organization.domain.Organization;
 import com.jnulocker.organization.utils.OrganizationTestUtil;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -176,7 +177,7 @@ public class EventTestUtil {
         organizationRepository.deleteAll();
     }
 
-    public Event getEventById(Long eventId) {
+    public Event getEventById(UUID eventId) {
         return eventRepository.findById(eventId).orElseThrow();
     }
 }

--- a/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
@@ -17,7 +17,6 @@ import com.jnulocker.events.utils.EventTestUtil;
 import com.jnulocker.events.utils.LockerEventContext;
 import com.jnulocker.member.domain.Role;
 import com.jnulocker.member.utils.MemberTestUtil;
-import com.jnulocker.organization.utils.OrganizationTestUtil;
 import com.jnulocker.registration.application.port.in.request.RegisterForEventRequest;
 import com.jnulocker.registration.application.port.in.response.RegistrationCustomPage;
 import com.jnulocker.registration.application.port.in.response.RegistrationListItem;
@@ -29,6 +28,7 @@ import io.restassured.RestAssured;
 import io.restassured.http.Cookie;
 import io.restassured.response.ValidatableResponse;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -58,8 +58,6 @@ class RegistrationControllerIntegrationTest {
     @Autowired private MemberTestUtil memberTestUtil;
 
     @Autowired private AuthTestUtil authTestUtil;
-
-    @Autowired private OrganizationTestUtil organizationTestUtil;
 
     @Autowired private RegistrationTestUtil registrationTestUtil;
 
@@ -271,9 +269,11 @@ class RegistrationControllerIntegrationTest {
 
         Event event = context.event();
 
+        UUID nonExistentEventId = UUID.randomUUID();
+
         // when
         ErrorResponse errorResponse =
-                registerForEvent(Long.MAX_VALUE, createRequestForAvailableLocker(event))
+                registerForEvent(nonExistentEventId, createRequestForAvailableLocker(event))
                         .statusCode(EventErrorCode.EVENT_NOT_FOUND.getHttpStatus().value())
                         .extract()
                         .as(ErrorResponse.class);
@@ -468,9 +468,11 @@ class RegistrationControllerIntegrationTest {
 
         registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
 
+        UUID nonExistentEventId = UUID.randomUUID();
+
         // when, then
         ErrorResponse errorResponse =
-                cancelMyRegistration(Long.MAX_VALUE)
+                cancelMyRegistration(nonExistentEventId)
                         .statusCode(EventErrorCode.EVENT_NOT_FOUND.getHttpStatus().value())
                         .extract()
                         .as(ErrorResponse.class);
@@ -520,7 +522,7 @@ class RegistrationControllerIntegrationTest {
                 .isEqualTo(availableLockerCountBefore - 1);
     }
 
-    private ValidatableResponse getRegistrations(Long eventId) {
+    private ValidatableResponse getRegistrations(UUID eventId) {
         return given().cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
                 .when()
                 .get(REGISTRATION_URL, eventId)
@@ -529,7 +531,7 @@ class RegistrationControllerIntegrationTest {
                 .ifError();
     }
 
-    private ValidatableResponse getMyRegistration(Long eventId) {
+    private ValidatableResponse getMyRegistration(UUID eventId) {
         return given().cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
                 .when()
                 .get(REGISTRATION_URL + "/me", eventId)
@@ -538,7 +540,7 @@ class RegistrationControllerIntegrationTest {
                 .ifError();
     }
 
-    private ValidatableResponse registerForEvent(Long eventId, RegisterForEventRequest request) {
+    private ValidatableResponse registerForEvent(UUID eventId, RegisterForEventRequest request) {
         return given().contentType(MediaType.APPLICATION_JSON_VALUE)
                 .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
                 .body(request)
@@ -549,7 +551,7 @@ class RegistrationControllerIntegrationTest {
                 .ifError();
     }
 
-    private ValidatableResponse cancelMyRegistration(Long eventId) {
+    private ValidatableResponse cancelMyRegistration(UUID eventId) {
         return given().cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
                 .when()
                 .delete(REGISTRATION_URL + "/me", eventId)


### PR DESCRIPTION
### 개요
close #80 

### 작업사항

#### AS-IS 

- 이벤트 ID가 `Long`

  ```java
  public class Event extends BaseEntity {
  
      @Id
      @GeneratedValue(strategy = GenerationType.IDENTITY)
      @Column(name = "event_id")
      private Long id;
  ```

#### TO-BE

- 이벤트 ID를 `UUID`로 변경

  ```java
  public class Event extends BaseEntity {
  
      @Id
      @GeneratedValue(strategy = GenerationType.UUID)
      @Column(name = "event_id")
      private UUID id;
  ```

### 변경로직
- 이벤트 ID를 `Long` 에서 `UUID`로 변경
- 연관된 모든 로직에서 `Long` 대신 `UUID`를 사용하도록 변경
- 테스트코드 수정

### 테스트 결과

  <img width="276" alt="image" src="https://github.com/user-attachments/assets/6c6610b8-e64d-46a7-8e17-3738e5bc22d5" />

### reference

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - 이벤트 및 등록 관련 기능에서 이벤트 식별자가 Long 타입에서 UUID 타입으로 변경되었습니다. 이제 모든 이벤트 및 등록 API, 응답, 내부 처리에서 UUID 형식의 이벤트 ID를 사용합니다.

- **Bug Fixes**
    - 테스트 코드 및 예시에서 존재하지 않는 이벤트 ID를 UUID로 생성하여 실제 동작과 일치하도록 개선되었습니다.

- **Tests**
    - 통합 테스트 및 유틸리티에서 이벤트 ID 타입을 UUID로 변경하여 실제 서비스와 일관성을 유지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->