### PR TITLE
[FEAT] 공지사항 생성 및 조회 API 구현

### DIFF
--- a/src/main/java/com/jnulocker/announce/adapter/in/AnnounceController.java
+++ b/src/main/java/com/jnulocker/announce/adapter/in/AnnounceController.java
@@ -6,7 +6,9 @@ import com.jnulocker.announce.application.port.in.AnnounceQuery;
 import com.jnulocker.announce.application.port.in.request.CreateAnnounceRequest;
 import com.jnulocker.announce.application.port.in.response.AnnounceCustomPage;
 import com.jnulocker.announce.application.port.in.response.AnnouncePageable;
+import com.jnulocker.announce.application.port.in.response.MyAnnounceResponse;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
@@ -39,5 +41,10 @@ public class AnnounceController implements AnnounceApi {
             @Valid @ParameterObject AnnouncePageable announcePageable) {
         Pageable pageable = announcePageable.toPageable();
         return ResponseEntity.ok(announceQuery.getAllAnnounces(pageable));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<List<MyAnnounceResponse>> getMyAnnounces() {
+        return ResponseEntity.ok(announceQuery.getMyAnnounces());
     }
 }

--- a/src/main/java/com/jnulocker/announce/adapter/in/AnnounceController.java
+++ b/src/main/java/com/jnulocker/announce/adapter/in/AnnounceController.java
@@ -43,6 +43,7 @@ public class AnnounceController implements AnnounceApi {
         return ResponseEntity.ok(announceQuery.getAllAnnounces(pageable));
     }
 
+    @Override
     @GetMapping("/me")
     public ResponseEntity<List<MyAnnounceResponse>> getMyAnnounces() {
         return ResponseEntity.ok(announceQuery.getMyAnnounces());

--- a/src/main/java/com/jnulocker/announce/adapter/in/AnnounceController.java
+++ b/src/main/java/com/jnulocker/announce/adapter/in/AnnounceController.java
@@ -2,11 +2,17 @@ package com.jnulocker.announce.adapter.in;
 
 import com.jnulocker.announce.adapter.in.docs.AnnounceApi;
 import com.jnulocker.announce.application.port.in.AnnounceCommand;
+import com.jnulocker.announce.application.port.in.AnnounceQuery;
 import com.jnulocker.announce.application.port.in.request.CreateAnnounceRequest;
+import com.jnulocker.announce.application.port.in.response.AnnounceCustomPage;
+import com.jnulocker.announce.application.port.in.response.AnnouncePageable;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,11 +24,20 @@ import org.springframework.web.bind.annotation.RestController;
 public class AnnounceController implements AnnounceApi {
 
     private final AnnounceCommand announceCommand;
+    private final AnnounceQuery announceQuery;
 
     @Override
     @PostMapping
     public ResponseEntity<Void> createAnnounce(@Valid @RequestBody CreateAnnounceRequest request) {
         announceCommand.createAnnounce(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Override
+    @GetMapping
+    public ResponseEntity<AnnounceCustomPage> getAnnounces(
+            @Valid @ParameterObject AnnouncePageable announcePageable) {
+        Pageable pageable = announcePageable.toPageable();
+        return ResponseEntity.ok(announceQuery.getAllAnnounces(pageable));
     }
 }

--- a/src/main/java/com/jnulocker/announce/adapter/in/AnnounceController.java
+++ b/src/main/java/com/jnulocker/announce/adapter/in/AnnounceController.java
@@ -1,0 +1,28 @@
+package com.jnulocker.announce.adapter.in;
+
+import com.jnulocker.announce.adapter.in.docs.AnnounceApi;
+import com.jnulocker.announce.application.port.in.AnnounceCommand;
+import com.jnulocker.announce.application.port.in.request.CreateAnnounceRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/announces")
+public class AnnounceController implements AnnounceApi {
+
+    private final AnnounceCommand announceCommand;
+
+    @Override
+    @PostMapping
+    public ResponseEntity<Void> createAnnounce(@Valid @RequestBody CreateAnnounceRequest request) {
+        announceCommand.createAnnounce(request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/com/jnulocker/announce/adapter/in/docs/AnnounceApi.java
+++ b/src/main/java/com/jnulocker/announce/adapter/in/docs/AnnounceApi.java
@@ -3,13 +3,16 @@ package com.jnulocker.announce.adapter.in.docs;
 import com.jnulocker.announce.application.port.in.request.CreateAnnounceRequest;
 import com.jnulocker.announce.application.port.in.response.AnnounceCustomPage;
 import com.jnulocker.announce.application.port.in.response.AnnouncePageable;
+import com.jnulocker.announce.application.port.in.response.MyAnnounceResponse;
 import com.jnulocker.common.swagger.ApiExceptionExamples;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -33,4 +36,20 @@ public interface AnnounceApi {
                             schema = @Schema(implementation = AnnounceCustomPage.class)))
     ResponseEntity<AnnounceCustomPage> getAnnounces(
             @Valid @ParameterObject AnnouncePageable announcePageable);
+
+    @ApiExceptionExamples(GetMyAnnouncesExceptionDocs.class)
+    @Operation(summary = "자신의 소속학과 대상 공지사항 목록 조회", description = "자신의 소속학과가 참여한 공지사항 목록을 조회합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "자신의 소속학과 대상 공지사항 목록 조회 성공",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            array =
+                                    @ArraySchema(
+                                            schema =
+                                                    @Schema(
+                                                            implementation =
+                                                                    MyAnnounceResponse.class))))
+    ResponseEntity<List<MyAnnounceResponse>> getMyAnnounces();
 }

--- a/src/main/java/com/jnulocker/announce/adapter/in/docs/AnnounceApi.java
+++ b/src/main/java/com/jnulocker/announce/adapter/in/docs/AnnounceApi.java
@@ -1,11 +1,17 @@
 package com.jnulocker.announce.adapter.in.docs;
 
 import com.jnulocker.announce.application.port.in.request.CreateAnnounceRequest;
+import com.jnulocker.announce.application.port.in.response.AnnounceCustomPage;
+import com.jnulocker.announce.application.port.in.response.AnnouncePageable;
 import com.jnulocker.common.swagger.ApiExceptionExamples;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -16,4 +22,15 @@ public interface AnnounceApi {
     @Operation(summary = "공지사항 생성", description = "공지사항을 생성합니다.")
     @ApiResponse(responseCode = "201", description = "공지사항 생성 성공")
     ResponseEntity<Void> createAnnounce(@Valid @RequestBody CreateAnnounceRequest request);
+
+    @Operation(summary = "공지사항 목록 조회", description = "공지사항 목록을 조회합니다. 페이지네이션이 지원됩니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "공지사항 목록 조회 성공",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = AnnounceCustomPage.class)))
+    ResponseEntity<AnnounceCustomPage> getAnnounces(
+            @Valid @ParameterObject AnnouncePageable announcePageable);
 }

--- a/src/main/java/com/jnulocker/announce/adapter/in/docs/AnnounceApi.java
+++ b/src/main/java/com/jnulocker/announce/adapter/in/docs/AnnounceApi.java
@@ -1,0 +1,19 @@
+package com.jnulocker.announce.adapter.in.docs;
+
+import com.jnulocker.announce.application.port.in.request.CreateAnnounceRequest;
+import com.jnulocker.common.swagger.ApiExceptionExamples;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "공지사항", description = "공지사항 관련 API")
+public interface AnnounceApi {
+
+    @ApiExceptionExamples(CreateAnnounceExceptionDocs.class)
+    @Operation(summary = "공지사항 생성", description = "공지사항을 생성합니다.")
+    @ApiResponse(responseCode = "201", description = "공지사항 생성 성공")
+    ResponseEntity<Void> createAnnounce(@Valid @RequestBody CreateAnnounceRequest request);
+}

--- a/src/main/java/com/jnulocker/announce/adapter/in/docs/CreateAnnounceExceptionDocs.java
+++ b/src/main/java/com/jnulocker/announce/adapter/in/docs/CreateAnnounceExceptionDocs.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CreateAnnounceExceptionDocs implements SwaggerExceptionDoc {
 
-    @ExplainError("이벤트 주관 학과가 존재하지 않거나 이벤트 참여 학과가 존재하지 않을 때 발생하는 예외입니다")
-    public static final BusinessException 이벤트_주관_학과가_존재하지_않거나_이벤트_참여_학과가_존재하지_않을_때 =
+    @ExplainError("공지사항 주관 학과가 존재하지 않거나 공지사항 참여 학과가 존재하지 않을 때 발생하는 예외입니다")
+    public static final BusinessException 공지사항_주관_학과가_존재하지_않거나_공지사항_참여_학과가_존재하지_않을_때 =
             DepartmentNotFoundException.EXCEPTION;
 }

--- a/src/main/java/com/jnulocker/announce/adapter/in/docs/CreateAnnounceExceptionDocs.java
+++ b/src/main/java/com/jnulocker/announce/adapter/in/docs/CreateAnnounceExceptionDocs.java
@@ -1,0 +1,18 @@
+package com.jnulocker.announce.adapter.in.docs;
+
+import com.jnulocker.common.exception.BusinessException;
+import com.jnulocker.common.swagger.ExceptionDoc;
+import com.jnulocker.common.swagger.ExplainError;
+import com.jnulocker.common.swagger.SwaggerExceptionDoc;
+import com.jnulocker.organization.exception.DepartmentNotFoundException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@ExceptionDoc
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CreateAnnounceExceptionDocs implements SwaggerExceptionDoc {
+
+    @ExplainError("이벤트 주관 학과가 존재하지 않거나 이벤트 참여 학과가 존재하지 않을 때 발생하는 예외입니다")
+    public static final BusinessException 이벤트_주관_학과가_존재하지_않거나_이벤트_참여_학과가_존재하지_않을_때 =
+            DepartmentNotFoundException.EXCEPTION;
+}

--- a/src/main/java/com/jnulocker/announce/adapter/in/docs/GetMyAnnouncesExceptionDocs.java
+++ b/src/main/java/com/jnulocker/announce/adapter/in/docs/GetMyAnnouncesExceptionDocs.java
@@ -1,0 +1,17 @@
+package com.jnulocker.announce.adapter.in.docs;
+
+import com.jnulocker.common.exception.BusinessException;
+import com.jnulocker.common.swagger.ExceptionDoc;
+import com.jnulocker.common.swagger.ExplainError;
+import com.jnulocker.common.swagger.SwaggerExceptionDoc;
+import com.jnulocker.member.exception.MemberNotFoundException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@ExceptionDoc
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetMyAnnouncesExceptionDocs implements SwaggerExceptionDoc {
+
+    @ExplainError("회원 정보를 조회할 수 없을 때 발생하는 예외입니다")
+    public static final BusinessException 회원_정보를_조회할_수_없을_때 = MemberNotFoundException.EXCEPTION;
+}

--- a/src/main/java/com/jnulocker/announce/adapter/out/AnnounceParticipationRepository.java
+++ b/src/main/java/com/jnulocker/announce/adapter/out/AnnounceParticipationRepository.java
@@ -1,0 +1,7 @@
+package com.jnulocker.announce.adapter.out;
+
+import com.jnulocker.announce.domain.AnnounceParticipation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnnounceParticipationRepository
+        extends JpaRepository<AnnounceParticipation, Long> {}

--- a/src/main/java/com/jnulocker/announce/adapter/out/AnnouncePersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/announce/adapter/out/AnnouncePersistenceAdapter.java
@@ -1,15 +1,19 @@
 package com.jnulocker.announce.adapter.out;
 
+import com.jnulocker.announce.application.port.out.AnnounceLoadPort;
 import com.jnulocker.announce.application.port.out.AnnounceRecordPort;
 import com.jnulocker.announce.domain.Announce;
 import com.jnulocker.announce.domain.AnnounceParticipation;
 import com.jnulocker.common.annotation.PersistenceAdapter;
+import com.jnulocker.organization.domain.Department;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class AnnouncePersistenceAdapter implements AnnounceRecordPort {
+public class AnnouncePersistenceAdapter implements AnnounceRecordPort, AnnounceLoadPort {
     private final AnnounceRepository announceRepository;
     private final AnnounceParticipationRepository announceParticipationRepository;
 
@@ -21,5 +25,10 @@ public class AnnouncePersistenceAdapter implements AnnounceRecordPort {
     @Override
     public void saveAnnounceParticipations(List<AnnounceParticipation> announceParticipations) {
         announceParticipationRepository.saveAll(announceParticipations);
+    }
+
+    @Override
+    public Page<Announce> getAllAnnouncesByDepartment(Department department, Pageable pageable) {
+        return announceRepository.findAllByDepartment(department, pageable);
     }
 }

--- a/src/main/java/com/jnulocker/announce/adapter/out/AnnouncePersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/announce/adapter/out/AnnouncePersistenceAdapter.java
@@ -1,0 +1,25 @@
+package com.jnulocker.announce.adapter.out;
+
+import com.jnulocker.announce.application.port.out.AnnounceRecordPort;
+import com.jnulocker.announce.domain.Announce;
+import com.jnulocker.announce.domain.AnnounceParticipation;
+import com.jnulocker.common.annotation.PersistenceAdapter;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class AnnouncePersistenceAdapter implements AnnounceRecordPort {
+    private final AnnounceRepository announceRepository;
+    private final AnnounceParticipationRepository announceParticipationRepository;
+
+    @Override
+    public Announce saveAnnounce(Announce announce) {
+        return announceRepository.save(announce);
+    }
+
+    @Override
+    public void saveAnnounceParticipations(List<AnnounceParticipation> announceParticipations) {
+        announceParticipationRepository.saveAll(announceParticipations);
+    }
+}

--- a/src/main/java/com/jnulocker/announce/adapter/out/AnnouncePersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/announce/adapter/out/AnnouncePersistenceAdapter.java
@@ -31,4 +31,9 @@ public class AnnouncePersistenceAdapter implements AnnounceRecordPort, AnnounceL
     public Page<Announce> getAllAnnouncesByDepartment(Department department, Pageable pageable) {
         return announceRepository.findAllByDepartment(department, pageable);
     }
+
+    @Override
+    public List<Announce> getAnnouncesByParticipationDepartment(Department department) {
+        return announceRepository.findAllByAnnounceParticipations_Department(department);
+    }
 }

--- a/src/main/java/com/jnulocker/announce/adapter/out/AnnounceRepository.java
+++ b/src/main/java/com/jnulocker/announce/adapter/out/AnnounceRepository.java
@@ -2,11 +2,16 @@ package com.jnulocker.announce.adapter.out;
 
 import com.jnulocker.announce.domain.Announce;
 import com.jnulocker.organization.domain.Department;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AnnounceRepository extends JpaRepository<Announce, Long> {
 
     Page<Announce> findAllByDepartment(Department department, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"department"})
+    List<Announce> findAllByAnnounceParticipations_Department(Department department);
 }

--- a/src/main/java/com/jnulocker/announce/adapter/out/AnnounceRepository.java
+++ b/src/main/java/com/jnulocker/announce/adapter/out/AnnounceRepository.java
@@ -1,6 +1,12 @@
 package com.jnulocker.announce.adapter.out;
 
 import com.jnulocker.announce.domain.Announce;
+import com.jnulocker.organization.domain.Department;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface AnnounceRepository extends JpaRepository<Announce, Long> {}
+public interface AnnounceRepository extends JpaRepository<Announce, Long> {
+
+    Page<Announce> findAllByDepartment(Department department, Pageable pageable);
+}

--- a/src/main/java/com/jnulocker/announce/adapter/out/AnnounceRepository.java
+++ b/src/main/java/com/jnulocker/announce/adapter/out/AnnounceRepository.java
@@ -1,0 +1,6 @@
+package com.jnulocker.announce.adapter.out;
+
+import com.jnulocker.announce.domain.Announce;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnnounceRepository extends JpaRepository<Announce, Long> {}

--- a/src/main/java/com/jnulocker/announce/application/port/in/AnnounceCommand.java
+++ b/src/main/java/com/jnulocker/announce/application/port/in/AnnounceCommand.java
@@ -1,0 +1,7 @@
+package com.jnulocker.announce.application.port.in;
+
+import com.jnulocker.announce.application.port.in.request.CreateAnnounceRequest;
+
+public interface AnnounceCommand {
+    void createAnnounce(CreateAnnounceRequest request);
+}

--- a/src/main/java/com/jnulocker/announce/application/port/in/AnnounceQuery.java
+++ b/src/main/java/com/jnulocker/announce/application/port/in/AnnounceQuery.java
@@ -1,9 +1,13 @@
 package com.jnulocker.announce.application.port.in;
 
 import com.jnulocker.announce.application.port.in.response.AnnounceCustomPage;
+import com.jnulocker.announce.application.port.in.response.MyAnnounceResponse;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 
 public interface AnnounceQuery {
 
     AnnounceCustomPage getAllAnnounces(Pageable pageable);
+
+    List<MyAnnounceResponse> getMyAnnounces();
 }

--- a/src/main/java/com/jnulocker/announce/application/port/in/AnnounceQuery.java
+++ b/src/main/java/com/jnulocker/announce/application/port/in/AnnounceQuery.java
@@ -1,0 +1,9 @@
+package com.jnulocker.announce.application.port.in;
+
+import com.jnulocker.announce.application.port.in.response.AnnounceCustomPage;
+import org.springframework.data.domain.Pageable;
+
+public interface AnnounceQuery {
+
+    AnnounceCustomPage getAllAnnounces(Pageable pageable);
+}

--- a/src/main/java/com/jnulocker/announce/application/port/in/request/CreateAnnounceRequest.java
+++ b/src/main/java/com/jnulocker/announce/application/port/in/request/CreateAnnounceRequest.java
@@ -1,0 +1,20 @@
+package com.jnulocker.announce.application.port.in.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record CreateAnnounceRequest(
+        @Schema(description = "공지사항 제목", example = "백도 사물함 신청 안내")
+                @NotBlank(message = "공지사항 제목은 필수입니다.")
+                @Size(max = 50, message = "공지사항 제목은 50자를 초과할 수 없습니다.")
+                String title,
+        @Schema(description = "공지사항 내용", example = "공지사항 내용입니다.")
+                @NotBlank(message = "공지사항 내용은 필수입니다.")
+                @Size(max = 1500, message = "공지사항 내용은 1500자를 초과할 수 없습니다.")
+                String content,
+        @Schema(description = "참여 학과/학부 ID 목록", example = "[1, 2, 3]")
+                @NotEmpty(message = "참여 학과/학부는 최소 1개 이상이어야 합니다.")
+                List<Long> participationDepartmentIds) {}

--- a/src/main/java/com/jnulocker/announce/application/port/in/response/AnnounceCustomPage.java
+++ b/src/main/java/com/jnulocker/announce/application/port/in/response/AnnounceCustomPage.java
@@ -1,0 +1,18 @@
+package com.jnulocker.announce.application.port.in.response;
+
+import com.jnulocker.announce.domain.Announce;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record AnnounceCustomPage(
+        @Schema(description = "공지사항 목록") List<AnnounceListItem> content,
+        @Schema(description = "공지사항 전체 개수", example = "10") Long totalElements,
+        @Schema(description = "마지막 페이지 여부", example = "false") Boolean last) {
+    public static AnnounceCustomPage from(Page<Announce> announces) {
+        return new AnnounceCustomPage(
+                announces.getContent().stream().map(AnnounceListItem::from).toList(),
+                announces.getTotalElements(),
+                announces.isLast());
+    }
+}

--- a/src/main/java/com/jnulocker/announce/application/port/in/response/AnnounceListItem.java
+++ b/src/main/java/com/jnulocker/announce/application/port/in/response/AnnounceListItem.java
@@ -1,0 +1,15 @@
+package com.jnulocker.announce.application.port.in.response;
+
+import com.jnulocker.announce.domain.Announce;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AnnounceListItem(
+        @Schema(description = "공지사항 ID", example = "1") Long id,
+        @Schema(description = "공지사항 제목", example = "백도 사물함 신청 안내") String title,
+        @Schema(description = "공지사항 내용", example = "공지사항 내용입니다.") String content,
+        @Schema(description = "공지사항 작성자", example = "도서관자치위원회 백문이불여일견") String writer) {
+    public static AnnounceListItem from(Announce announce) {
+        return new AnnounceListItem(
+                announce.getId(), announce.getTitle(), announce.getContent(), announce.getWriter());
+    }
+}

--- a/src/main/java/com/jnulocker/announce/application/port/in/response/AnnounceListItem.java
+++ b/src/main/java/com/jnulocker/announce/application/port/in/response/AnnounceListItem.java
@@ -2,14 +2,20 @@ package com.jnulocker.announce.application.port.in.response;
 
 import com.jnulocker.announce.domain.Announce;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 
 public record AnnounceListItem(
         @Schema(description = "공지사항 ID", example = "1") Long id,
         @Schema(description = "공지사항 제목", example = "백도 사물함 신청 안내") String title,
         @Schema(description = "공지사항 내용", example = "공지사항 내용입니다.") String content,
-        @Schema(description = "공지사항 작성자", example = "도서관자치위원회 백문이불여일견") String writer) {
+        @Schema(description = "공지사항 작성자", example = "도서관자치위원회 백문이불여일견") String writer,
+        @Schema(description = "등록 일자", example = "2025-08-01T15:00:00") LocalDateTime createdAt) {
     public static AnnounceListItem from(Announce announce) {
         return new AnnounceListItem(
-                announce.getId(), announce.getTitle(), announce.getContent(), announce.getWriter());
+                announce.getId(),
+                announce.getTitle(),
+                announce.getContent(),
+                announce.getWriter(),
+                announce.getCreatedAt());
     }
 }

--- a/src/main/java/com/jnulocker/announce/application/port/in/response/AnnouncePageable.java
+++ b/src/main/java/com/jnulocker/announce/application/port/in/response/AnnouncePageable.java
@@ -1,0 +1,35 @@
+package com.jnulocker.announce.application.port.in.response;
+
+import com.jnulocker.common.swagger.model.AbstractPageable;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
+import java.util.Set;
+
+@Schema()
+public class AnnouncePageable extends AbstractPageable {
+
+    public static final String DEFAULT_SORT = "createdAt";
+
+    public static final String VALID_SORT_MESSAGE =
+            "정렬 기준은 다음 중 하나여야 합니다: [id, title, createdAt, updatedAt].";
+
+    // Announce 도메인에 맞는 정렬 필드
+    public static final Set<String> VALID_SORT_FIELDS =
+            Set.of("id", "title", "createdAt", "updatedAt");
+
+    public AnnouncePageable(Integer page, Integer size, String direction, String sort) {
+        super(page, size, direction, sort);
+    }
+
+    @Override
+    @AssertTrue(message = VALID_SORT_MESSAGE)
+    protected boolean isValidSort() {
+        return !getSort().isBlank() && VALID_SORT_FIELDS.contains(getSort());
+    }
+
+    // Announce 도메인에 맞는 기본 정렬 값
+    @Override
+    protected String getDefaultSort() {
+        return DEFAULT_SORT;
+    }
+}

--- a/src/main/java/com/jnulocker/announce/application/port/in/response/MyAnnounceResponse.java
+++ b/src/main/java/com/jnulocker/announce/application/port/in/response/MyAnnounceResponse.java
@@ -1,0 +1,21 @@
+package com.jnulocker.announce.application.port.in.response;
+
+import com.jnulocker.announce.domain.Announce;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+public record MyAnnounceResponse(
+        @Schema(description = "공지사항 ID", example = "1") Long id,
+        @Schema(description = "공지사항 제목", example = "백도 사물함 신청 안내") String title,
+        @Schema(description = "공지사항 내용", example = "공지사항 내용입니다.") String content,
+        @Schema(description = "공지사항 작성자", example = "도서관자치위원회 백문이불여일견") String writer,
+        @Schema(description = "등록 일자", example = "2025-08-01T15:00:00") LocalDateTime createdAt) {
+    public static MyAnnounceResponse from(Announce announce) {
+        return new MyAnnounceResponse(
+                announce.getId(),
+                announce.getTitle(),
+                announce.getContent(),
+                announce.getWriter(),
+                announce.getCreatedAt());
+    }
+}

--- a/src/main/java/com/jnulocker/announce/application/port/out/AnnounceLoadPort.java
+++ b/src/main/java/com/jnulocker/announce/application/port/out/AnnounceLoadPort.java
@@ -2,10 +2,13 @@ package com.jnulocker.announce.application.port.out;
 
 import com.jnulocker.announce.domain.Announce;
 import com.jnulocker.organization.domain.Department;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface AnnounceLoadPort {
 
     Page<Announce> getAllAnnouncesByDepartment(Department department, Pageable pageable);
+
+    List<Announce> getAnnouncesByParticipationDepartment(Department department);
 }

--- a/src/main/java/com/jnulocker/announce/application/port/out/AnnounceLoadPort.java
+++ b/src/main/java/com/jnulocker/announce/application/port/out/AnnounceLoadPort.java
@@ -1,0 +1,11 @@
+package com.jnulocker.announce.application.port.out;
+
+import com.jnulocker.announce.domain.Announce;
+import com.jnulocker.organization.domain.Department;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface AnnounceLoadPort {
+
+    Page<Announce> getAllAnnouncesByDepartment(Department department, Pageable pageable);
+}

--- a/src/main/java/com/jnulocker/announce/application/port/out/AnnounceRecordPort.java
+++ b/src/main/java/com/jnulocker/announce/application/port/out/AnnounceRecordPort.java
@@ -1,0 +1,11 @@
+package com.jnulocker.announce.application.port.out;
+
+import com.jnulocker.announce.domain.Announce;
+import com.jnulocker.announce.domain.AnnounceParticipation;
+import java.util.List;
+
+public interface AnnounceRecordPort {
+    Announce saveAnnounce(Announce announce);
+
+    void saveAnnounceParticipations(List<AnnounceParticipation> announceParticipations);
+}

--- a/src/main/java/com/jnulocker/announce/application/service/AnnounceCommandService.java
+++ b/src/main/java/com/jnulocker/announce/application/service/AnnounceCommandService.java
@@ -1,0 +1,67 @@
+package com.jnulocker.announce.application.service;
+
+import com.jnulocker.announce.application.port.in.AnnounceCommand;
+import com.jnulocker.announce.application.port.in.request.CreateAnnounceRequest;
+import com.jnulocker.announce.application.port.out.AnnounceRecordPort;
+import com.jnulocker.announce.domain.Announce;
+import com.jnulocker.announce.domain.AnnounceParticipation;
+import com.jnulocker.auth.security.SecurityUtils;
+import com.jnulocker.member.application.port.in.MemberQuery;
+import com.jnulocker.organization.application.port.in.DepartmentQuery;
+import com.jnulocker.organization.domain.Department;
+import com.jnulocker.organization.exception.DepartmentNotFoundException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AnnounceCommandService implements AnnounceCommand {
+
+    private final AnnounceRecordPort announceRecordPort;
+    private final MemberQuery memberQuery;
+    private final DepartmentQuery departmentQuery;
+
+    @Override
+    @Transactional
+    public void createAnnounce(CreateAnnounceRequest request) {
+        // 공지사항 생성 및 저장
+        Announce savedAnnounce = createAndSaveAnnounce(request);
+
+        // 공지사항 참여 학과 정보 생성 및 저장
+        setupAnnounceParticipations(savedAnnounce, request.participationDepartmentIds());
+    }
+
+    private Announce createAndSaveAnnounce(CreateAnnounceRequest request) {
+        // 공지사항을 게시하는 department 조회
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        Department organizerDepartment =
+                memberQuery.findByIdWithDepartmentOrThrow(memberId).getDepartment();
+
+        // 공지사항 생성 및 저장
+        return announceRecordPort.saveAnnounce(
+                Announce.create(
+                        request.title(),
+                        request.content(),
+                        organizerDepartment.getNickname(),
+                        organizerDepartment));
+    }
+
+    private void setupAnnounceParticipations(
+            Announce announce, List<Long> participationDepartmentIds) {
+        // 공지사항에 참여하는 학과 조회
+        List<Department> departments =
+                departmentQuery.getDepartmentsByIdIn(participationDepartmentIds);
+        if (departments.size() != participationDepartmentIds.size()) {
+            throw DepartmentNotFoundException.EXCEPTION;
+        }
+
+        // 공지사항 참여 정보 생성 및 저장
+        List<AnnounceParticipation> participations =
+                departments.stream()
+                        .map(department -> AnnounceParticipation.create(announce, department))
+                        .toList();
+        announceRecordPort.saveAnnounceParticipations(participations);
+    }
+}

--- a/src/main/java/com/jnulocker/announce/application/service/AnnounceQueryService.java
+++ b/src/main/java/com/jnulocker/announce/application/service/AnnounceQueryService.java
@@ -2,11 +2,13 @@ package com.jnulocker.announce.application.service;
 
 import com.jnulocker.announce.application.port.in.AnnounceQuery;
 import com.jnulocker.announce.application.port.in.response.AnnounceCustomPage;
+import com.jnulocker.announce.application.port.in.response.MyAnnounceResponse;
 import com.jnulocker.announce.application.port.out.AnnounceLoadPort;
 import com.jnulocker.announce.domain.Announce;
 import com.jnulocker.auth.security.SecurityUtils;
 import com.jnulocker.member.application.port.in.MemberQuery;
 import com.jnulocker.member.domain.Member;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -27,5 +29,17 @@ public class AnnounceQueryService implements AnnounceQuery {
         Page<Announce> announces =
                 announceLoadPort.getAllAnnouncesByDepartment(member.getDepartment(), pageable);
         return AnnounceCustomPage.from(announces);
+    }
+
+    @Override
+    public List<MyAnnounceResponse> getMyAnnounces() {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        Member member = memberQuery.findByIdOrThrow(memberId);
+
+        // 사용자의 소속학과가 참여하는 공지사항 조회
+        List<Announce> announces =
+                announceLoadPort.getAnnouncesByParticipationDepartment(member.getDepartment());
+
+        return announces.stream().map(MyAnnounceResponse::from).toList();
     }
 }

--- a/src/main/java/com/jnulocker/announce/application/service/AnnounceQueryService.java
+++ b/src/main/java/com/jnulocker/announce/application/service/AnnounceQueryService.java
@@ -1,0 +1,31 @@
+package com.jnulocker.announce.application.service;
+
+import com.jnulocker.announce.application.port.in.AnnounceQuery;
+import com.jnulocker.announce.application.port.in.response.AnnounceCustomPage;
+import com.jnulocker.announce.application.port.out.AnnounceLoadPort;
+import com.jnulocker.announce.domain.Announce;
+import com.jnulocker.auth.security.SecurityUtils;
+import com.jnulocker.member.application.port.in.MemberQuery;
+import com.jnulocker.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AnnounceQueryService implements AnnounceQuery {
+
+    private final MemberQuery memberQuery;
+    private final AnnounceLoadPort announceLoadPort;
+
+    @Override
+    public AnnounceCustomPage getAllAnnounces(Pageable pageable) {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        Member member = memberQuery.findByIdWithDepartmentOrThrow(memberId);
+
+        Page<Announce> announces =
+                announceLoadPort.getAllAnnouncesByDepartment(member.getDepartment(), pageable);
+        return AnnounceCustomPage.from(announces);
+    }
+}

--- a/src/main/java/com/jnulocker/announce/domain/Announce.java
+++ b/src/main/java/com/jnulocker/announce/domain/Announce.java
@@ -1,0 +1,49 @@
+package com.jnulocker.announce.domain;
+
+import com.jnulocker.common.persistence.BaseEntity;
+import com.jnulocker.organization.domain.Department;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Announce extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "announce_id")
+    private Long id;
+
+    private String title;
+
+    private String content;
+
+    private String writer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "department_id")
+    private Department department;
+
+    public static Announce create(
+            String title, String content, String writer, Department department) {
+        return Announce.builder()
+                .title(title)
+                .content(content)
+                .writer(writer)
+                .department(department)
+                .build();
+    }
+}

--- a/src/main/java/com/jnulocker/announce/domain/Announce.java
+++ b/src/main/java/com/jnulocker/announce/domain/Announce.java
@@ -2,6 +2,7 @@ package com.jnulocker.announce.domain;
 
 import com.jnulocker.common.persistence.BaseEntity;
 import com.jnulocker.organization.domain.Department;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -10,6 +11,9 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -36,6 +40,9 @@ public class Announce extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "department_id")
     private Department department;
+
+    @OneToMany(mappedBy = "announce", orphanRemoval = true, cascade = CascadeType.ALL)
+    private final List<AnnounceParticipation> announceParticipations = new ArrayList<>();
 
     public static Announce create(
             String title, String content, String writer, Department department) {

--- a/src/main/java/com/jnulocker/announce/domain/AnnounceParticipation.java
+++ b/src/main/java/com/jnulocker/announce/domain/AnnounceParticipation.java
@@ -1,0 +1,42 @@
+package com.jnulocker.announce.domain;
+
+import com.jnulocker.common.persistence.BaseEntity;
+import com.jnulocker.organization.domain.Department;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AnnounceParticipation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "announce_participation_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "announce_id")
+    private Announce announce;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "department_id")
+    private Department department;
+
+    public static AnnounceParticipation create(Announce announce, Department department) {
+        return AnnounceParticipation.builder().announce(announce).department(department).build();
+    }
+}

--- a/src/main/java/com/jnulocker/config/SecurityConfig.java
+++ b/src/main/java/com/jnulocker/config/SecurityConfig.java
@@ -87,6 +87,12 @@ public class SecurityConfig {
                                 .hasAuthority(Role.MANAGER.getRole())
                                 .requestMatchers(HttpMethod.PUT, "/v1/events/*/publish")
                                 .hasAuthority(Role.MANAGER.getRole())
+                                .requestMatchers(HttpMethod.POST, "/v1/announces")
+                                .hasAuthority(Role.MANAGER.getRole())
+                                .requestMatchers(HttpMethod.GET, "/v1/announces")
+                                .hasAuthority(Role.MANAGER.getRole())
+                                .requestMatchers(HttpMethod.GET, "/v1/announces/me")
+                                .hasAuthority(Role.USER.getRole())
                                 // 토큰의 role과 db의 role과 다른 문제 고려
                                 .anyRequest()
                                 .authenticated());

--- a/src/test/java/com/jnulocker/announce/adapter/in/AnnounceControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/announce/adapter/in/AnnounceControllerIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.jnulocker.announce.adapter.in;
 
-import static announce.application.CreateAnnounceRequestTestDataBuilder.createAnnounceRequestBuilder;
+import static announce.application.port.in.request.CreateAnnounceRequestTestDataBuilder.createAnnounceRequestBuilder;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/com/jnulocker/announce/adapter/in/AnnounceControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/announce/adapter/in/AnnounceControllerIntegrationTest.java
@@ -1,0 +1,220 @@
+package com.jnulocker.announce.adapter.in;
+
+import static announce.application.CreateAnnounceReqeustTestDataBuilder.createAnnounceReqeustBuilder;
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jnulocker.announce.application.port.in.request.CreateAnnounceRequest;
+import com.jnulocker.announce.application.port.in.response.AnnounceCustomPage;
+import com.jnulocker.announce.application.port.in.response.MyAnnounceResponse;
+import com.jnulocker.announce.utils.AnnounceTestUtil;
+import com.jnulocker.auth.utils.AuthTestUtil;
+import com.jnulocker.member.domain.Member;
+import com.jnulocker.member.domain.Role;
+import com.jnulocker.member.utils.MemberTestUtil;
+import com.jnulocker.organization.domain.Department;
+import com.jnulocker.organization.utils.OrganizationTestUtil;
+import io.restassured.RestAssured;
+import io.restassured.http.Cookie;
+import io.restassured.response.ValidatableResponse;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@Testcontainers
+@ActiveProfiles("test")
+@DisplayName("공지사항 컨트롤러 통합 테스트")
+public class AnnounceControllerIntegrationTest {
+
+    private static final String ANNOUNCE_URL = "/v1/announces";
+    private static final String ACCESS_TOKEN = "access_token";
+
+    @LocalServerPort private int port;
+
+    @Autowired private AuthTestUtil authTestUtil;
+
+    @Autowired private OrganizationTestUtil organizationTestUtil;
+
+    @Autowired private MemberTestUtil memberTestUtil;
+
+    @Autowired private AnnounceTestUtil announceTestUtil;
+
+    private static String accessToken;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+
+        // 토큰 생성
+        accessToken = authTestUtil.generateAccessToken(Role.MANAGER);
+    }
+
+    @AfterEach
+    void tearDown() {
+        memberTestUtil.deleteAll();
+        announceTestUtil.deleteAll();
+    }
+
+    @Test
+    void 공지사항을_생성할_수_있다() {
+        // given
+        createAnnounce();
+
+        // then
+        // 생성된 공지사항 조회
+        AnnounceCustomPage announceCustomPage =
+                getAnnounces(0, 10, accessToken)
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .as(AnnounceCustomPage.class);
+
+        // 생성된 공지사항이 목록에 포함되어 있는지 확인
+        assertThat(announceCustomPage.content()).hasSize(1);
+    }
+
+    // 공지사항 목록 조회 테스트
+    @ParameterizedTest(name = "[{index}] 조회[총: {0}, 크기: {1}, 페이지: {2}] -> 마지막: {3}")
+    @CsvSource({
+        "10, 5, 0, false", // 10개 생성, 5개씩, 0페이지(1~5), 마지막 아님
+        "10, 5, 1, true", // 10개 생성, 5개씩, 1페이지(6~10), 마지막
+        "8, 3, 0, false", // 8개 생성, 3개씩, 0페이지(1~3), 마지막 아님
+        "8, 3, 2, true", // 8개 생성, 3개씩, 2페이지(7~8), 마지막
+        "5, 10, 0, true" // 5개 생성, 10개씩, 0페이지(1~5), 마지막
+    })
+    void 공지사항_목록을_조회할_수_있다(int createCount, int pageSize, int page, boolean expectedLast) {
+        // given
+        Department department = organizationTestUtil.createCouncilDepartment();
+        Member member = memberTestUtil.createMemberFromRoleWithDepartment(Role.MANAGER, department);
+        accessToken = authTestUtil.generateAccessTokenWithMember(member);
+
+        for (int i = 0; i < createCount; i++) {
+            announceTestUtil.createAnnounceWithParticipationDepartment(department);
+        }
+
+        // when
+        AnnounceCustomPage announceCustomPage =
+                getAnnounces(page, pageSize, accessToken)
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .as(AnnounceCustomPage.class);
+
+        // then
+        int expectedSize = calculateExpectedSize(createCount, pageSize, page);
+        assertThat(announceCustomPage.content()).hasSize(expectedSize);
+        assertThat(announceCustomPage.totalElements()).isEqualTo(createCount);
+        assertThat(announceCustomPage.last()).isEqualTo(expectedLast);
+    }
+
+    @Test
+    void 자신이_속한_학과가_참여하는_이벤트를_조회할_수_있다() {
+        // given
+        Department department = organizationTestUtil.createCouncilDepartment();
+        Member member = memberTestUtil.createMemberFromRoleWithDepartment(Role.USER, department);
+
+        // 공지사항 생성
+        announceTestUtil.createAnnounceWithParticipationDepartment(department);
+
+        // when
+        accessToken = authTestUtil.generateAccessTokenWithMember(member);
+        List<MyAnnounceResponse> myAnnounces =
+                getMyAnnounces(accessToken)
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .jsonPath()
+                        .getList(".", MyAnnounceResponse.class);
+
+        MyAnnounceResponse myAnnounceResponse = myAnnounces.getFirst();
+
+        // then
+        assertThat(myAnnounces).hasSize(1);
+    }
+
+    @Test
+    void 자신의_소속학과가_주관하지_않는_공지사항은_조회할_수_없다() {
+        // given
+        Department department = organizationTestUtil.createCouncilDepartment();
+        Member member = memberTestUtil.createMemberFromRoleWithDepartment(Role.USER, department);
+        accessToken = authTestUtil.generateAccessTokenWithMember(member);
+
+        // 공지사항 생성: 비참여 학과로 생성
+        announceTestUtil.createAnnounce();
+
+        // when
+        List<MyAnnounceResponse> myAnnounces =
+                getMyAnnounces(accessToken)
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .jsonPath()
+                        .getList(".", MyAnnounceResponse.class);
+
+        // then
+        assertThat(myAnnounces).isEmpty();
+    }
+
+    private void createAnnounce() {
+        Department department = organizationTestUtil.createCouncilDepartment();
+        createAnnounceWithDepartment(department);
+    }
+
+    private void createAnnounceWithDepartment(Department department) {
+        CreateAnnounceRequest request =
+                createAnnounceReqeustBuilder()
+                        .withParticipationDepartmentIds(List.of(department.getId()))
+                        .build();
+
+        given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
+                .body(request)
+                .when()
+                .post(ANNOUNCE_URL)
+                .then()
+                .statusCode(HttpStatus.CREATED.value());
+    }
+
+    public static ValidatableResponse getAnnounces(int page, int size, String accessToken) {
+        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
+                .queryParam("page", page)
+                .queryParam("size", size)
+                .queryParam("direction", "DESC")
+                .queryParam("sort", "createdAt")
+                .when()
+                .get(ANNOUNCE_URL)
+                .then()
+                .log()
+                .all();
+    }
+
+    // 유틸 메서드들
+    private int calculateExpectedSize(int totalCount, int pageSize, int page) {
+        int startIndex = page * pageSize;
+        if (startIndex >= totalCount) {
+            return 0; // 페이지가 범위를 벗어나면 빈 리스트
+        }
+        int remainingItems = totalCount - startIndex;
+        return Math.min(remainingItems, pageSize);
+    }
+
+    public static ValidatableResponse getMyAnnounces(String accessToken) {
+        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
+                .when()
+                .get(ANNOUNCE_URL + "/me")
+                .then()
+                .log()
+                .all();
+    }
+}

--- a/src/test/java/com/jnulocker/announce/adapter/in/AnnounceControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/announce/adapter/in/AnnounceControllerIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.jnulocker.announce.adapter.in;
 
-import static announce.application.CreateAnnounceReqeustTestDataBuilder.createAnnounceReqeustBuilder;
+import static announce.application.CreateAnnounceRequestTestDataBuilder.createAnnounceRequestBuilder;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -171,7 +171,7 @@ public class AnnounceControllerIntegrationTest {
 
     private void createAnnounceWithDepartment(Department department) {
         CreateAnnounceRequest request =
-                createAnnounceReqeustBuilder()
+                createAnnounceRequestBuilder()
                         .withParticipationDepartmentIds(List.of(department.getId()))
                         .build();
 

--- a/src/test/java/com/jnulocker/announce/application/port/in/request/CreateAnnounceRequestTest.java
+++ b/src/test/java/com/jnulocker/announce/application/port/in/request/CreateAnnounceRequestTest.java
@@ -1,6 +1,6 @@
 package com.jnulocker.announce.application.port.in.request;
 
-import static announce.application.CreateAnnounceRequestTestDataBuilder.createAnnounceRequestBuilder;
+import static announce.application.port.in.request.CreateAnnounceRequestTestDataBuilder.createAnnounceRequestBuilder;
 import static jakarta.validation.Validation.buildDefaultValidatorFactory;
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/com/jnulocker/announce/application/port/in/request/CreateAnnounceRequestTest.java
+++ b/src/test/java/com/jnulocker/announce/application/port/in/request/CreateAnnounceRequestTest.java
@@ -1,6 +1,6 @@
 package com.jnulocker.announce.application.port.in.request;
 
-import static announce.application.CreateAnnounceReqeustTestDataBuilder.createAnnounceReqeustBuilder;
+import static announce.application.CreateAnnounceRequestTestDataBuilder.createAnnounceRequestBuilder;
 import static jakarta.validation.Validation.buildDefaultValidatorFactory;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -26,7 +26,7 @@ public class CreateAnnounceRequestTest {
 
     @Test
     void 유효한_요청은_검증을_통과한다() {
-        CreateAnnounceRequest request = createAnnounceReqeustBuilder().build();
+        CreateAnnounceRequest request = createAnnounceRequestBuilder().build();
 
         Set<ConstraintViolation<CreateAnnounceRequest>> violations = validator.validate(request);
         assertThat(violations).isEmpty();
@@ -34,7 +34,7 @@ public class CreateAnnounceRequestTest {
 
     @Test
     void 제목이_빈_문자열이면_검증에_실패한다() {
-        CreateAnnounceRequest request = createAnnounceReqeustBuilder().withTitle("").build();
+        CreateAnnounceRequest request = createAnnounceRequestBuilder().withTitle("").build();
 
         Set<ConstraintViolation<CreateAnnounceRequest>> violations = validator.validate(request);
         assertThat(violations).hasSize(1);
@@ -43,7 +43,7 @@ public class CreateAnnounceRequestTest {
 
     @Test
     void 제목이_null이면_검증에_실패한다() {
-        CreateAnnounceRequest request = createAnnounceReqeustBuilder().withTitle(null).build();
+        CreateAnnounceRequest request = createAnnounceRequestBuilder().withTitle(null).build();
 
         Set<ConstraintViolation<CreateAnnounceRequest>> violations = validator.validate(request);
         assertThat(violations).hasSize(1);
@@ -53,7 +53,7 @@ public class CreateAnnounceRequestTest {
     @Test
     void 제목이_50자를_초과하면_검증에_실패한다() {
         String longTitle = "a".repeat(51);
-        CreateAnnounceRequest request = createAnnounceReqeustBuilder().withTitle(longTitle).build();
+        CreateAnnounceRequest request = createAnnounceRequestBuilder().withTitle(longTitle).build();
 
         Set<ConstraintViolation<CreateAnnounceRequest>> violations = validator.validate(request);
         assertThat(violations).hasSize(1);
@@ -63,7 +63,7 @@ public class CreateAnnounceRequestTest {
 
     @Test
     void 내용이_빈_문자열이면_검증에_실패한다() {
-        CreateAnnounceRequest request = createAnnounceReqeustBuilder().withContent("").build();
+        CreateAnnounceRequest request = createAnnounceRequestBuilder().withContent("").build();
 
         Set<ConstraintViolation<CreateAnnounceRequest>> violations = validator.validate(request);
         assertThat(violations).hasSize(1);
@@ -72,7 +72,7 @@ public class CreateAnnounceRequestTest {
 
     @Test
     void 내용이_null이면_검증에_실패한다() {
-        CreateAnnounceRequest request = createAnnounceReqeustBuilder().withContent(null).build();
+        CreateAnnounceRequest request = createAnnounceRequestBuilder().withContent(null).build();
 
         Set<ConstraintViolation<CreateAnnounceRequest>> violations = validator.validate(request);
         assertThat(violations).hasSize(1);
@@ -83,7 +83,7 @@ public class CreateAnnounceRequestTest {
     void 내용이_1500자를_초과하면_검증에_실패한다() {
         String longContent = "a".repeat(1501);
         CreateAnnounceRequest request =
-                createAnnounceReqeustBuilder().withContent(longContent).build();
+                createAnnounceRequestBuilder().withContent(longContent).build();
 
         Set<ConstraintViolation<CreateAnnounceRequest>> violations = validator.validate(request);
         assertThat(violations).hasSize(1);
@@ -94,7 +94,7 @@ public class CreateAnnounceRequestTest {
     @Test
     void 참여_학과_목록이_비어있으면_검증에_실패한다() {
         CreateAnnounceRequest request =
-                createAnnounceReqeustBuilder()
+                createAnnounceRequestBuilder()
                         .withParticipationDepartmentIds(Collections.emptyList())
                         .build();
 

--- a/src/test/java/com/jnulocker/announce/application/port/in/request/CreateAnnounceRequestTest.java
+++ b/src/test/java/com/jnulocker/announce/application/port/in/request/CreateAnnounceRequestTest.java
@@ -1,0 +1,106 @@
+package com.jnulocker.announce.application.port.in.request;
+
+import static announce.application.CreateAnnounceReqeustTestDataBuilder.createAnnounceReqeustBuilder;
+import static jakarta.validation.Validation.buildDefaultValidatorFactory;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.util.Collections;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("공지사항 생성 요청 본문 검증 테스트")
+public class CreateAnnounceRequestTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUp() {
+        ValidatorFactory factory = buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    void 유효한_요청은_검증을_통과한다() {
+        CreateAnnounceRequest request = createAnnounceReqeustBuilder().build();
+
+        Set<ConstraintViolation<CreateAnnounceRequest>> violations = validator.validate(request);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void 제목이_빈_문자열이면_검증에_실패한다() {
+        CreateAnnounceRequest request = createAnnounceReqeustBuilder().withTitle("").build();
+
+        Set<ConstraintViolation<CreateAnnounceRequest>> violations = validator.validate(request);
+        assertThat(violations).hasSize(1);
+        assertThat(violations.iterator().next().getMessage()).isEqualTo("공지사항 제목은 필수입니다.");
+    }
+
+    @Test
+    void 제목이_null이면_검증에_실패한다() {
+        CreateAnnounceRequest request = createAnnounceReqeustBuilder().withTitle(null).build();
+
+        Set<ConstraintViolation<CreateAnnounceRequest>> violations = validator.validate(request);
+        assertThat(violations).hasSize(1);
+        assertThat(violations.iterator().next().getMessage()).isEqualTo("공지사항 제목은 필수입니다.");
+    }
+
+    @Test
+    void 제목이_50자를_초과하면_검증에_실패한다() {
+        String longTitle = "a".repeat(51);
+        CreateAnnounceRequest request = createAnnounceReqeustBuilder().withTitle(longTitle).build();
+
+        Set<ConstraintViolation<CreateAnnounceRequest>> violations = validator.validate(request);
+        assertThat(violations).hasSize(1);
+        assertThat(violations.iterator().next().getMessage())
+                .isEqualTo("공지사항 제목은 50자를 초과할 수 없습니다.");
+    }
+
+    @Test
+    void 내용이_빈_문자열이면_검증에_실패한다() {
+        CreateAnnounceRequest request = createAnnounceReqeustBuilder().withContent("").build();
+
+        Set<ConstraintViolation<CreateAnnounceRequest>> violations = validator.validate(request);
+        assertThat(violations).hasSize(1);
+        assertThat(violations.iterator().next().getMessage()).isEqualTo("공지사항 내용은 필수입니다.");
+    }
+
+    @Test
+    void 내용이_null이면_검증에_실패한다() {
+        CreateAnnounceRequest request = createAnnounceReqeustBuilder().withContent(null).build();
+
+        Set<ConstraintViolation<CreateAnnounceRequest>> violations = validator.validate(request);
+        assertThat(violations).hasSize(1);
+        assertThat(violations.iterator().next().getMessage()).isEqualTo("공지사항 내용은 필수입니다.");
+    }
+
+    @Test
+    void 내용이_1500자를_초과하면_검증에_실패한다() {
+        String longContent = "a".repeat(1501);
+        CreateAnnounceRequest request =
+                createAnnounceReqeustBuilder().withContent(longContent).build();
+
+        Set<ConstraintViolation<CreateAnnounceRequest>> violations = validator.validate(request);
+        assertThat(violations).hasSize(1);
+        assertThat(violations.iterator().next().getMessage())
+                .isEqualTo("공지사항 내용은 1500자를 초과할 수 없습니다.");
+    }
+
+    @Test
+    void 참여_학과_목록이_비어있으면_검증에_실패한다() {
+        CreateAnnounceRequest request =
+                createAnnounceReqeustBuilder()
+                        .withParticipationDepartmentIds(Collections.emptyList())
+                        .build();
+
+        Set<ConstraintViolation<CreateAnnounceRequest>> violations = validator.validate(request);
+        assertThat(violations).hasSize(1);
+        assertThat(violations.iterator().next().getMessage())
+                .isEqualTo("참여 학과/학부는 최소 1개 이상이어야 합니다.");
+    }
+}

--- a/src/test/java/com/jnulocker/announce/utils/AnnounceTestUtil.java
+++ b/src/test/java/com/jnulocker/announce/utils/AnnounceTestUtil.java
@@ -1,0 +1,66 @@
+package com.jnulocker.announce.utils;
+
+import static announce.domain.AnnounceTestDataBuilder.announceBuilder;
+import static organization.domain.DepartmentTestDataBuilder.departmentBuilder;
+import static organization.domain.OrganizationTestDataBuilder.organizationBuilder;
+
+import com.jnulocker.announce.adapter.out.AnnounceParticipationRepository;
+import com.jnulocker.announce.adapter.out.AnnounceRepository;
+import com.jnulocker.announce.domain.Announce;
+import com.jnulocker.announce.domain.AnnounceParticipation;
+import com.jnulocker.organization.adapter.out.DepartmentRepository;
+import com.jnulocker.organization.adapter.out.OrganizationRepository;
+import com.jnulocker.organization.domain.Department;
+import com.jnulocker.organization.domain.Organization;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AnnounceTestUtil {
+
+    @Autowired private AnnounceRepository announceRepository;
+
+    @Autowired private AnnounceParticipationRepository announceParticipationRepository;
+
+    @Autowired private OrganizationRepository organizationRepository;
+
+    @Autowired private DepartmentRepository departmentRepository;
+
+    public Announce createAnnounceWithParticipationDepartment(Department department) {
+        // 공지사항 생성 및 저장
+        Announce savedAnnounce = createAndSaveAnnounce(department);
+
+        // 공지사항 참여 학과 정보 생성 및 저장
+        AnnounceParticipation announceParticipation =
+                AnnounceParticipation.create(savedAnnounce, department);
+        announceParticipationRepository.save(announceParticipation);
+
+        return savedAnnounce;
+    }
+
+    private Announce createAndSaveAnnounce(Department department) {
+
+        Announce announce = announceBuilder().withDepartment(department).build();
+        return announceRepository.save(announce);
+    }
+
+    public void deleteAll() {
+        announceRepository.deleteAll();
+        announceParticipationRepository.deleteAll();
+    }
+
+    public Announce createAnnounce() {
+        // 조직 생성 및 저장
+        Organization organization = organizationBuilder().build();
+        Organization savedOrganization = organizationRepository.save(organization);
+
+        // 학과 생성 및 저장
+        Department department = departmentBuilder().withOrganization(savedOrganization).build();
+        Department savedDepartment = departmentRepository.save(department);
+
+        // 공지사항 생성 및 저장
+        Announce savedAnnounce = createAndSaveAnnounce(savedDepartment);
+
+        return savedAnnounce;
+    }
+}

--- a/src/testFixtures/java/announce/application/CreateAnnounceReqeustTestDataBuilder.java
+++ b/src/testFixtures/java/announce/application/CreateAnnounceReqeustTestDataBuilder.java
@@ -1,0 +1,36 @@
+package announce.application;
+
+import com.jnulocker.announce.application.port.in.request.CreateAnnounceRequest;
+import java.util.List;
+
+public class CreateAnnounceReqeustTestDataBuilder {
+    private String title = "백도 사물함 신청 안내";
+    private String content = "공지사항 내용입니다.";
+    private List<Long> participationDepartmentIds = List.of(1L, 2L, 3L);
+
+    private CreateAnnounceReqeustTestDataBuilder() {}
+
+    public static CreateAnnounceReqeustTestDataBuilder createAnnounceReqeustBuilder() {
+        return new CreateAnnounceReqeustTestDataBuilder();
+    }
+
+    public CreateAnnounceReqeustTestDataBuilder withTitle(String title) {
+        this.title = title;
+        return this;
+    }
+
+    public CreateAnnounceReqeustTestDataBuilder withContent(String content) {
+        this.content = content;
+        return this;
+    }
+
+    public CreateAnnounceReqeustTestDataBuilder withParticipationDepartmentIds(
+            List<Long> participationDepartmentIds) {
+        this.participationDepartmentIds = participationDepartmentIds;
+        return this;
+    }
+
+    public CreateAnnounceRequest build() {
+        return new CreateAnnounceRequest(title, content, participationDepartmentIds);
+    }
+}

--- a/src/testFixtures/java/announce/application/CreateAnnounceRequestTestDataBuilder.java
+++ b/src/testFixtures/java/announce/application/CreateAnnounceRequestTestDataBuilder.java
@@ -3,28 +3,28 @@ package announce.application;
 import com.jnulocker.announce.application.port.in.request.CreateAnnounceRequest;
 import java.util.List;
 
-public class CreateAnnounceReqeustTestDataBuilder {
+public class CreateAnnounceRequestTestDataBuilder {
     private String title = "백도 사물함 신청 안내";
     private String content = "공지사항 내용입니다.";
     private List<Long> participationDepartmentIds = List.of(1L, 2L, 3L);
 
-    private CreateAnnounceReqeustTestDataBuilder() {}
+    private CreateAnnounceRequestTestDataBuilder() {}
 
-    public static CreateAnnounceReqeustTestDataBuilder createAnnounceReqeustBuilder() {
-        return new CreateAnnounceReqeustTestDataBuilder();
+    public static CreateAnnounceRequestTestDataBuilder createAnnounceRequestBuilder() {
+        return new CreateAnnounceRequestTestDataBuilder();
     }
 
-    public CreateAnnounceReqeustTestDataBuilder withTitle(String title) {
+    public CreateAnnounceRequestTestDataBuilder withTitle(String title) {
         this.title = title;
         return this;
     }
 
-    public CreateAnnounceReqeustTestDataBuilder withContent(String content) {
+    public CreateAnnounceRequestTestDataBuilder withContent(String content) {
         this.content = content;
         return this;
     }
 
-    public CreateAnnounceReqeustTestDataBuilder withParticipationDepartmentIds(
+    public CreateAnnounceRequestTestDataBuilder withParticipationDepartmentIds(
             List<Long> participationDepartmentIds) {
         this.participationDepartmentIds = participationDepartmentIds;
         return this;

--- a/src/testFixtures/java/announce/application/port/in/request/CreateAnnounceRequestTestDataBuilder.java
+++ b/src/testFixtures/java/announce/application/port/in/request/CreateAnnounceRequestTestDataBuilder.java
@@ -1,4 +1,4 @@
-package announce.application;
+package announce.application.port.in.request;
 
 import com.jnulocker.announce.application.port.in.request.CreateAnnounceRequest;
 import java.util.List;

--- a/src/testFixtures/java/announce/domain/AnnounceTestDataBuilder.java
+++ b/src/testFixtures/java/announce/domain/AnnounceTestDataBuilder.java
@@ -1,0 +1,44 @@
+package announce.domain;
+
+import static organization.domain.DepartmentTestDataBuilder.departmentBuilder;
+
+import com.jnulocker.announce.domain.Announce;
+import com.jnulocker.organization.domain.Department;
+
+public class AnnounceTestDataBuilder {
+
+    private String title = "테스트 공지사항";
+    private String content = "테스트 공지사항 내용";
+    private Department department = departmentBuilder().build();
+    private String writer = department.getNickname();
+
+    private AnnounceTestDataBuilder() {}
+
+    public static AnnounceTestDataBuilder announceBuilder() {
+        return new AnnounceTestDataBuilder();
+    }
+
+    public AnnounceTestDataBuilder withTitle(String title) {
+        this.title = title;
+        return this;
+    }
+
+    public AnnounceTestDataBuilder withContent(String content) {
+        this.content = content;
+        return this;
+    }
+
+    public AnnounceTestDataBuilder withDepartment(Department department) {
+        this.department = department;
+        return this;
+    }
+
+    public AnnounceTestDataBuilder withWriter(String writer) {
+        this.writer = writer;
+        return this;
+    }
+
+    public Announce build() {
+        return Announce.create(title, content, writer, department);
+    }
+}


### PR DESCRIPTION
### 개요
close #86 

### 작업사항
- 공지사항 엔티티를 작성하고 공지사항 생성 및 조회 API를 구현했습니다.

### 테스트 결과
<p>
  <img src="https://github.com/user-attachments/assets/ac495d94-b1b6-4eda-a356-426c74155bdd" width="400px">
</p>

**추가된 테스트케이스**
- 공지사항 컨트롤러 통합 테스트
    <p>
  <img src="https://github.com/user-attachments/assets/d777f645-6118-4553-a7d2-e8e294569994" width="400px">
</p>

- 공지사항 생성 요청 본문 테스트
   <p>
  <img src="https://github.com/user-attachments/assets/6ce7c0e9-bda1-47e1-9a37-2124d28027cd" width="250px">
</p>

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 공지사항 생성, 전체 조회(페이징), 내 학과 관련 공지사항 조회 API가 추가되었습니다.
  - 공지사항 생성 시 제목, 내용, 참여 학과 목록을 입력할 수 있습니다.
  - 공지사항 목록은 페이지네이션 및 정렬이 지원되며, 내 학과와 관련된 공지사항만 따로 조회할 수 있습니다.

- **문서화**
  - 공지사항 API 및 예외 상황에 대한 Swagger 문서가 추가되었습니다.

- **테스트**
  - 공지사항 API 통합 테스트 및 입력값 검증 테스트가 추가되었습니다.
  - 테스트 유틸리티와 테스트 데이터 빌더가 도입되었습니다.

- **보안**
  - 공지사항 API 엔드포인트별 접근 권한(매니저, 사용자)이 적용되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->