### PR TITLE
[CHORE] Prometheus, Grafana 모니터링 구축

### DIFF
--- a/config/grafana.ini
+++ b/config/grafana.ini
@@ -1,0 +1,5 @@
+[server]
+# The full public facing url you use in browser, used for redirects and emails
+# If you use reverse proxy and sub path specify full url (with sub path)
+root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana/
+serve_from_sub_path = true

--- a/config/prometheus.yml.tmpl
+++ b/config/prometheus.yml.tmpl
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: ${SCRAPE_INTERVAL}
+  evaluation_interval: ${EVALUATION_INTERVAL}
+scrape_configs:
+  - job_name: 'prometheus'
+    metrics_path: '${MANAGEMENT_BASE_PATH}/prometheus'
+    static_configs:
+      - targets: ['${WAS_TARGET}:8080']

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,7 +4,9 @@ echo -e "배포 스크립트 시작\n\n"
 # .env 파일 로드
 echo "환경 변수 로드 중..."
 if [ -f ".env" ]; then
-    export $(grep -v '^#' .env | xargs)
+    set -o allexport
+    source .env
+    set +o allexport
     echo ".env 파일 로드 완료"
 else
     echo ".env 파일이 존재하지 않습니다"

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,25 @@
 #!/bin/bash
 echo -e "배포 스크립트 시작\n\n"
 
+# .env 파일 로드
+echo "환경 변수 로드 중..."
+if [ -f ".env" ]; then
+    export $(grep -v '^#' .env | xargs)
+    echo ".env 파일 로드 완료"
+else
+    echo ".env 파일이 존재하지 않습니다"
+    exit 1
+fi
+
+# prometheus.yml 생성
+echo "prometheus.yml 생성 중..."
+if envsubst < ./config/prometheus.yml.tmpl > ./config/prometheus.yml; then
+    echo "prometheus.yml 생성 완료"
+else
+    echo "prometheus.yml 생성 실패"
+    exit 1
+fi
+
 # WAS 이미지 pull
 echo "WAS 이미지 pull"
 docker compose pull was

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - jnu-locker-network
 
   redis:
-    container_name: redis
+    container_name: redis-jnu-locker
     image: redis:alpine
     ports:
       - "6379:6379"
@@ -62,6 +62,78 @@ services:
     networks:
       - jnu-locker-network
 
+  prometheus:
+    # user: root # 최초 실행시에만 하기 (컨테이너 접속 후 /data 경로 nobody 권한 주는 용도)
+    container_name: prometheus-jnu-locker
+    image: prom/prometheus:latest
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./config/prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus-data:/data
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/data' # 기본값이 /data
+      - '--storage.tsdb.retention.time=1y' # 데이터 보존 기간 설정 (1년: 1y or 365d)
+    depends_on:
+      was:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9090/metrics"]
+      start_period: 20s
+      start_interval: 5s
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    networks:
+      - jnu-locker-network
+
+  grafana:
+    container_name: grafana-jnu-locker
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./config/grafana.ini:/etc/grafana/grafana.ini
+      - grafana-data:/var/lib/grafana
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}
+    depends_on:
+      prometheus:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000"]
+      start_period: 20s
+      start_interval: 5s
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    networks:
+      - jnu-locker-network
+
+  nginx:
+    image: nginx:stable-alpine
+    container_name: nginx-jnu-locker
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/conf.d/default.conf:/etc/nginx/conf.d/default.conf
+      - ./nginx/log:/home/jnu-locker/log
+    environment:
+      TZ: Asia/Seoul
+    networks:
+      - jnu-locker-network
+    depends_on:
+      was:
+        condition: service_healthy
+
 networks:
   jnu-locker-network:
     driver: bridge
+
+volumes:
+  grafana-data:
+    external: true
+  prometheus-data:
+    external: true

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -23,8 +23,8 @@ server {
     proxy_redirect / /prometheus/;
   }
 
-  location /grafana {
-    proxy_pass http://grafana:3000;
+  location /grafana/ {
+    proxy_pass http://grafana:3000/;
     proxy_set_header Host $host;
   }
 }

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -1,0 +1,30 @@
+server {
+  listen 80;
+  server_name localhost;
+
+  access_log /home/jnu-locker/log/access.log;
+  error_log /home/jnu-locker/log/error.log;
+
+  location / {
+    proxy_pass http://was:8080; # docker compose에서 서비스 이름인 was로 프록시
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location /swagger-ui {
+    proxy_pass http://was:8080;
+  }
+
+  location /prometheus/ {
+    proxy_pass http://prometheus:9090/;
+    proxy_set_header Host $host;
+    proxy_redirect / /prometheus/;
+  }
+
+  location /grafana {
+    proxy_pass http://grafana:3000;
+    proxy_set_header Host $host;
+  }
+}

--- a/src/main/java/com/jnulocker/config/SecurityConfig.java
+++ b/src/main/java/com/jnulocker/config/SecurityConfig.java
@@ -78,6 +78,8 @@ public class SecurityConfig {
                                 .hasAuthority(Role.USER.getRole())
                                 .requestMatchers(HttpMethod.GET, "/v1/auth/managers/pending")
                                 .hasAuthority(Role.MANAGER.getRole())
+                                .requestMatchers(HttpMethod.GET, "/v1/events")
+                                .hasAuthority(Role.MANAGER.getRole())
                                 .requestMatchers(
                                         HttpMethod.POST, "/v1/events", "/v1/auth/managers/approve")
                                 .hasAuthority(Role.MANAGER.getRole())


### PR DESCRIPTION
### 개요
close #84 

### 작업사항
- `prometheus`, `grafana` 서비스를 `docker compose`로 관리하며 모니터링 서비스 구축

### 변경로직
- `prometheus`, `grafana` 도커 컴포즈 서비스 구축
- `nginx` 리버스 프록시 설정
- 배포 스크립트에 `grafana` 설정파일 생성 스크립트 추가

### 테스트 결과

  <img width="333" alt="image" src="https://github.com/user-attachments/assets/d65772ee-d0c1-48c4-b4c0-898fb0c15897" />

### reference
- 디스코드 `정보-공유` 채널 `BE 서버 주소`에 관련 주소 업로드했습니다.

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - Prometheus, Grafana, Nginx 서비스가 추가되어 모니터링 및 대시보드 기능을 제공합니다.
    - Grafana와 Prometheus 데이터의 영구 저장을 위한 외부 볼륨이 추가되었습니다.
    - Grafana가 서브 경로(`/grafana/`)에서 서비스되도록 설정이 추가되었습니다.
    - "/v1/events" GET 요청에 대해 MANAGER 권한이 부여되었습니다.

- **버그 수정**
    - Redis 컨테이너의 이름이 `redis-jnu-locker`로 변경되었습니다.

- **문서화**
    - Prometheus 및 Grafana 설정 템플릿이 추가되었습니다.

- **기타**
    - 배포 스크립트에 환경 변수 파일 로드 및 설정 파일 생성 과정이 추가되어 설정 누락 시 오류를 안내합니다.
    - Nginx가 여러 백엔드 서비스로 리버스 프록시하도록 설정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->