### PR TITLE
[CHORE] 스케줄링 등록 에러 로깅 및 Grafana 설정 변경

### DIFF
--- a/config/grafana.ini
+++ b/config/grafana.ini
@@ -1,5 +1,0 @@
-[server]
-# The full public facing url you use in browser, used for redirects and emails
-# If you use reverse proxy and sub path specify full url (with sub path)
-root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana/
-serve_from_sub_path = true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,10 +94,10 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - ./config/grafana.ini:/etc/grafana/grafana.ini
       - grafana-data:/var/lib/grafana
     environment:
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}
+      GF_SERVER_ROOT_URL: https://api.dev.jnu-locker.site/grafana
     depends_on:
       prometheus:
         condition: service_healthy
@@ -126,6 +126,8 @@ services:
       - jnu-locker-network
     depends_on:
       was:
+        condition: service_healthy
+      grafana:
         condition: service_healthy
 
 networks:

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -1,6 +1,6 @@
 server {
   listen 80;
-  server_name localhost;
+  server_name api.dev.jnu-locker.site;
 
   access_log /home/jnu-locker/log/access.log;
   error_log /home/jnu-locker/log/error.log;
@@ -25,6 +25,7 @@ server {
 
   location /grafana/ {
     proxy_pass http://grafana:3000/;
+    rewrite ^/grafana/?(.*) /$1 break;
     proxy_set_header Host $host;
   }
 }

--- a/src/main/java/com/jnulocker/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/jnulocker/auth/jwt/JwtFilter.java
@@ -31,7 +31,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
-    @Value(("${management.endpoints.web.base-path}"))
+    @Value("${management.endpoints.web.base-path}")
     private String actuatorBasePath;
 
     private final TokenProvider tokenProvider;

--- a/src/main/java/com/jnulocker/events/event/LockerEventCreatedEventHandler.java
+++ b/src/main/java/com/jnulocker/events/event/LockerEventCreatedEventHandler.java
@@ -12,6 +12,7 @@ import java.time.ZoneId;
 import java.util.Date;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.quartz.JobBuilder;
 import org.quartz.JobDetail;
 import org.quartz.Scheduler;
@@ -21,6 +22,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class LockerEventCreatedEventHandler {
@@ -51,7 +53,7 @@ public class LockerEventCreatedEventHandler {
     @TransactionalEventListener(
             classes = LockerEventCreatedEvent.class,
             phase = TransactionPhase.AFTER_COMMIT)
-    public void handle(LockerEventCreatedEvent lockerEventCreatedEvent) throws SchedulerException {
+    public void handle(LockerEventCreatedEvent lockerEventCreatedEvent) {
 
         UUID eventId = lockerEventCreatedEvent.getEventId();
 
@@ -89,8 +91,7 @@ public class LockerEventCreatedEventHandler {
             JobBuilder newJob,
             String jobName,
             UUID eventId,
-            String triggerName)
-            throws SchedulerException {
+            String triggerName) {
         Date startAt = Date.from(localDateTime.atZone(ZoneId.of(ASIA_SEOUL)).toInstant());
 
         JobDetail jobDetail =
@@ -105,6 +106,10 @@ public class LockerEventCreatedEventHandler {
                         .startAt(startAt)
                         .build();
 
-        scheduler.scheduleJob(jobDetail, eventOpenTrigger);
+        try {
+            scheduler.scheduleJob(jobDetail, eventOpenTrigger);
+        } catch (SchedulerException e) {
+            log.error("스케줄링 작업 생성 실패: jobName={}, eventId={}", jobName, eventId, e);
+        }
     }
 }


### PR DESCRIPTION
### 개요
close #89 

### 작업사항
- 이벤트 생성 API에서 스케줄링 등록 실패 시 에러 로깅
- Grafana 설정을 `docker-compose.yml`에서 직접 관리하며 `nginx` 설정도 변경
  - 기존에는 `localhost:3000`으로 도메인이 이동되는 문제가 있어 컴포즈 파일로 관리하도록 변경

### 변경로직
- `LockerEventCreatedEventHandler` 에러 로깅 로직 추가
- `docker-compose.yml` 및 `default.conf` 설정 변경

### 테스트 결과

<img width="353" alt="image" src="https://github.com/user-attachments/assets/84ca10ef-4e8b-43c4-89a6-66cf2594233b" />

### reference

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 잘못된 Spring 프로퍼티 주입 구문을 수정하여 애플리케이션 구동 오류를 방지했습니다.
- **리팩터**
	- 이벤트 처리 시 예외 발생 시 로그로 기록하도록 개선하여 안정성을 높였습니다.
- **설정**
	- Grafana 및 Nginx 관련 설정이 변경되어, Grafana가 새로운 도메인 및 경로에서 정상적으로 동작하도록 조정되었습니다.
	- 서비스 간 의존성 및 환경 변수 구성이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->