### PR TITLE
[FEAT] 공지사항 수정 API 구현

### DIFF
--- a/src/main/java/com/jnulocker/announce/adapter/in/AnnounceController.java
+++ b/src/main/java/com/jnulocker/announce/adapter/in/AnnounceController.java
@@ -66,6 +66,6 @@ public class AnnounceController implements AnnounceApi {
             @PathVariable("announce-id") Long announceId,
             @Valid @RequestBody UpdateAnnounceRequest request) {
         announceCommand.updateAnnounce(announceId, request);
-        return ResponseEntity.status(HttpStatus.OK).build();
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/com/jnulocker/announce/adapter/in/AnnounceController.java
+++ b/src/main/java/com/jnulocker/announce/adapter/in/AnnounceController.java
@@ -64,7 +64,7 @@ public class AnnounceController implements AnnounceApi {
     @PutMapping("/{announce-id}")
     public ResponseEntity<Void> updateAnnounce(
             @PathVariable("announce-id") Long announceId,
-            @RequestBody UpdateAnnounceRequest request) {
+            @Valid @RequestBody UpdateAnnounceRequest request) {
         announceCommand.updateAnnounce(announceId, request);
         return ResponseEntity.status(HttpStatus.OK).build();
     }

--- a/src/main/java/com/jnulocker/announce/adapter/in/AnnounceController.java
+++ b/src/main/java/com/jnulocker/announce/adapter/in/AnnounceController.java
@@ -60,6 +60,7 @@ public class AnnounceController implements AnnounceApi {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
+    @Override
     @PutMapping("/{announce-id}")
     public ResponseEntity<Void> updateAnnounce(
             @PathVariable("announce-id") Long announceId,

--- a/src/main/java/com/jnulocker/announce/adapter/in/AnnounceController.java
+++ b/src/main/java/com/jnulocker/announce/adapter/in/AnnounceController.java
@@ -4,6 +4,7 @@ import com.jnulocker.announce.adapter.in.docs.AnnounceApi;
 import com.jnulocker.announce.application.port.in.AnnounceCommand;
 import com.jnulocker.announce.application.port.in.AnnounceQuery;
 import com.jnulocker.announce.application.port.in.request.CreateAnnounceRequest;
+import com.jnulocker.announce.application.port.in.request.UpdateAnnounceRequest;
 import com.jnulocker.announce.application.port.in.response.AnnounceCustomPage;
 import com.jnulocker.announce.application.port.in.response.AnnouncePageable;
 import com.jnulocker.announce.application.port.in.response.MyAnnounceResponse;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -56,5 +58,13 @@ public class AnnounceController implements AnnounceApi {
     public ResponseEntity<Void> deleteAnnounce(@PathVariable("announce-id") Long announceId) {
         announceCommand.deleteAnnounce(announceId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @PutMapping("/{announce-id}")
+    public ResponseEntity<Void> updateAnnounce(
+            @PathVariable("announce-id") Long announceId,
+            @RequestBody UpdateAnnounceRequest request) {
+        announceCommand.updateAnnounce(announceId, request);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/com/jnulocker/announce/adapter/in/docs/AnnounceApi.java
+++ b/src/main/java/com/jnulocker/announce/adapter/in/docs/AnnounceApi.java
@@ -1,6 +1,7 @@
 package com.jnulocker.announce.adapter.in.docs;
 
 import com.jnulocker.announce.application.port.in.request.CreateAnnounceRequest;
+import com.jnulocker.announce.application.port.in.request.UpdateAnnounceRequest;
 import com.jnulocker.announce.application.port.in.response.AnnounceCustomPage;
 import com.jnulocker.announce.application.port.in.response.AnnouncePageable;
 import com.jnulocker.announce.application.port.in.response.MyAnnounceResponse;
@@ -58,4 +59,11 @@ public interface AnnounceApi {
     @Operation(summary = "공지사항 삭제", description = "공지사항을 삭제합니다.")
     @ApiResponse(responseCode = "204", description = "공지사항 삭제 성공")
     ResponseEntity<Void> deleteAnnounce(@PathVariable("announce-id") Long announceId);
+
+    @ApiExceptionExamples(UpdateAnnounceExceptionDocs.class)
+    @Operation(summary = "공지사항 수정", description = "공지사항을 수정합니다.")
+    @ApiResponse(responseCode = "200", description = "공지사항 수정 성공")
+    ResponseEntity<Void> updateAnnounce(
+            @PathVariable("announce-id") Long announceId,
+            @RequestBody UpdateAnnounceRequest request);
 }

--- a/src/main/java/com/jnulocker/announce/adapter/in/docs/UpdateAnnounceExceptionDocs.java
+++ b/src/main/java/com/jnulocker/announce/adapter/in/docs/UpdateAnnounceExceptionDocs.java
@@ -1,0 +1,30 @@
+package com.jnulocker.announce.adapter.in.docs;
+
+import com.jnulocker.announce.exception.AnnounceNotFoundException;
+import com.jnulocker.announce.exception.OnlyManagerCanUpdateAnnounceException;
+import com.jnulocker.common.exception.BusinessException;
+import com.jnulocker.common.swagger.ExceptionDoc;
+import com.jnulocker.common.swagger.ExplainError;
+import com.jnulocker.common.swagger.SwaggerExceptionDoc;
+import com.jnulocker.member.exception.MemberNotFoundException;
+import com.jnulocker.organization.exception.DepartmentNotFoundException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@ExceptionDoc
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UpdateAnnounceExceptionDocs implements SwaggerExceptionDoc {
+    @ExplainError("회원 정보를 조회할 수 없을 때 발생하는 예외입니다")
+    public static final BusinessException 회원_정보를_조회할_수_없을_때 = MemberNotFoundException.EXCEPTION;
+
+    @ExplainError("공지사항이 존재하지 않을 때 발생하는 예외입니다")
+    public static final BusinessException 공지사항이_존재하지_않을_때 = AnnounceNotFoundException.EXCEPTION;
+
+    @ExplainError("공지사항 주최 학과가 아닐 때 발생하는 예외입니다")
+    public static final BusinessException 공지사항_주최_학과가_아닐_때 =
+            OnlyManagerCanUpdateAnnounceException.EXCEPTION;
+
+    @ExplainError("공지사항 주관 학과가 존재하지 않거나 공지사항 참여 학과가 존재하지 않을 때 발생하는 예외입니다")
+    public static final BusinessException 공지사항_주관_학과가_존재하지_않거나_공지사항_참여_학과가_존재하지_않을_때 =
+            DepartmentNotFoundException.EXCEPTION;
+}

--- a/src/main/java/com/jnulocker/announce/adapter/out/AnnouncePersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/announce/adapter/out/AnnouncePersistenceAdapter.java
@@ -48,4 +48,9 @@ public class AnnouncePersistenceAdapter implements AnnounceRecordPort, AnnounceL
         announceParticipationRepository.deleteAllByAnnounce(announce);
         announceRepository.delete(announce);
     }
+
+    @Override
+    public void deleteAnnounceParticipationsByAnnounce(Announce announce) {
+        announceParticipationRepository.deleteAllByAnnounce(announce);
+    }
 }

--- a/src/main/java/com/jnulocker/announce/application/port/in/AnnounceCommand.java
+++ b/src/main/java/com/jnulocker/announce/application/port/in/AnnounceCommand.java
@@ -1,9 +1,12 @@
 package com.jnulocker.announce.application.port.in;
 
 import com.jnulocker.announce.application.port.in.request.CreateAnnounceRequest;
+import com.jnulocker.announce.application.port.in.request.UpdateAnnounceRequest;
 
 public interface AnnounceCommand {
     void createAnnounce(CreateAnnounceRequest request);
 
     void deleteAnnounce(Long announceId);
+
+    void updateAnnounce(Long announceId, UpdateAnnounceRequest request);
 }

--- a/src/main/java/com/jnulocker/announce/application/port/in/request/UpdateAnnounceRequest.java
+++ b/src/main/java/com/jnulocker/announce/application/port/in/request/UpdateAnnounceRequest.java
@@ -1,0 +1,20 @@
+package com.jnulocker.announce.application.port.in.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record UpdateAnnounceRequest(
+        @Schema(description = "공지사항 제목", example = "백도 사물함 신청 안내")
+                @NotBlank(message = "공지사항 제목은 필수입니다.")
+                @Size(max = 50, message = "공지사항 제목은 50자를 초과할 수 없습니다.")
+                String title,
+        @Schema(description = "공지사항 내용", example = "공지사항 내용입니다.")
+                @NotBlank(message = "공지사항 내용은 필수입니다.")
+                @Size(max = 1500, message = "공지사항 내용은 1500자를 초과할 수 없습니다.")
+                String content,
+        @Schema(description = "참여 학과/학부 ID 목록", example = "[1, 2, 3]")
+                @NotEmpty(message = "참여 학과/학부는 최소 1개 이상이어야 합니다.")
+                List<Long> participationDepartmentIds) {}

--- a/src/main/java/com/jnulocker/announce/application/port/out/AnnounceRecordPort.java
+++ b/src/main/java/com/jnulocker/announce/application/port/out/AnnounceRecordPort.java
@@ -10,4 +10,6 @@ public interface AnnounceRecordPort {
     void saveAnnounceParticipations(List<AnnounceParticipation> announceParticipations);
 
     void deleteAnnounce(Announce announce);
+
+    void deleteAnnounceParticipationsByAnnounce(Announce announce);
 }

--- a/src/main/java/com/jnulocker/announce/application/service/AnnounceCommandService.java
+++ b/src/main/java/com/jnulocker/announce/application/service/AnnounceCommandService.java
@@ -3,6 +3,7 @@ package com.jnulocker.announce.application.service;
 import com.jnulocker.announce.application.port.in.AnnounceCommand;
 import com.jnulocker.announce.application.port.in.AnnounceQuery;
 import com.jnulocker.announce.application.port.in.request.CreateAnnounceRequest;
+import com.jnulocker.announce.application.port.in.request.UpdateAnnounceRequest;
 import com.jnulocker.announce.application.port.out.AnnounceRecordPort;
 import com.jnulocker.announce.domain.Announce;
 import com.jnulocker.announce.domain.AnnounceParticipation;
@@ -46,6 +47,22 @@ public class AnnounceCommandService implements AnnounceCommand {
         announce.validateDeletable(member.getDepartment());
 
         announceRecordPort.deleteAnnounce(announce);
+    }
+
+    @Override
+    @Transactional
+    public void updateAnnounce(Long announceId, UpdateAnnounceRequest request) {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        Member member = memberQuery.findByIdOrThrow(memberId);
+
+        Announce announce = announceQuery.getByIdOrThrow(announceId);
+        announce.validateUpdatable(member.getDepartment());
+
+        announce.update(request.title(), request.content());
+
+        // 기존 참여 기록 제거
+        announceRecordPort.deleteAnnounceParticipationsByAnnounce(announce);
+        setupAnnounceParticipations(announce, request.participationDepartmentIds());
     }
 
     private Announce createAndSaveAnnounce(CreateAnnounceRequest request) {

--- a/src/main/java/com/jnulocker/announce/domain/Announce.java
+++ b/src/main/java/com/jnulocker/announce/domain/Announce.java
@@ -68,8 +68,8 @@ public class Announce extends BaseEntity {
         }
     }
 
-    public void update(String tilte, String content) {
-        this.title = tilte;
+    public void update(String title, String content) {
+        this.title = title;
         this.content = content;
     }
 }

--- a/src/main/java/com/jnulocker/announce/domain/Announce.java
+++ b/src/main/java/com/jnulocker/announce/domain/Announce.java
@@ -1,6 +1,7 @@
 package com.jnulocker.announce.domain;
 
 import com.jnulocker.announce.exception.OnlyManagerCanDeleteAnnounceException;
+import com.jnulocker.announce.exception.OnlyManagerCanUpdateAnnounceException;
 import com.jnulocker.common.persistence.BaseEntity;
 import com.jnulocker.organization.domain.Department;
 import jakarta.persistence.CascadeType;
@@ -59,5 +60,16 @@ public class Announce extends BaseEntity {
         if (!this.department.equals(department)) {
             throw OnlyManagerCanDeleteAnnounceException.EXCEPTION;
         }
+    }
+
+    public void validateUpdatable(Department department) {
+        if (!this.department.equals(department)) {
+            throw OnlyManagerCanUpdateAnnounceException.EXCEPTION;
+        }
+    }
+
+    public void update(String tilte, String content) {
+        this.title = tilte;
+        this.content = content;
     }
 }

--- a/src/main/java/com/jnulocker/announce/exception/AnnounceErrorCode.java
+++ b/src/main/java/com/jnulocker/announce/exception/AnnounceErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum AnnounceErrorCode implements ErrorCode {
     ANNOUNCE_NOT_FOUND("AN001", HttpStatus.NOT_FOUND, "공지사항이 존재하지 않습니다."),
     ONLY_MANAGER_CAN_DELETE_ANNOUNCE("AN002", HttpStatus.FORBIDDEN, "공지사항 관리자만 삭제할 수 있습니다."),
+    ONLY_MANAGER_CAN_UPDATE_ANNOUNCE("AN003", HttpStatus.FORBIDDEN, "공지사항 관리자만 수정할 수 있습니다."),
     ;
 
     private final String code;

--- a/src/main/java/com/jnulocker/announce/exception/AnnounceNotFoundException.java
+++ b/src/main/java/com/jnulocker/announce/exception/AnnounceNotFoundException.java
@@ -5,7 +5,7 @@ import com.jnulocker.common.exception.BusinessException;
 public class AnnounceNotFoundException extends BusinessException {
     public static final BusinessException EXCEPTION = new AnnounceNotFoundException();
 
-    public AnnounceNotFoundException() {
+    private AnnounceNotFoundException() {
         super(AnnounceErrorCode.ANNOUNCE_NOT_FOUND);
     }
 }

--- a/src/main/java/com/jnulocker/announce/exception/OnlyManagerCanDeleteAnnounceException.java
+++ b/src/main/java/com/jnulocker/announce/exception/OnlyManagerCanDeleteAnnounceException.java
@@ -6,7 +6,7 @@ public class OnlyManagerCanDeleteAnnounceException extends BusinessException {
 
     public static final BusinessException EXCEPTION = new OnlyManagerCanDeleteAnnounceException();
 
-    public OnlyManagerCanDeleteAnnounceException() {
+    private OnlyManagerCanDeleteAnnounceException() {
         super(AnnounceErrorCode.ONLY_MANAGER_CAN_DELETE_ANNOUNCE);
     }
 }

--- a/src/main/java/com/jnulocker/announce/exception/OnlyManagerCanUpdateAnnounceException.java
+++ b/src/main/java/com/jnulocker/announce/exception/OnlyManagerCanUpdateAnnounceException.java
@@ -1,0 +1,11 @@
+package com.jnulocker.announce.exception;
+
+import com.jnulocker.common.exception.BusinessException;
+
+public class OnlyManagerCanUpdateAnnounceException extends BusinessException {
+    public static final BusinessException EXCEPTION = new OnlyManagerCanUpdateAnnounceException();
+
+    private OnlyManagerCanUpdateAnnounceException() {
+        super(AnnounceErrorCode.ONLY_MANAGER_CAN_UPDATE_ANNOUNCE);
+    }
+}

--- a/src/main/java/com/jnulocker/config/SecurityConfig.java
+++ b/src/main/java/com/jnulocker/config/SecurityConfig.java
@@ -95,6 +95,8 @@ public class SecurityConfig {
                                 .hasAuthority(Role.USER.getRole())
                                 .requestMatchers(HttpMethod.DELETE, "/v1/announces/*")
                                 .hasAuthority(Role.MANAGER.getRole())
+                                .requestMatchers(HttpMethod.PUT, "/v1/announces/*")
+                                .hasAuthority(Role.MANAGER.getRole())
                                 // 토큰의 role과 db의 role과 다른 문제 고려
                                 .anyRequest()
                                 .authenticated());

--- a/src/test/java/com/jnulocker/announce/adapter/in/AnnounceControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/announce/adapter/in/AnnounceControllerIntegrationTest.java
@@ -121,7 +121,7 @@ public class AnnounceControllerIntegrationTest {
     }
 
     @Test
-    void 자신이_속한_학과가_참여하는_이벤트를_조회할_수_있다() {
+    void 자신이_속한_학과가_참여하는_공지사항을_조회할_수_있다() {
         // given
         Department department = organizationTestUtil.createCouncilDepartment();
         Member member = memberTestUtil.createMemberFromRoleWithDepartment(Role.USER, department);
@@ -137,8 +137,6 @@ public class AnnounceControllerIntegrationTest {
                         .extract()
                         .jsonPath()
                         .getList(".", MyAnnounceResponse.class);
-
-        MyAnnounceResponse myAnnounceResponse = myAnnounces.getFirst();
 
         // then
         assertThat(myAnnounces).hasSize(1);

--- a/src/test/java/com/jnulocker/announce/adapter/in/AnnounceControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/announce/adapter/in/AnnounceControllerIntegrationTest.java
@@ -1,10 +1,12 @@
 package com.jnulocker.announce.adapter.in;
 
 import static announce.application.port.in.request.CreateAnnounceRequestTestDataBuilder.createAnnounceRequestBuilder;
+import static announce.application.port.in.request.UpdateAnnounceRequestTestDataBuilder.updateAnnounceRequestBuilder;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.jnulocker.announce.application.port.in.request.CreateAnnounceRequest;
+import com.jnulocker.announce.application.port.in.request.UpdateAnnounceRequest;
 import com.jnulocker.announce.application.port.in.response.AnnounceCustomPage;
 import com.jnulocker.announce.application.port.in.response.MyAnnounceResponse;
 import com.jnulocker.announce.exception.AnnounceErrorCode;
@@ -230,6 +232,85 @@ public class AnnounceControllerIntegrationTest {
                 .isEqualTo(AnnounceErrorCode.ONLY_MANAGER_CAN_DELETE_ANNOUNCE.getMessage());
     }
 
+    @Test
+    void 공지사항을_수정할_수_있다() {
+        // given
+        Department department = organizationTestUtil.createCouncilDepartment();
+        createAnnounceWithDepartment(department);
+
+        // 생성된 공지사항 ID 조회
+        Long announceId = getLastAnnounceId();
+
+        UpdateAnnounceRequest request =
+                updateAnnounceRequestBuilder()
+                        .withTitle("수정된 공지사항 제목")
+                        .withContent("수정된 공지사항 내용")
+                        .withParticipationDepartmentIds(List.of(department.getId()))
+                        .build();
+
+        // when
+        updateAnnounce(announceId, request).statusCode(HttpStatus.OK.value());
+
+        // then
+        // 수정된 공지사항 조회
+        AnnounceCustomPage announceCustomPage =
+                getAnnounces(0, 10, accessToken)
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .as(AnnounceCustomPage.class);
+
+        assertThat(announceCustomPage.content()).hasSize(1);
+        assertThat(announceCustomPage.content().getFirst().title()).isEqualTo("수정된 공지사항 제목");
+        assertThat(announceCustomPage.content().getFirst().content()).isEqualTo("수정된 공지사항 내용");
+    }
+
+    @Test
+    void 존재하지_않는_공지사항은_수정할_수_없다() {
+        // given
+        Long nonExistentAnnounceId = System.currentTimeMillis();
+        UpdateAnnounceRequest request = updateAnnounceRequestBuilder().build();
+
+        // when
+        ErrorResponse errorResponse =
+                updateAnnounce(nonExistentAnnounceId, request)
+                        .statusCode(AnnounceErrorCode.ANNOUNCE_NOT_FOUND.getHttpStatus().value())
+                        .extract()
+                        .as(ErrorResponse.class);
+
+        // then
+        assertThat(errorResponse.message())
+                .isEqualTo(AnnounceErrorCode.ANNOUNCE_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 권한이_없는_사용자는_공지사항을_수정할_수_없다() {
+        // given
+        Department department = organizationTestUtil.createCouncilDepartment();
+        createAnnounceWithDepartment(department);
+
+        // 생성된 공지사항 ID 조회
+        Long announceId = getLastAnnounceId();
+
+        // 비조직원으로 로그인
+        accessToken = authTestUtil.generateAccessTokenWithAnotherDepartment(Role.MANAGER);
+
+        UpdateAnnounceRequest request = updateAnnounceRequestBuilder().build();
+
+        // when
+        ErrorResponse errorResponse =
+                updateAnnounce(announceId, request)
+                        .statusCode(
+                                AnnounceErrorCode.ONLY_MANAGER_CAN_UPDATE_ANNOUNCE
+                                        .getHttpStatus()
+                                        .value())
+                        .extract()
+                        .as(ErrorResponse.class);
+
+        // then
+        assertThat(errorResponse.message())
+                .isEqualTo(AnnounceErrorCode.ONLY_MANAGER_CAN_UPDATE_ANNOUNCE.getMessage());
+    }
+
     private void createAnnounce() {
         Department department = organizationTestUtil.createCouncilDepartment();
         createAnnounceWithDepartment(department);
@@ -299,6 +380,17 @@ public class AnnounceControllerIntegrationTest {
                 .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
                 .when()
                 .delete(ANNOUNCE_URL + "/{announce-id}", announceId)
+                .then()
+                .log()
+                .all();
+    }
+
+    private ValidatableResponse updateAnnounce(Long announceId, UpdateAnnounceRequest request) {
+        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
+                .body(request)
+                .when()
+                .put(ANNOUNCE_URL + "/{announce-id}", announceId)
                 .then()
                 .log()
                 .all();

--- a/src/test/java/com/jnulocker/announce/application/port/in/request/UpdateAnnounceRequestTest.java
+++ b/src/test/java/com/jnulocker/announce/application/port/in/request/UpdateAnnounceRequestTest.java
@@ -1,6 +1,6 @@
 package com.jnulocker.announce.application.port.in.request;
 
-import static announce.application.port.in.request.CreateAnnounceRequestTestDataBuilder.createAnnounceRequestBuilder;
+import static announce.application.port.in.request.UpdateAnnounceRequestTestDataBuilder.updateAnnounceRequestBuilder;
 import static jakarta.validation.Validation.buildDefaultValidatorFactory;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -13,8 +13,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("공지사항 생성 요청 본문 검증 테스트")
-class CreateAnnounceRequestTest {
+@DisplayName("공지사항 수정 요청 본문 검증 테스트")
+class UpdateAnnounceRequestTest {
 
     private static Validator validator;
 
@@ -25,27 +25,19 @@ class CreateAnnounceRequestTest {
     }
 
     @Test
-    void 유효한_요청은_검증을_통과한다() {
-        CreateAnnounceRequest request = createAnnounceRequestBuilder().build();
-
-        Set<ConstraintViolation<CreateAnnounceRequest>> violations = validator.validate(request);
-        assertThat(violations).isEmpty();
-    }
-
-    @Test
     void 제목이_빈_문자열이면_검증에_실패한다() {
-        CreateAnnounceRequest request = createAnnounceRequestBuilder().withTitle("").build();
+        UpdateAnnounceRequest request = updateAnnounceRequestBuilder().withTitle("").build();
 
-        Set<ConstraintViolation<CreateAnnounceRequest>> violations = validator.validate(request);
+        Set<ConstraintViolation<UpdateAnnounceRequest>> violations = validator.validate(request);
         assertThat(violations).hasSize(1);
         assertThat(violations.iterator().next().getMessage()).isEqualTo("공지사항 제목은 필수입니다.");
     }
 
     @Test
     void 제목이_null이면_검증에_실패한다() {
-        CreateAnnounceRequest request = createAnnounceRequestBuilder().withTitle(null).build();
+        UpdateAnnounceRequest request = updateAnnounceRequestBuilder().withTitle(null).build();
 
-        Set<ConstraintViolation<CreateAnnounceRequest>> violations = validator.validate(request);
+        Set<ConstraintViolation<UpdateAnnounceRequest>> violations = validator.validate(request);
         assertThat(violations).hasSize(1);
         assertThat(violations.iterator().next().getMessage()).isEqualTo("공지사항 제목은 필수입니다.");
     }
@@ -53,9 +45,9 @@ class CreateAnnounceRequestTest {
     @Test
     void 제목이_50자를_초과하면_검증에_실패한다() {
         String longTitle = "a".repeat(51);
-        CreateAnnounceRequest request = createAnnounceRequestBuilder().withTitle(longTitle).build();
+        UpdateAnnounceRequest request = updateAnnounceRequestBuilder().withTitle(longTitle).build();
 
-        Set<ConstraintViolation<CreateAnnounceRequest>> violations = validator.validate(request);
+        Set<ConstraintViolation<UpdateAnnounceRequest>> violations = validator.validate(request);
         assertThat(violations).hasSize(1);
         assertThat(violations.iterator().next().getMessage())
                 .isEqualTo("공지사항 제목은 50자를 초과할 수 없습니다.");
@@ -63,18 +55,18 @@ class CreateAnnounceRequestTest {
 
     @Test
     void 내용이_빈_문자열이면_검증에_실패한다() {
-        CreateAnnounceRequest request = createAnnounceRequestBuilder().withContent("").build();
+        UpdateAnnounceRequest request = updateAnnounceRequestBuilder().withContent("").build();
 
-        Set<ConstraintViolation<CreateAnnounceRequest>> violations = validator.validate(request);
+        Set<ConstraintViolation<UpdateAnnounceRequest>> violations = validator.validate(request);
         assertThat(violations).hasSize(1);
         assertThat(violations.iterator().next().getMessage()).isEqualTo("공지사항 내용은 필수입니다.");
     }
 
     @Test
     void 내용이_null이면_검증에_실패한다() {
-        CreateAnnounceRequest request = createAnnounceRequestBuilder().withContent(null).build();
+        UpdateAnnounceRequest request = updateAnnounceRequestBuilder().withContent(null).build();
 
-        Set<ConstraintViolation<CreateAnnounceRequest>> violations = validator.validate(request);
+        Set<ConstraintViolation<UpdateAnnounceRequest>> violations = validator.validate(request);
         assertThat(violations).hasSize(1);
         assertThat(violations.iterator().next().getMessage()).isEqualTo("공지사항 내용은 필수입니다.");
     }
@@ -82,10 +74,10 @@ class CreateAnnounceRequestTest {
     @Test
     void 내용이_1500자를_초과하면_검증에_실패한다() {
         String longContent = "a".repeat(1501);
-        CreateAnnounceRequest request =
-                createAnnounceRequestBuilder().withContent(longContent).build();
+        UpdateAnnounceRequest request =
+                updateAnnounceRequestBuilder().withContent(longContent).build();
 
-        Set<ConstraintViolation<CreateAnnounceRequest>> violations = validator.validate(request);
+        Set<ConstraintViolation<UpdateAnnounceRequest>> violations = validator.validate(request);
         assertThat(violations).hasSize(1);
         assertThat(violations.iterator().next().getMessage())
                 .isEqualTo("공지사항 내용은 1500자를 초과할 수 없습니다.");
@@ -93,12 +85,12 @@ class CreateAnnounceRequestTest {
 
     @Test
     void 참여_학과_목록이_비어있으면_검증에_실패한다() {
-        CreateAnnounceRequest request =
-                createAnnounceRequestBuilder()
+        UpdateAnnounceRequest request =
+                updateAnnounceRequestBuilder()
                         .withParticipationDepartmentIds(Collections.emptyList())
                         .build();
 
-        Set<ConstraintViolation<CreateAnnounceRequest>> violations = validator.validate(request);
+        Set<ConstraintViolation<UpdateAnnounceRequest>> violations = validator.validate(request);
         assertThat(violations).hasSize(1);
         assertThat(violations.iterator().next().getMessage())
                 .isEqualTo("참여 학과/학부는 최소 1개 이상이어야 합니다.");

--- a/src/testFixtures/java/announce/application/port/in/request/UpdateAnnounceRequestTestDataBuilder.java
+++ b/src/testFixtures/java/announce/application/port/in/request/UpdateAnnounceRequestTestDataBuilder.java
@@ -1,0 +1,36 @@
+package announce.application.port.in.request;
+
+import com.jnulocker.announce.application.port.in.request.UpdateAnnounceRequest;
+import java.util.List;
+
+public class UpdateAnnounceRequestTestDataBuilder {
+    private String title = "전자컴퓨터공학부 사물함 신청 안내";
+    private String content = "수정된 공지사항 내용입니다.";
+    private List<Long> participationDepartmentIds = List.of(4L, 5L);
+
+    private UpdateAnnounceRequestTestDataBuilder() {}
+
+    public static UpdateAnnounceRequestTestDataBuilder updateAnnounceRequestBuilder() {
+        return new UpdateAnnounceRequestTestDataBuilder();
+    }
+
+    public UpdateAnnounceRequestTestDataBuilder withTitle(String title) {
+        this.title = title;
+        return this;
+    }
+
+    public UpdateAnnounceRequestTestDataBuilder withContent(String content) {
+        this.content = content;
+        return this;
+    }
+
+    public UpdateAnnounceRequestTestDataBuilder withParticipationDepartmentIds(
+            List<Long> participationDepartmentIds) {
+        this.participationDepartmentIds = participationDepartmentIds;
+        return this;
+    }
+
+    public UpdateAnnounceRequest build() {
+        return new UpdateAnnounceRequest(title, content, participationDepartmentIds);
+    }
+}


### PR DESCRIPTION
### 개요
close #96 

### 작업사항
- 공지사항 수정 API를 구현하였습니다.

### 테스트 결과
<img width="350" alt="image" src="https://github.com/user-attachments/assets/736d2ff0-8df7-4057-a335-5dd2634a8f60" />

**추가된 테스트케이스**

- 공지사항 수정 요청 본문 테스트
<img width="250" alt="image" src="https://github.com/user-attachments/assets/54d5f980-1501-4dd0-836d-750907efbde0" />

- 공지사항 수정 API 컨트롤러 테스트
<img width="150" alt="image" src="https://github.com/user-attachments/assets/fde273c9-006e-4941-9c02-e0157aacba6f" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/de8a75a5-b970-456f-970b-b773a165f288" />
<img width="220" alt="image" src="https://github.com/user-attachments/assets/b4bfc592-c54c-42a9-9324-7a80cd1a2831" />


### reference
- 공지사항 조회 API 수정될 수 있어 공지사항 조회 시 수정 상태는 아직 추가하지 않았습니다.

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 기존 공지사항을 수정할 수 있는 기능이 추가되었습니다. 이제 제목, 내용, 참여 학과를 변경할 수 있습니다.

- **버그 수정**
  - 공지사항 수정 시 권한이 없는 사용자는 수정할 수 없도록 제한되었습니다.

- **문서화**
  - 공지사항 수정 관련 API 및 예외 상황에 대한 문서가 추가되었습니다.

- **테스트**
  - 공지사항 수정 기능과 유효성 검증에 대한 통합 및 단위 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->