### PR TITLE
[FEAT] 부하테스트를 위한 Fixed Code 이메일 인증 서비스 구현

### DIFF
--- a/src/main/java/com/jnulocker/auth/adapter/out/FixedCodeEmailSender.java
+++ b/src/main/java/com/jnulocker/auth/adapter/out/FixedCodeEmailSender.java
@@ -1,0 +1,33 @@
+package com.jnulocker.auth.adapter.out;
+
+import com.jnulocker.auth.application.port.out.EmailSender;
+import com.jnulocker.common.util.RedisUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "custom.email-verification.fixed", havingValue = "true")
+public class FixedCodeEmailSender implements EmailSender {
+
+    private final RedisUtil redisUtil;
+
+    @Value("${custom.email-verification.code}")
+    private int fixedCode;
+
+    @Override
+    public void sendVerificationEmail(String email, int code) {
+        log.info("Fixed 환경 - 이메일 전송 생략: 코드: {} \t 이메일: {}", code, email);
+        redisUtil.setEmailVerificationCode(email, code);
+    }
+
+    @Override
+    public int generateVerificationCode() {
+        log.info("Fixed 환경 - 고정된 코드 생성: {}", fixedCode);
+        return fixedCode;
+    }
+}

--- a/src/main/java/com/jnulocker/auth/adapter/out/FixedCodeEmailSender.java
+++ b/src/main/java/com/jnulocker/auth/adapter/out/FixedCodeEmailSender.java
@@ -17,16 +17,16 @@ public class FixedCodeEmailSender implements EmailSender {
     private final RedisUtil redisUtil;
 
     @Value("${custom.email-verification.code}")
-    private int fixedCode;
+    private String fixedCode;
 
     @Override
-    public void sendVerificationEmail(String email, int code) {
+    public void sendVerificationEmail(String email, String code) {
         log.info("Fixed 환경 - 이메일 전송 생략: 코드: {} \t 이메일: {}", code, email);
         redisUtil.setEmailVerificationCode(email, code);
     }
 
     @Override
-    public int generateVerificationCode() {
+    public String generateVerificationCode() {
         log.info("Fixed 환경 - 고정된 코드 생성: {}", fixedCode);
         return fixedCode;
     }

--- a/src/main/java/com/jnulocker/auth/adapter/out/RandomCodeEmailSender.java
+++ b/src/main/java/com/jnulocker/auth/adapter/out/RandomCodeEmailSender.java
@@ -1,0 +1,68 @@
+package com.jnulocker.auth.adapter.out;
+
+import com.jnulocker.auth.application.port.out.EmailSender;
+import com.jnulocker.auth.exception.FailedToCreateCodeException;
+import com.jnulocker.auth.exception.SendEmailException;
+import com.jnulocker.common.util.RedisUtil;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import java.security.SecureRandom;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "custom.email-verification.fixed", havingValue = "false")
+public class RandomCodeEmailSender implements EmailSender {
+
+    private final RedisUtil redisUtil;
+    private final JavaMailSender javaMailSender;
+    private final TemplateEngine templateEngine;
+
+    @Override
+    public void sendVerificationEmail(String email, int code) {
+        try {
+            MimeMessage message = setupEmailForm(email, code);
+            javaMailSender.send(message);
+            redisUtil.setEmailVerificationCode(email, code);
+        } catch (Exception e) {
+            throw SendEmailException.EXCEPTION;
+        }
+    }
+
+    private MimeMessage setupEmailForm(String email, int code) throws MessagingException {
+        String form = generateEmailForm(code);
+
+        MimeMessage message = javaMailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(message, false, "UTF-8");
+
+        helper.setTo(email);
+        helper.setSubject("[전남대학교 사물함 신청 서비스] 인증 코드 전송");
+        helper.setText(form, true);
+        return message;
+    }
+
+    private String generateEmailForm(int code) {
+        Context context = new Context();
+        context.setVariable("code", code);
+        return templateEngine.process("email-verification", context);
+    }
+
+    @Override
+    public int generateVerificationCode() {
+        try {
+            SecureRandom random = SecureRandom.getInstanceStrong();
+            return 100000 + random.nextInt(900000);
+        } catch (Exception e) {
+            log.error("Error generating verification code", e);
+            throw FailedToCreateCodeException.EXCEPTION;
+        }
+    }
+}

--- a/src/main/java/com/jnulocker/auth/adapter/out/RandomCodeEmailSender.java
+++ b/src/main/java/com/jnulocker/auth/adapter/out/RandomCodeEmailSender.java
@@ -27,7 +27,7 @@ public class RandomCodeEmailSender implements EmailSender {
     private final TemplateEngine templateEngine;
 
     @Override
-    public void sendVerificationEmail(String email, int code) {
+    public void sendVerificationEmail(String email, String code) {
         try {
             MimeMessage message = setupEmailForm(email, code);
             javaMailSender.send(message);
@@ -37,7 +37,7 @@ public class RandomCodeEmailSender implements EmailSender {
         }
     }
 
-    private MimeMessage setupEmailForm(String email, int code) throws MessagingException {
+    private MimeMessage setupEmailForm(String email, String code) throws MessagingException {
         String form = generateEmailForm(code);
 
         MimeMessage message = javaMailSender.createMimeMessage();
@@ -49,17 +49,18 @@ public class RandomCodeEmailSender implements EmailSender {
         return message;
     }
 
-    private String generateEmailForm(int code) {
+    private String generateEmailForm(String code) {
         Context context = new Context();
         context.setVariable("code", code);
         return templateEngine.process("email-verification", context);
     }
 
     @Override
-    public int generateVerificationCode() {
+    public String generateVerificationCode() {
         try {
             SecureRandom random = SecureRandom.getInstanceStrong();
-            return 100000 + random.nextInt(900000);
+            int integerCode = 100000 + random.nextInt(900000);
+            return String.valueOf(integerCode);
         } catch (Exception e) {
             log.error("Error generating verification code", e);
             throw FailedToCreateCodeException.EXCEPTION;

--- a/src/main/java/com/jnulocker/auth/application/port/out/EmailSender.java
+++ b/src/main/java/com/jnulocker/auth/application/port/out/EmailSender.java
@@ -1,7 +1,7 @@
 package com.jnulocker.auth.application.port.out;
 
 public interface EmailSender {
-    void sendVerificationEmail(String email, int code);
+    void sendVerificationEmail(String email, String code);
 
-    int generateVerificationCode();
+    String generateVerificationCode();
 }

--- a/src/main/java/com/jnulocker/auth/application/port/out/EmailSender.java
+++ b/src/main/java/com/jnulocker/auth/application/port/out/EmailSender.java
@@ -1,0 +1,7 @@
+package com.jnulocker.auth.application.port.out;
+
+public interface EmailSender {
+    void sendVerificationEmail(String email, int code);
+
+    int generateVerificationCode();
+}

--- a/src/main/java/com/jnulocker/auth/application/service/EmailService.java
+++ b/src/main/java/com/jnulocker/auth/application/service/EmailService.java
@@ -29,7 +29,7 @@ public class EmailService implements SendEmailCommand, VerifyCodeCommand {
             redisUtil.deleteVerifiedData(request.email());
         }
 
-        int code = emailSender.generateVerificationCode();
+        String code = emailSender.generateVerificationCode();
         emailSender.sendVerificationEmail(request.email(), code);
     }
 

--- a/src/main/java/com/jnulocker/auth/application/service/EmailService.java
+++ b/src/main/java/com/jnulocker/auth/application/service/EmailService.java
@@ -4,27 +4,20 @@ import com.jnulocker.auth.application.port.in.SendEmailCommand;
 import com.jnulocker.auth.application.port.in.VerifyCodeCommand;
 import com.jnulocker.auth.application.port.in.request.SendEmailRequest;
 import com.jnulocker.auth.application.port.in.request.VerifyCodeRequest;
+import com.jnulocker.auth.application.port.out.EmailSender;
 import com.jnulocker.auth.exception.CodeNotCorrectException;
-import com.jnulocker.auth.exception.FailedToCreateCodeException;
-import com.jnulocker.auth.exception.SendEmailException;
 import com.jnulocker.common.util.RedisUtil;
-import jakarta.mail.internet.MimeMessage;
-import java.security.SecureRandom;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
-import org.thymeleaf.TemplateEngine;
-import org.thymeleaf.context.Context;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class EmailService implements SendEmailCommand, VerifyCodeCommand {
-    private final TemplateEngine templateEngine;
-    private final JavaMailSender javaMailSender;
+
     private final RedisUtil redisUtil;
+    private final EmailSender emailSender;
     private final AuthCommandService authCommandService;
 
     @Override
@@ -36,22 +29,8 @@ public class EmailService implements SendEmailCommand, VerifyCodeCommand {
             redisUtil.deleteVerifiedData(request.email());
         }
 
-        int code = createCode();
-        String form = generateHtml(code);
-
-        try {
-            MimeMessage message = javaMailSender.createMimeMessage();
-            MimeMessageHelper helper = new MimeMessageHelper(message, false, "UTF-8");
-
-            helper.setTo(request.email());
-            helper.setSubject("[전남대학교 사물함 신청 서비스] 인증 코드 전송");
-            helper.setText(form, true);
-
-            javaMailSender.send(message);
-            redisUtil.setEmailVerificationCode(request.email(), code);
-        } catch (Exception e) {
-            throw SendEmailException.EXCEPTION;
-        }
+        int code = emailSender.generateVerificationCode();
+        emailSender.sendVerificationEmail(request.email(), code);
     }
 
     @Override
@@ -63,21 +42,5 @@ public class EmailService implements SendEmailCommand, VerifyCodeCommand {
 
         redisUtil.setEmailVerified(request.email());
         redisUtil.deleteData(request.email());
-    }
-
-    private int createCode() {
-        try {
-            SecureRandom random = SecureRandom.getInstanceStrong();
-            return 100000 + random.nextInt(900000);
-        } catch (Exception e) {
-            log.error("Error generating verification code", e);
-            throw FailedToCreateCodeException.EXCEPTION;
-        }
-    }
-
-    private String generateHtml(int code) {
-        Context context = new Context();
-        context.setVariable("code", code);
-        return templateEngine.process("email-verification", context);
     }
 }

--- a/src/main/java/com/jnulocker/common/util/RedisUtil.java
+++ b/src/main/java/com/jnulocker/common/util/RedisUtil.java
@@ -60,8 +60,8 @@ public class RedisUtil {
         return emailVerificationRepository.findById(getVerifiedKey(email)).isPresent();
     }
 
-    public void setEmailVerificationCode(String email, int code) {
-        setData(email, Integer.toString(code), EMAIL_CODE_EXPIRE);
+    public void setEmailVerificationCode(String email, String code) {
+        setData(email, code, EMAIL_CODE_EXPIRE);
     }
 
     public void setEmailVerified(String email) {

--- a/src/main/java/com/jnulocker/events/adapter/in/docs/EventApi.java
+++ b/src/main/java/com/jnulocker/events/adapter/in/docs/EventApi.java
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Tag(name = "이벤트", description = "이벤트 관련 API")
 public interface EventApi {
 
+    @ApiExceptionExamples(GetEventsExceptionDocs.class)
     @Operation(summary = "이벤트 목록 조회", description = "이벤트 목록을 조회합니다. 페이지네이션이 지원됩니다.")
     @ApiResponse(
             responseCode = "200",

--- a/src/main/java/com/jnulocker/events/adapter/in/docs/GetEventsExceptionDocs.java
+++ b/src/main/java/com/jnulocker/events/adapter/in/docs/GetEventsExceptionDocs.java
@@ -1,0 +1,17 @@
+package com.jnulocker.events.adapter.in.docs;
+
+import com.jnulocker.common.exception.BusinessException;
+import com.jnulocker.common.swagger.ExceptionDoc;
+import com.jnulocker.common.swagger.ExplainError;
+import com.jnulocker.common.swagger.SwaggerExceptionDoc;
+import com.jnulocker.member.exception.MemberNotFoundException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@ExceptionDoc
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetEventsExceptionDocs implements SwaggerExceptionDoc {
+
+    @ExplainError("회원 정보를 조회할 수 없을 때 발생하는 예외입니다")
+    public static final BusinessException 회원_정보를_조회할_수_없을_때 = MemberNotFoundException.EXCEPTION;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -81,6 +81,9 @@ decorator:
       enable-logging: true
 
 custom:
+  email-verification:
+    fixed: ${EMAIL_VERIFICATION_FIXED:false}
+    code: ${EMAIL_VERIFICATION_CODE:123456}
   jwt:
     access-secret-key: ${JWT_ACCESS_SECRET_KEY:dGVzdC1zZWNyZXQta2V5LXRlc3Qtc2VjcmV0LWtleS10ZXN0LXNlY3JldC1rZXktdGVzdC1zZWNyZXQta2V5}
     refresh-secret-key: ${JWT_REFRESH_SECRET_KEY:dGVzdC1yZWZyZXNoLXNlY3JldC1rZXktdGVzdC1yZWZyZXNoLXNlY3JldC1rZXktdGVzdC1yZWZyZXNoLXNlY3JldC1rZXktdGVzdC1yZWZyZXNo}

--- a/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
@@ -508,7 +508,7 @@ class AuthControllerIntegrationTest {
         String code = "123456";
         VerifyCodeRequest request =
                 verifyCodeRequestBuilder().withEmail(email).withCode(code).build();
-        redisUtil.setEmailVerificationCode(request.email(), Integer.parseInt(code));
+        redisUtil.setEmailVerificationCode(request.email(), code);
 
         // when
         ValidatableResponse response = verify(request);
@@ -522,7 +522,7 @@ class AuthControllerIntegrationTest {
         // given
         String email = "test@example.com";
         String incorrectCode = "12347";
-        redisUtil.setEmailVerificationCode(email, Integer.parseInt(incorrectCode));
+        redisUtil.setEmailVerificationCode(email, incorrectCode);
 
         VerifyCodeRequest request =
                 verifyCodeRequestBuilder().withEmail(email).withCode("123456").build();


### PR DESCRIPTION
### 개요
close #102 

### 작업사항
- 부하 테스트를 위해 익명 사용자 회원가입을 위한 고정된 이메일 코드 인증 방식 구현
- 실제로 `JavaMailSender`를 이용하는 것이 아닌 `Redis`에 고정된 인증 코드만 저장

### 변경로직
- 고정된 이메일 코드 요청 서비스 구현
- 환경변수에 따라 이메일 서비스 빈이 다르게 등록되도록 설정

### 테스트 결과
<img width="298" alt="image" src="https://github.com/user-attachments/assets/a41f1cd8-40a8-4601-ad13-2e31c0604cb9" />

### reference
- EC2 서버는 `fixed: true`로 두었습니다.

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 이메일 인증 코드 발송 방식이 고정 코드 또는 랜덤 코드로 선택 가능해졌습니다.
  - 이메일 인증 코드 및 발송 방식이 환경 변수로 설정 가능합니다.

- **문서화**
  - 이벤트 목록 조회 API에 예외 응답 예시가 추가되었습니다.
  - 이벤트 조회 관련 예외 문서가 추가되었습니다.

- **리팩터링**
  - 이메일 인증 코드 생성 및 발송 로직이 외부 컴포넌트로 분리되어 서비스 구조가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->