### PR TITLE
[FIX] 이벤트 생성 시 스케줄링 작업 등록 AFTER_COMMIT 으로 진행

### DIFF
--- a/src/main/java/com/jnulocker/events/event/LockerEventCreatedEventHandler.java
+++ b/src/main/java/com/jnulocker/events/event/LockerEventCreatedEventHandler.java
@@ -50,7 +50,7 @@ public class LockerEventCreatedEventHandler {
 
     @TransactionalEventListener(
             classes = LockerEventCreatedEvent.class,
-            phase = TransactionPhase.BEFORE_COMMIT)
+            phase = TransactionPhase.AFTER_COMMIT)
     public void handle(LockerEventCreatedEvent lockerEventCreatedEvent) throws SchedulerException {
 
         UUID eventId = lockerEventCreatedEvent.getEventId();


### PR DESCRIPTION
### 개요
close #87 

### 작업사항

- 이벤트 생성 시 이벤트 시작 시각에 따라 다음과 같은 작업이 실행됩니다

  - 이벤트 시작 이후
    - `OPEN`, `publish = true` 스케줄링 작업 바로 실행
  - 이벤트 시작 2시간 이내 ~ 시작 이전
    - `publish = true` 작업 바로 실행
  - 이벤트 시작 2시간 이전
    - 아무 작업 안함

여기서 스케줄링 작업이 바로 실행될 때 `BEFORE_COMMIT`으로 인해 이벤트 영속화 작업이 `commit`되지 않으면서 스케줄링 작업 실행 시 이벤트 내용 조회가 불가능해 에러가 발생하는 상황이었습니다.

`@TransactionalEventListener`의 `phase` 옵션을 `AFTER_COMMIT`으로 변경해 영속화 이후 작업이 바로 실행될 수 있도록 합니다.

### 변경로직
- `@TransactionalEventListener`의 `phase` 옵션을 `AFTER_COMMIT`으로 변경

### 테스트 결과

  <img width="333" alt="image" src="https://github.com/user-attachments/assets/b4efd1d3-79e4-4601-8cc7-0b45d4e9b94e" />
  

### reference
- 추후 `Job`들을 `DataSource`에 연결해 영속화를 한다면, `@Transactional(propagation = Propagation.REQUIRES_NEW)` 옵션을 핸들러에 붙일 생각입니다.
- 관련 내용은 [해당 블로그](https://velog.io/@guswns3371/TransactionalEventListener-%EC%82%AC%EC%9A%A9%EC%8B%9C-%EC%A3%BC%EC%9D%98%ED%95%A0-%EA%B2%83) 참고해주세요

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 이벤트 처리 시점이 트랜잭션 커밋 이후로 변경되어, 이벤트 관련 작업이 트랜잭션이 성공적으로 완료된 후에만 실행됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->