### PR TITLE
[FEAT] 이벤트 목록 조회 시 MANAGER 소속 학과 이벤트만 조회되도록 수정

### DIFF
--- a/src/main/java/com/jnulocker/events/adapter/out/EventPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/EventPersistenceAdapter.java
@@ -35,8 +35,8 @@ public class EventPersistenceAdapter implements EventLoadPort, EventRecordPort {
     }
 
     @Override
-    public Page<Event> getAllEvents(Pageable pageable) {
-        return eventRepository.findAll(pageable);
+    public Page<Event> getAllEventsByDepartment(Department department, Pageable pageable) {
+        return eventRepository.findAllByDepartment(department, pageable);
     }
 
     @Override

--- a/src/main/java/com/jnulocker/events/adapter/out/EventRepository.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/EventRepository.java
@@ -4,6 +4,8 @@ import com.jnulocker.events.domain.Event;
 import com.jnulocker.organization.domain.Department;
 import java.util.List;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -11,4 +13,6 @@ public interface EventRepository extends JpaRepository<Event, UUID> {
 
     @EntityGraph(attributePaths = {"department"})
     List<Event> findAllByPublishTrueAndEventParticipations_Department(Department department);
+
+    Page<Event> findAllByDepartment(Department department, Pageable pageable);
 }

--- a/src/main/java/com/jnulocker/events/application/port/out/EventLoadPort.java
+++ b/src/main/java/com/jnulocker/events/application/port/out/EventLoadPort.java
@@ -14,7 +14,7 @@ public interface EventLoadPort {
 
     Optional<Event> getById(UUID eventId);
 
-    Page<Event> getAllEvents(Pageable pageable);
+    Page<Event> getAllEventsByDepartment(Department department, Pageable pageable);
 
     List<Event> getEventsByParticipationDepartment(Department department);
 }

--- a/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
+++ b/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
@@ -39,8 +39,11 @@ public class EventQueryService implements EventQuery {
 
     @Override
     public EventCustomPage getAllEvents(Pageable pageable) {
-        // TODO: MANAGER가 조회하는 경우 자신이 소속된 조직의 이벤트만 조회할 수 있도록 수정
-        Page<Event> events = eventLoadPort.getAllEvents(pageable);
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        Member member = memberQuery.findByIdWithDepartmentOrThrow(memberId);
+
+        Page<Event> events =
+                eventLoadPort.getAllEventsByDepartment(member.getDepartment(), pageable);
         return EventCustomPage.from(events);
     }
 

--- a/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
@@ -89,8 +89,13 @@ public class EventControllerIntegrationTest {
     })
     void 이벤트_목록을_조회할_수_있다(int createCount, int pageSize, int page, boolean expectedLast) {
         // given
+        Department department = organizationTestUtil.createCouncilDepartment();
+        Member member = memberTestUtil.createMemberFromRoleWithDepartment(Role.MANAGER, department);
+        accessToken = authTestUtil.generateAccessTokenWithMember(member);
+
         for (int i = 0; i < createCount; i++) {
-            eventTestUtil.createEventWithFloorAndLockers(List.of(1), EventStatus.OPEN, true);
+            eventTestUtil.createEventWithParticipationDepartment(
+                    List.of(5, 10), department, EventStatus.OPEN, true);
         }
 
         // when
@@ -105,6 +110,28 @@ public class EventControllerIntegrationTest {
         assertThat(eventCustomPage.content()).hasSize(expectedSize);
         assertThat(eventCustomPage.totalElements()).isEqualTo(createCount);
         assertThat(eventCustomPage.last()).isEqualTo(expectedLast);
+    }
+
+    @Test
+    void 자신의_소속학과가_주관하지_않는_이벤트는_조회할_수_없다() {
+        // given
+        Department department = organizationTestUtil.createCouncilDepartment();
+        Member member = memberTestUtil.createMemberFromRoleWithDepartment(Role.USER, department);
+        accessToken = authTestUtil.generateAccessTokenWithMember(member);
+
+        // 이벤트 생성: 비참여 학과로 생성
+        eventTestUtil.createEventWithFloorAndLockers(List.of(5, 10), EventStatus.OPEN, true);
+
+        // when
+        List<MyEventResponse> myEvents =
+                getMyEvents(accessToken)
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .jsonPath()
+                        .getList(".", MyEventResponse.class);
+
+        // then
+        assertThat(myEvents).isEmpty();
     }
 
     @ParameterizedTest(name = "층별 사물함 수: {0}")


### PR DESCRIPTION
### 개요
close #82 

### 작업사항
- 이벤트 목록 조회 시 MANAGER 소속 학과 이벤트만 조회되도록 수정

### 변경로직
- 이벤트 목록 조회 시 MANAGER 정보 조회
- 해당 MANAGER의 소속학과가 주관하는 쿼리 작성

### 테스트 결과

  <img width="302" alt="image" src="https://github.com/user-attachments/assets/e55d94c6-2e26-4826-a40c-bf55b7b3b82a" />

#### 추가된 테스트케이스

  <img width="352" alt="image" src="https://github.com/user-attachments/assets/78d24c5e-c353-4989-9069-83f25a3f82ee" />

### reference

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 이벤트 목록 조회 시 사용자의 소속 학과별로 필터링되어 조회됩니다.
- **버그 수정**
	- 소속 학과가 주관하지 않는 이벤트는 더 이상 조회되지 않습니다.
- **테스트**
	- 사용자가 소속 학과가 주관하지 않은 이벤트를 조회할 수 없는지 확인하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->