### PR TITLE
[FIX] Grafana healthcheck 엔드포인트 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       prometheus:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000"]
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/api/health"]
       start_period: 20s
       start_interval: 5s
       interval: 10s


### PR DESCRIPTION
### 개요
close #91 

### 작업사항
- Grafana의 healthcheck 엔드포인트는 `/api/health`로 제공되고 있어 여기로 수정

### 변경로직
- `docker-compose.yml` 파일 `grafana` 서비스 헬스체크 엔드포인트 수정

### 테스트 결과
<img width="353" alt="image" src="https://github.com/user-attachments/assets/c3adc6e4-56aa-4f6b-92d4-61cb04a4e676" />

### reference

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Grafana 서비스의 헬스체크가 루트 페이지 대신 실제 상태를 확인하는 전용 엔드포인트(`/api/health`)를 사용하도록 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->