### PR TITLE
[FEAT] 내 정보 조회에 Role 필드 추가

### DIFF
--- a/src/main/java/com/jnulocker/member/application/port/in/response/MemberInfoResponse.java
+++ b/src/main/java/com/jnulocker/member/application/port/in/response/MemberInfoResponse.java
@@ -1,5 +1,6 @@
 package com.jnulocker.member.application.port.in.response;
 
+import com.jnulocker.member.domain.Role;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record MemberInfoResponse(
@@ -8,15 +9,17 @@ public record MemberInfoResponse(
         @Schema(description = "학번", example = "222222") String studentNumber,
         @Schema(description = "소속", example = "수학과") String affiliation,
         @Schema(description = "전화번호", example = "010-1234-1234") String phoneNumber,
-        @Schema(description = "이메일", example = "test@example.com") String email) {
+        @Schema(description = "이메일", example = "test@example.com") String email,
+        @Schema(description = "회원 권한", example = "USER") Role role) {
     public static MemberInfoResponse of(
             Long memberId,
             String name,
             String studentNumber,
             String affiliation,
             String phoneNumber,
-            String email) {
+            String email,
+            Role role) {
         return new MemberInfoResponse(
-                memberId, name, studentNumber, affiliation, phoneNumber, email);
+                memberId, name, studentNumber, affiliation, phoneNumber, email, role);
     }
 }

--- a/src/main/java/com/jnulocker/member/application/service/MemberQueryService.java
+++ b/src/main/java/com/jnulocker/member/application/service/MemberQueryService.java
@@ -73,7 +73,8 @@ public class MemberQueryService implements MemberQuery {
                 studentNumber,
                 affiliation,
                 member.getPhoneNumber(),
-                member.getEmail());
+                member.getEmail(),
+                member.getRole());
     }
 
     public Page<Member> getByRoleAndDepartment(

--- a/src/main/java/com/jnulocker/member/application/service/MemberQueryService.java
+++ b/src/main/java/com/jnulocker/member/application/service/MemberQueryService.java
@@ -8,7 +8,6 @@ import com.jnulocker.member.domain.Member;
 import com.jnulocker.member.domain.Role;
 import com.jnulocker.member.exception.MemberNotFoundException;
 import com.jnulocker.organization.domain.Department;
-import com.jnulocker.organization.domain.OrganizationType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -51,19 +50,12 @@ public class MemberQueryService implements MemberQuery {
         Long memberId = SecurityUtils.getCurrentMemberId();
         Member member = findByIdOrThrow(memberId);
 
-        String studentNumber = null;
-        String affiliation = null;
+        String studentNumber = member.getStudentNumber();
+        String affiliation = member.getDepartment().getName();
 
         Role role = member.getRole();
-        OrganizationType orgType = member.getDepartment().getOrganization().getType();
 
-        if (role == Role.USER) {
-            studentNumber = member.getStudentNumber();
-            affiliation = member.getDepartment().getName();
-        } else if (role == Role.MANAGER) {
-            if (orgType == OrganizationType.COUNCIL) {
-                studentNumber = member.getStudentNumber();
-            }
+        if (role == Role.MANAGER) {
             affiliation = member.getDepartment().getNickname();
         }
 

--- a/src/test/java/com/jnulocker/announce/adapter/in/AnnounceControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/announce/adapter/in/AnnounceControllerIntegrationTest.java
@@ -249,7 +249,7 @@ public class AnnounceControllerIntegrationTest {
                         .build();
 
         // when
-        updateAnnounce(announceId, request).statusCode(HttpStatus.OK.value());
+        updateAnnounce(announceId, request).statusCode(HttpStatus.NO_CONTENT.value());
 
         // then
         // 수정된 공지사항 조회

--- a/src/test/java/com/jnulocker/member/adapter/in/MemberControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/member/adapter/in/MemberControllerIntegrationTest.java
@@ -124,11 +124,11 @@ public class MemberControllerIntegrationTest {
         assertThat(memberInfoResponse).isNotNull();
         assertThat(memberInfoResponse.memberId()).isEqualTo(expectedMember.getId());
         assertThat(memberInfoResponse.name()).isEqualTo(expectedMember.getName());
-        assertThat(memberInfoResponse.studentNumber()).isNull();
         assertThat(memberInfoResponse.affiliation())
                 .isEqualTo(expectedMember.getDepartment().getNickname());
         assertThat(memberInfoResponse.phoneNumber()).isEqualTo(expectedMember.getPhoneNumber());
         assertThat(memberInfoResponse.email()).isEqualTo(expectedMember.getEmail());
+        assertThat(memberInfoResponse.role()).isEqualTo(expectedMember.getRole());
     }
 
     public static ValidatableResponse getMemberInfo(String accessToken) {


### PR DESCRIPTION
### 개요
close #99 

### 작업사항
- 내 정보 조회 API 응답 필드에 Role 필드 추가

### 변경로직
- `"/info"` API 응답 본문에 `Role` 응답 추가
- 내 정보 조회 비즈니스 로직 리팩토링
- 테스트케이스 수정

### 테스트 결과
<img width="297" alt="image" src="https://github.com/user-attachments/assets/cb008ea3-1fa1-4d5e-8603-37cfe1f4fb44" />


### reference

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 회원 정보 응답에 역할(role) 정보가 추가되어, 회원의 권한 수준을 확인할 수 있습니다.

- **버그 수정**
  - 공지사항 수정 시 성공 응답 코드가 200 OK에서 204 No Content로 변경되었습니다.

- **테스트**
  - 회원 정보 조회 테스트에서 역할(role) 필드 검증이 추가되었습니다.
  - 공지사항 수정 테스트가 변경된 응답 코드를 반영하도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->