### PR TITLE
[FEAT] 공지사항 조회 API 응답 명세 변경

### DIFF
--- a/src/main/java/com/jnulocker/announce/adapter/in/AnnounceController.java
+++ b/src/main/java/com/jnulocker/announce/adapter/in/AnnounceController.java
@@ -62,6 +62,7 @@ public class AnnounceController implements AnnounceApi {
         return ResponseEntity.ok(announceQuery.getMyAnnounces(pageable));
     }
 
+    @Override
     @GetMapping("/me/{announce-id}")
     public ResponseEntity<MyAnnounceDetailResponse> getMyAnnounce(
             @PathVariable("announce-id") Long announceId) {

--- a/src/main/java/com/jnulocker/announce/adapter/in/AnnounceController.java
+++ b/src/main/java/com/jnulocker/announce/adapter/in/AnnounceController.java
@@ -8,10 +8,9 @@ import com.jnulocker.announce.application.port.in.request.UpdateAnnounceRequest;
 import com.jnulocker.announce.application.port.in.response.AnnounceCustomPage;
 import com.jnulocker.announce.application.port.in.response.AnnounceDetailResponse;
 import com.jnulocker.announce.application.port.in.response.AnnouncePageable;
+import com.jnulocker.announce.application.port.in.response.MyAnnounceCustomPage;
 import com.jnulocker.announce.application.port.in.response.MyAnnounceDetailResponse;
-import com.jnulocker.announce.application.port.in.response.MyAnnounceResponse;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
@@ -57,8 +56,10 @@ public class AnnounceController implements AnnounceApi {
 
     @Override
     @GetMapping("/me")
-    public ResponseEntity<List<MyAnnounceResponse>> getMyAnnounces() {
-        return ResponseEntity.ok(announceQuery.getMyAnnounces());
+    public ResponseEntity<MyAnnounceCustomPage> getMyAnnounces(
+            @Valid @ParameterObject AnnouncePageable announcePageable) {
+        Pageable pageable = announcePageable.toPageable();
+        return ResponseEntity.ok(announceQuery.getMyAnnounces(pageable));
     }
 
     @GetMapping("/me/{announce-id}")

--- a/src/main/java/com/jnulocker/announce/adapter/in/AnnounceController.java
+++ b/src/main/java/com/jnulocker/announce/adapter/in/AnnounceController.java
@@ -6,7 +6,9 @@ import com.jnulocker.announce.application.port.in.AnnounceQuery;
 import com.jnulocker.announce.application.port.in.request.CreateAnnounceRequest;
 import com.jnulocker.announce.application.port.in.request.UpdateAnnounceRequest;
 import com.jnulocker.announce.application.port.in.response.AnnounceCustomPage;
+import com.jnulocker.announce.application.port.in.response.AnnounceDetailResponse;
 import com.jnulocker.announce.application.port.in.response.AnnouncePageable;
+import com.jnulocker.announce.application.port.in.response.MyAnnounceDetailResponse;
 import com.jnulocker.announce.application.port.in.response.MyAnnounceResponse;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -47,10 +49,22 @@ public class AnnounceController implements AnnounceApi {
         return ResponseEntity.ok(announceQuery.getAllAnnounces(pageable));
     }
 
+    @GetMapping("/{announce-id}")
+    public ResponseEntity<AnnounceDetailResponse> getAnnounce(
+            @PathVariable("announce-id") Long announceId) {
+        return ResponseEntity.ok(announceQuery.getAnnounce(announceId));
+    }
+
     @Override
     @GetMapping("/me")
     public ResponseEntity<List<MyAnnounceResponse>> getMyAnnounces() {
         return ResponseEntity.ok(announceQuery.getMyAnnounces());
+    }
+
+    @GetMapping("/me/{announce-id}")
+    public ResponseEntity<MyAnnounceDetailResponse> getMyAnnounce(
+            @PathVariable("announce-id") Long announceId) {
+        return ResponseEntity.ok(announceQuery.getMyAnnounce(announceId));
     }
 
     @Override

--- a/src/main/java/com/jnulocker/announce/adapter/in/AnnounceController.java
+++ b/src/main/java/com/jnulocker/announce/adapter/in/AnnounceController.java
@@ -45,7 +45,7 @@ public class AnnounceController implements AnnounceApi {
     public ResponseEntity<AnnounceCustomPage> getAnnounces(
             @Valid @ParameterObject AnnouncePageable announcePageable) {
         Pageable pageable = announcePageable.toPageable();
-        return ResponseEntity.ok(announceQuery.getAllAnnounces(pageable));
+        return ResponseEntity.ok(announceQuery.getAnnounces(pageable));
     }
 
     @GetMapping("/{announce-id}")

--- a/src/main/java/com/jnulocker/announce/adapter/in/docs/AnnounceApi.java
+++ b/src/main/java/com/jnulocker/announce/adapter/in/docs/AnnounceApi.java
@@ -5,17 +5,15 @@ import com.jnulocker.announce.application.port.in.request.UpdateAnnounceRequest;
 import com.jnulocker.announce.application.port.in.response.AnnounceCustomPage;
 import com.jnulocker.announce.application.port.in.response.AnnounceDetailResponse;
 import com.jnulocker.announce.application.port.in.response.AnnouncePageable;
+import com.jnulocker.announce.application.port.in.response.MyAnnounceCustomPage;
 import com.jnulocker.announce.application.port.in.response.MyAnnounceDetailResponse;
-import com.jnulocker.announce.application.port.in.response.MyAnnounceResponse;
 import com.jnulocker.common.swagger.ApiExceptionExamples;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -61,13 +59,9 @@ public interface AnnounceApi {
             content =
                     @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            array =
-                                    @ArraySchema(
-                                            schema =
-                                                    @Schema(
-                                                            implementation =
-                                                                    MyAnnounceResponse.class))))
-    ResponseEntity<List<MyAnnounceResponse>> getMyAnnounces();
+                            schema = @Schema(implementation = MyAnnounceCustomPage.class)))
+    ResponseEntity<MyAnnounceCustomPage> getMyAnnounces(
+            @Valid @ParameterObject AnnouncePageable announcePageable);
 
     @Operation(summary = "자신의 소속학과 대상 공지사항 상세 조회", description = "자신의 소속학과가 참여한 공지사항 상세 내용을 조회합니다.")
     @ApiResponse(

--- a/src/main/java/com/jnulocker/announce/adapter/in/docs/AnnounceApi.java
+++ b/src/main/java/com/jnulocker/announce/adapter/in/docs/AnnounceApi.java
@@ -63,6 +63,7 @@ public interface AnnounceApi {
     ResponseEntity<MyAnnounceCustomPage> getMyAnnounces(
             @Valid @ParameterObject AnnouncePageable announcePageable);
 
+    @ApiExceptionExamples(GetMyAnnounceExceptionDocs.class)
     @Operation(summary = "자신의 소속학과 대상 공지사항 상세 조회", description = "자신의 소속학과가 참여한 공지사항 상세 내용을 조회합니다.")
     @ApiResponse(
             responseCode = "200",

--- a/src/main/java/com/jnulocker/announce/adapter/in/docs/AnnounceApi.java
+++ b/src/main/java/com/jnulocker/announce/adapter/in/docs/AnnounceApi.java
@@ -3,7 +3,9 @@ package com.jnulocker.announce.adapter.in.docs;
 import com.jnulocker.announce.application.port.in.request.CreateAnnounceRequest;
 import com.jnulocker.announce.application.port.in.request.UpdateAnnounceRequest;
 import com.jnulocker.announce.application.port.in.response.AnnounceCustomPage;
+import com.jnulocker.announce.application.port.in.response.AnnounceDetailResponse;
 import com.jnulocker.announce.application.port.in.response.AnnouncePageable;
+import com.jnulocker.announce.application.port.in.response.MyAnnounceDetailResponse;
 import com.jnulocker.announce.application.port.in.response.MyAnnounceResponse;
 import com.jnulocker.common.swagger.ApiExceptionExamples;
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,6 +30,7 @@ public interface AnnounceApi {
     @ApiResponse(responseCode = "201", description = "공지사항 생성 성공")
     ResponseEntity<Void> createAnnounce(@Valid @RequestBody CreateAnnounceRequest request);
 
+    @ApiExceptionExamples(GetAnnouncesExceptionDocs.class)
     @Operation(summary = "공지사항 목록 조회", description = "공지사항 목록을 조회합니다. 페이지네이션이 지원됩니다.")
     @ApiResponse(
             responseCode = "200",
@@ -38,6 +41,17 @@ public interface AnnounceApi {
                             schema = @Schema(implementation = AnnounceCustomPage.class)))
     ResponseEntity<AnnounceCustomPage> getAnnounces(
             @Valid @ParameterObject AnnouncePageable announcePageable);
+
+    @ApiExceptionExamples(GetAnnounceExceptionDocs.class)
+    @Operation(summary = "공지사항 상세 조회", description = "공지사항 상세 내용을 조회합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "공지사항 상세 조회 성공",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = AnnounceDetailResponse.class)))
+    ResponseEntity<AnnounceDetailResponse> getAnnounce(@PathVariable Long announceId);
 
     @ApiExceptionExamples(GetMyAnnouncesExceptionDocs.class)
     @Operation(summary = "자신의 소속학과 대상 공지사항 목록 조회", description = "자신의 소속학과가 참여한 공지사항 목록을 조회합니다.")
@@ -54,6 +68,16 @@ public interface AnnounceApi {
                                                             implementation =
                                                                     MyAnnounceResponse.class))))
     ResponseEntity<List<MyAnnounceResponse>> getMyAnnounces();
+
+    @Operation(summary = "자신의 소속학과 대상 공지사항 상세 조회", description = "자신의 소속학과가 참여한 공지사항 상세 내용을 조회합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "자신의 소속학과 대상 공지사항 상세 내용 조회 성공",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = MyAnnounceDetailResponse.class)))
+    ResponseEntity<MyAnnounceDetailResponse> getMyAnnounce(@PathVariable Long announceId);
 
     @ApiExceptionExamples(DeleteAnnounceExceptionDocs.class)
     @Operation(summary = "공지사항 삭제", description = "공지사항을 삭제합니다.")

--- a/src/main/java/com/jnulocker/announce/adapter/in/docs/GetAnnounceExceptionDocs.java
+++ b/src/main/java/com/jnulocker/announce/adapter/in/docs/GetAnnounceExceptionDocs.java
@@ -1,0 +1,20 @@
+package com.jnulocker.announce.adapter.in.docs;
+
+import com.jnulocker.announce.exception.AnnounceNotFoundException;
+import com.jnulocker.common.exception.BusinessException;
+import com.jnulocker.common.swagger.ExceptionDoc;
+import com.jnulocker.common.swagger.ExplainError;
+import com.jnulocker.common.swagger.SwaggerExceptionDoc;
+import com.jnulocker.member.exception.MemberNotFoundException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@ExceptionDoc
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetAnnounceExceptionDocs implements SwaggerExceptionDoc {
+    @ExplainError("회원 정보를 조회할 수 없을 때 발생하는 예외입니다")
+    public static final BusinessException 회원_정보를_조회할_수_없을_때 = MemberNotFoundException.EXCEPTION;
+
+    @ExplainError("공지사항이 존재하지 않을 때 발생하는 예외입니다")
+    public static final BusinessException 공지사항이_존재하지_않을_때 = AnnounceNotFoundException.EXCEPTION;
+}

--- a/src/main/java/com/jnulocker/announce/adapter/in/docs/GetAnnouncesExceptionDocs.java
+++ b/src/main/java/com/jnulocker/announce/adapter/in/docs/GetAnnouncesExceptionDocs.java
@@ -1,0 +1,16 @@
+package com.jnulocker.announce.adapter.in.docs;
+
+import com.jnulocker.common.exception.BusinessException;
+import com.jnulocker.common.swagger.ExceptionDoc;
+import com.jnulocker.common.swagger.ExplainError;
+import com.jnulocker.common.swagger.SwaggerExceptionDoc;
+import com.jnulocker.member.exception.MemberNotFoundException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@ExceptionDoc
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetAnnouncesExceptionDocs implements SwaggerExceptionDoc {
+    @ExplainError("회원 정보를 조회할 수 없을 때 발생하는 예외입니다")
+    public static final BusinessException 회원_정보를_조회할_수_없을_때 = MemberNotFoundException.EXCEPTION;
+}

--- a/src/main/java/com/jnulocker/announce/adapter/in/docs/GetMyAnnounceExceptionDocs.java
+++ b/src/main/java/com/jnulocker/announce/adapter/in/docs/GetMyAnnounceExceptionDocs.java
@@ -1,0 +1,21 @@
+package com.jnulocker.announce.adapter.in.docs;
+
+import com.jnulocker.announce.exception.AnnounceParticipationNotFoundException;
+import com.jnulocker.common.exception.BusinessException;
+import com.jnulocker.common.swagger.ExceptionDoc;
+import com.jnulocker.common.swagger.ExplainError;
+import com.jnulocker.common.swagger.SwaggerExceptionDoc;
+import com.jnulocker.member.exception.MemberNotFoundException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@ExceptionDoc
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetMyAnnounceExceptionDocs implements SwaggerExceptionDoc {
+    @ExplainError("회원 정보를 조회할 수 없을 때 발생하는 예외입니다")
+    public static final BusinessException 회원_정보를_조회할_수_없을_때 = MemberNotFoundException.EXCEPTION;
+
+    @ExplainError("공지사항 참여 정보가 존재하지 않을 때 발생하는 예외입니다")
+    public static final BusinessException 공지사항_참여_정보가_존재하지_않을_때 =
+            AnnounceParticipationNotFoundException.EXCEPTION;
+}

--- a/src/main/java/com/jnulocker/announce/adapter/out/AnnounceParticipationRepository.java
+++ b/src/main/java/com/jnulocker/announce/adapter/out/AnnounceParticipationRepository.java
@@ -3,6 +3,7 @@ package com.jnulocker.announce.adapter.out;
 import com.jnulocker.announce.domain.Announce;
 import com.jnulocker.announce.domain.AnnounceParticipation;
 import com.jnulocker.organization.domain.Department;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,4 +15,7 @@ public interface AnnounceParticipationRepository
     @EntityGraph(attributePaths = {"announce"})
     Optional<AnnounceParticipation> findByAnnounceIdAndDepartment(
             Long announceId, Department department);
+
+    @EntityGraph(attributePaths = {"department"})
+    List<AnnounceParticipation> findAllByAnnounce(Announce announce);
 }

--- a/src/main/java/com/jnulocker/announce/adapter/out/AnnounceParticipationRepository.java
+++ b/src/main/java/com/jnulocker/announce/adapter/out/AnnounceParticipationRepository.java
@@ -2,9 +2,16 @@ package com.jnulocker.announce.adapter.out;
 
 import com.jnulocker.announce.domain.Announce;
 import com.jnulocker.announce.domain.AnnounceParticipation;
+import com.jnulocker.organization.domain.Department;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AnnounceParticipationRepository
         extends JpaRepository<AnnounceParticipation, Long> {
     void deleteAllByAnnounce(Announce announce);
+
+    @EntityGraph(attributePaths = {"announce"})
+    Optional<AnnounceParticipation> findByAnnounceIdAndDepartment(
+            Long announceId, Department department);
 }

--- a/src/main/java/com/jnulocker/announce/adapter/out/AnnouncePersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/announce/adapter/out/AnnouncePersistenceAdapter.java
@@ -50,6 +50,18 @@ public class AnnouncePersistenceAdapter implements AnnounceRecordPort, AnnounceL
     }
 
     @Override
+    public Optional<Announce> getByIdAndDepartment(Long announceId, Department department) {
+        return announceRepository.findByIdAndDepartment(announceId, department);
+    }
+
+    @Override
+    public Optional<AnnounceParticipation> getByAnnounceIdAndDepartment(
+            Long announceId, Department department) {
+        return announceParticipationRepository.findByAnnounceIdAndDepartment(
+                announceId, department);
+    }
+
+    @Override
     public void deleteAnnounceParticipationsByAnnounce(Announce announce) {
         announceParticipationRepository.deleteAllByAnnounce(announce);
     }

--- a/src/main/java/com/jnulocker/announce/adapter/out/AnnouncePersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/announce/adapter/out/AnnouncePersistenceAdapter.java
@@ -34,8 +34,9 @@ public class AnnouncePersistenceAdapter implements AnnounceRecordPort, AnnounceL
     }
 
     @Override
-    public List<Announce> getAnnouncesByParticipationDepartment(Department department) {
-        return announceRepository.findAllByAnnounceParticipations_Department(department);
+    public Page<Announce> getAnnouncesByParticipationDepartment(
+            Department department, Pageable pageable) {
+        return announceRepository.findAllByAnnounceParticipations_Department(department, pageable);
     }
 
     @Override

--- a/src/main/java/com/jnulocker/announce/adapter/out/AnnouncePersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/announce/adapter/out/AnnouncePersistenceAdapter.java
@@ -29,7 +29,7 @@ public class AnnouncePersistenceAdapter implements AnnounceRecordPort, AnnounceL
     }
 
     @Override
-    public Page<Announce> getAllAnnouncesByDepartment(Department department, Pageable pageable) {
+    public Page<Announce> getAnnouncesByDepartment(Department department, Pageable pageable) {
         return announceRepository.findAllByDepartment(department, pageable);
     }
 

--- a/src/main/java/com/jnulocker/announce/adapter/out/AnnouncePersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/announce/adapter/out/AnnouncePersistenceAdapter.java
@@ -66,4 +66,11 @@ public class AnnouncePersistenceAdapter implements AnnounceRecordPort, AnnounceL
     public void deleteAnnounceParticipationsByAnnounce(Announce announce) {
         announceParticipationRepository.deleteAllByAnnounce(announce);
     }
+
+    @Override
+    public List<Department> getParticipationDepartments(Announce announce) {
+        return announceParticipationRepository.findAllByAnnounce(announce).stream()
+                .map(AnnounceParticipation::getDepartment)
+                .toList();
+    }
 }

--- a/src/main/java/com/jnulocker/announce/adapter/out/AnnounceRepository.java
+++ b/src/main/java/com/jnulocker/announce/adapter/out/AnnounceRepository.java
@@ -2,7 +2,6 @@ package com.jnulocker.announce.adapter.out;
 
 import com.jnulocker.announce.domain.Announce;
 import com.jnulocker.organization.domain.Department;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -14,7 +13,8 @@ public interface AnnounceRepository extends JpaRepository<Announce, Long> {
     Page<Announce> findAllByDepartment(Department department, Pageable pageable);
 
     @EntityGraph(attributePaths = {"department"})
-    List<Announce> findAllByAnnounceParticipations_Department(Department department);
+    Page<Announce> findAllByAnnounceParticipations_Department(
+            Department department, Pageable pageable);
 
     Optional<Announce> findByIdAndDepartment(Long announceId, Department department);
 }

--- a/src/main/java/com/jnulocker/announce/adapter/out/AnnounceRepository.java
+++ b/src/main/java/com/jnulocker/announce/adapter/out/AnnounceRepository.java
@@ -3,6 +3,7 @@ package com.jnulocker.announce.adapter.out;
 import com.jnulocker.announce.domain.Announce;
 import com.jnulocker.organization.domain.Department;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -14,4 +15,6 @@ public interface AnnounceRepository extends JpaRepository<Announce, Long> {
 
     @EntityGraph(attributePaths = {"department"})
     List<Announce> findAllByAnnounceParticipations_Department(Department department);
+
+    Optional<Announce> findByIdAndDepartment(Long announceId, Department department);
 }

--- a/src/main/java/com/jnulocker/announce/application/port/in/AnnounceQuery.java
+++ b/src/main/java/com/jnulocker/announce/application/port/in/AnnounceQuery.java
@@ -1,8 +1,12 @@
 package com.jnulocker.announce.application.port.in;
 
 import com.jnulocker.announce.application.port.in.response.AnnounceCustomPage;
+import com.jnulocker.announce.application.port.in.response.AnnounceDetailResponse;
+import com.jnulocker.announce.application.port.in.response.MyAnnounceDetailResponse;
 import com.jnulocker.announce.application.port.in.response.MyAnnounceResponse;
 import com.jnulocker.announce.domain.Announce;
+import com.jnulocker.announce.domain.AnnounceParticipation;
+import com.jnulocker.organization.domain.Department;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 
@@ -13,4 +17,13 @@ public interface AnnounceQuery {
     List<MyAnnounceResponse> getMyAnnounces();
 
     Announce getByIdOrThrow(Long announceId);
+
+    AnnounceDetailResponse getAnnounce(Long announceId);
+
+    MyAnnounceDetailResponse getMyAnnounce(Long announceId);
+
+    Announce getByIdAndDepartmentOrThrow(Long announceId, Department department);
+
+    AnnounceParticipation getByAnnounceIdAndDepartmentOrThrow(
+            Long announceId, Department department);
 }

--- a/src/main/java/com/jnulocker/announce/application/port/in/AnnounceQuery.java
+++ b/src/main/java/com/jnulocker/announce/application/port/in/AnnounceQuery.java
@@ -11,7 +11,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface AnnounceQuery {
 
-    AnnounceCustomPage getAllAnnounces(Pageable pageable);
+    AnnounceCustomPage getAnnounces(Pageable pageable);
 
     MyAnnounceCustomPage getMyAnnounces(Pageable pageable);
 

--- a/src/main/java/com/jnulocker/announce/application/port/in/AnnounceQuery.java
+++ b/src/main/java/com/jnulocker/announce/application/port/in/AnnounceQuery.java
@@ -2,19 +2,18 @@ package com.jnulocker.announce.application.port.in;
 
 import com.jnulocker.announce.application.port.in.response.AnnounceCustomPage;
 import com.jnulocker.announce.application.port.in.response.AnnounceDetailResponse;
+import com.jnulocker.announce.application.port.in.response.MyAnnounceCustomPage;
 import com.jnulocker.announce.application.port.in.response.MyAnnounceDetailResponse;
-import com.jnulocker.announce.application.port.in.response.MyAnnounceResponse;
 import com.jnulocker.announce.domain.Announce;
 import com.jnulocker.announce.domain.AnnounceParticipation;
 import com.jnulocker.organization.domain.Department;
-import java.util.List;
 import org.springframework.data.domain.Pageable;
 
 public interface AnnounceQuery {
 
     AnnounceCustomPage getAllAnnounces(Pageable pageable);
 
-    List<MyAnnounceResponse> getMyAnnounces();
+    MyAnnounceCustomPage getMyAnnounces(Pageable pageable);
 
     Announce getByIdOrThrow(Long announceId);
 

--- a/src/main/java/com/jnulocker/announce/application/port/in/response/AnnounceDetailResponse.java
+++ b/src/main/java/com/jnulocker/announce/application/port/in/response/AnnounceDetailResponse.java
@@ -1,8 +1,10 @@
 package com.jnulocker.announce.application.port.in.response;
 
 import com.jnulocker.announce.domain.Announce;
+import com.jnulocker.organization.domain.Department;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record AnnounceDetailResponse(
         @Schema(description = "공지사항 ID", example = "1") Long id,
@@ -10,14 +12,18 @@ public record AnnounceDetailResponse(
         @Schema(description = "공지사항 내용", example = "공지사항 내용입니다.") String content,
         @Schema(description = "공지사항 작성자", example = "도서관자치위원회 백문이불여일견") String writer,
         @Schema(description = "등록 일자", example = "2025-08-01T15:00:00") LocalDateTime createdAt,
-        @Schema(description = "수정 일자", example = "2025-08-10T15:00:00") LocalDateTime updatedAt) {
-    public static AnnounceDetailResponse from(Announce announce) {
+        @Schema(description = "수정 일자", example = "2025-08-10T15:00:00") LocalDateTime updatedAt,
+        @Schema(description = "참여 학과 목록") List<DepartmentResponse> departments) {
+    public static AnnounceDetailResponse from(Announce announce, List<Department> departments) {
+        List<DepartmentResponse> departmentResponses =
+                departments.stream().map(DepartmentResponse::from).toList();
         return new AnnounceDetailResponse(
                 announce.getId(),
                 announce.getTitle(),
                 announce.getContent(),
                 announce.getWriter(),
                 announce.getCreatedAt(),
-                announce.getUpdatedAt());
+                announce.getUpdatedAt(),
+                departmentResponses);
     }
 }

--- a/src/main/java/com/jnulocker/announce/application/port/in/response/AnnounceDetailResponse.java
+++ b/src/main/java/com/jnulocker/announce/application/port/in/response/AnnounceDetailResponse.java
@@ -1,0 +1,23 @@
+package com.jnulocker.announce.application.port.in.response;
+
+import com.jnulocker.announce.domain.Announce;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+public record AnnounceDetailResponse(
+        @Schema(description = "공지사항 ID", example = "1") Long id,
+        @Schema(description = "공지사항 제목", example = "백도 사물함 신청 안내") String title,
+        @Schema(description = "공지사항 내용", example = "공지사항 내용입니다.") String content,
+        @Schema(description = "공지사항 작성자", example = "도서관자치위원회 백문이불여일견") String writer,
+        @Schema(description = "등록 일자", example = "2025-08-01T15:00:00") LocalDateTime createdAt,
+        @Schema(description = "수정 일자", example = "2025-08-10T15:00:00") LocalDateTime updatedAt) {
+    public static AnnounceDetailResponse from(Announce announce) {
+        return new AnnounceDetailResponse(
+                announce.getId(),
+                announce.getTitle(),
+                announce.getContent(),
+                announce.getWriter(),
+                announce.getCreatedAt(),
+                announce.getUpdatedAt());
+    }
+}

--- a/src/main/java/com/jnulocker/announce/application/port/in/response/AnnounceDetailResponse.java
+++ b/src/main/java/com/jnulocker/announce/application/port/in/response/AnnounceDetailResponse.java
@@ -14,7 +14,7 @@ public record AnnounceDetailResponse(
         @Schema(description = "등록 일자", example = "2025-08-01T15:00:00") LocalDateTime createdAt,
         @Schema(description = "수정 일자", example = "2025-08-10T15:00:00") LocalDateTime updatedAt,
         @Schema(description = "참여 학과 목록") List<DepartmentResponse> departments) {
-    public static AnnounceDetailResponse from(Announce announce, List<Department> departments) {
+    public static AnnounceDetailResponse of(Announce announce, List<Department> departments) {
         List<DepartmentResponse> departmentResponses =
                 departments.stream().map(DepartmentResponse::from).toList();
         return new AnnounceDetailResponse(

--- a/src/main/java/com/jnulocker/announce/application/port/in/response/AnnounceListItem.java
+++ b/src/main/java/com/jnulocker/announce/application/port/in/response/AnnounceListItem.java
@@ -7,7 +7,6 @@ import java.time.LocalDateTime;
 public record AnnounceListItem(
         @Schema(description = "공지사항 ID", example = "1") Long id,
         @Schema(description = "공지사항 제목", example = "백도 사물함 신청 안내") String title,
-        @Schema(description = "공지사항 내용", example = "공지사항 내용입니다.") String content,
         @Schema(description = "공지사항 작성자", example = "도서관자치위원회 백문이불여일견") String writer,
         @Schema(description = "등록 일자", example = "2025-08-01T15:00:00") LocalDateTime createdAt) {
     public static AnnounceListItem from(Announce announce) {
@@ -15,7 +14,6 @@ public record AnnounceListItem(
                 announce.getId(),
                 announce.getTitle(),
                 announce.getContent(),
-                announce.getWriter(),
                 announce.getCreatedAt());
     }
 }

--- a/src/main/java/com/jnulocker/announce/application/port/in/response/DepartmentResponse.java
+++ b/src/main/java/com/jnulocker/announce/application/port/in/response/DepartmentResponse.java
@@ -1,0 +1,12 @@
+package com.jnulocker.announce.application.port.in.response;
+
+import com.jnulocker.organization.domain.Department;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record DepartmentResponse(
+        @Schema(description = "학과 ID", example = "101") Long id,
+        @Schema(description = "학과 이름", example = "컴퓨터정보통신공학과") String name) {
+    public static DepartmentResponse from(Department department) {
+        return new DepartmentResponse(department.getId(), department.getName());
+    }
+}

--- a/src/main/java/com/jnulocker/announce/application/port/in/response/MyAnnounceCustomPage.java
+++ b/src/main/java/com/jnulocker/announce/application/port/in/response/MyAnnounceCustomPage.java
@@ -1,0 +1,18 @@
+package com.jnulocker.announce.application.port.in.response;
+
+import com.jnulocker.announce.domain.Announce;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record MyAnnounceCustomPage(
+        @Schema(description = "공지사항 목록") List<AnnounceListItem> content,
+        @Schema(description = "공지사항 전체 개수", example = "10") Long totalElements,
+        @Schema(description = "마지막 페이지 여부", example = "false") Boolean last) {
+    public static MyAnnounceCustomPage from(Page<Announce> announces) {
+        return new MyAnnounceCustomPage(
+                announces.getContent().stream().map(AnnounceListItem::from).toList(),
+                announces.getTotalElements(),
+                announces.isLast());
+    }
+}

--- a/src/main/java/com/jnulocker/announce/application/port/in/response/MyAnnounceDetailResponse.java
+++ b/src/main/java/com/jnulocker/announce/application/port/in/response/MyAnnounceDetailResponse.java
@@ -10,7 +10,7 @@ public record MyAnnounceDetailResponse(
         @Schema(description = "공지사항 내용", example = "공지사항 내용입니다.") String content,
         @Schema(description = "공지사항 작성자", example = "도서관자치위원회 백문이불여일견") String writer,
         @Schema(description = "등록 일자", example = "2025-08-01T15:00:00") LocalDateTime createdAt,
-        @Schema(description = "수정 일자", example = "2025-08-10T15:00:00") LocalDateTime updateAt) {
+        @Schema(description = "수정 일자", example = "2025-08-10T15:00:00") LocalDateTime updatedAt) {
     public static MyAnnounceDetailResponse from(Announce announce) {
         return new MyAnnounceDetailResponse(
                 announce.getId(),

--- a/src/main/java/com/jnulocker/announce/application/port/in/response/MyAnnounceDetailResponse.java
+++ b/src/main/java/com/jnulocker/announce/application/port/in/response/MyAnnounceDetailResponse.java
@@ -1,0 +1,23 @@
+package com.jnulocker.announce.application.port.in.response;
+
+import com.jnulocker.announce.domain.Announce;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+public record MyAnnounceDetailResponse(
+        @Schema(description = "공지사항 ID", example = "1") Long id,
+        @Schema(description = "공지사항 제목", example = "백도 사물함 신청 안내") String title,
+        @Schema(description = "공지사항 내용", example = "공지사항 내용입니다.") String content,
+        @Schema(description = "공지사항 작성자", example = "도서관자치위원회 백문이불여일견") String writer,
+        @Schema(description = "등록 일자", example = "2025-08-01T15:00:00") LocalDateTime createdAt,
+        @Schema(description = "수정 일자", example = "2025-08-10T15:00:00") LocalDateTime updateAt) {
+    public static MyAnnounceDetailResponse from(Announce announce) {
+        return new MyAnnounceDetailResponse(
+                announce.getId(),
+                announce.getTitle(),
+                announce.getContent(),
+                announce.getWriter(),
+                announce.getCreatedAt(),
+                announce.getCreatedAt());
+    }
+}

--- a/src/main/java/com/jnulocker/announce/application/port/in/response/MyAnnounceDetailResponse.java
+++ b/src/main/java/com/jnulocker/announce/application/port/in/response/MyAnnounceDetailResponse.java
@@ -18,6 +18,6 @@ public record MyAnnounceDetailResponse(
                 announce.getContent(),
                 announce.getWriter(),
                 announce.getCreatedAt(),
-                announce.getCreatedAt());
+                announce.getUpdatedAt());
     }
 }

--- a/src/main/java/com/jnulocker/announce/application/port/out/AnnounceLoadPort.java
+++ b/src/main/java/com/jnulocker/announce/application/port/out/AnnounceLoadPort.java
@@ -1,6 +1,7 @@
 package com.jnulocker.announce.application.port.out;
 
 import com.jnulocker.announce.domain.Announce;
+import com.jnulocker.announce.domain.AnnounceParticipation;
 import com.jnulocker.organization.domain.Department;
 import java.util.List;
 import java.util.Optional;
@@ -14,4 +15,9 @@ public interface AnnounceLoadPort {
     List<Announce> getAnnouncesByParticipationDepartment(Department department);
 
     Optional<Announce> getById(Long announceId);
+
+    Optional<Announce> getByIdAndDepartment(Long announceId, Department department);
+
+    Optional<AnnounceParticipation> getByAnnounceIdAndDepartment(
+            Long announceId, Department department);
 }

--- a/src/main/java/com/jnulocker/announce/application/port/out/AnnounceLoadPort.java
+++ b/src/main/java/com/jnulocker/announce/application/port/out/AnnounceLoadPort.java
@@ -10,7 +10,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface AnnounceLoadPort {
 
-    Page<Announce> getAllAnnouncesByDepartment(Department department, Pageable pageable);
+    Page<Announce> getAnnouncesByDepartment(Department department, Pageable pageable);
 
     Page<Announce> getAnnouncesByParticipationDepartment(Department department, Pageable pageable);
 

--- a/src/main/java/com/jnulocker/announce/application/port/out/AnnounceLoadPort.java
+++ b/src/main/java/com/jnulocker/announce/application/port/out/AnnounceLoadPort.java
@@ -3,6 +3,7 @@ package com.jnulocker.announce.application.port.out;
 import com.jnulocker.announce.domain.Announce;
 import com.jnulocker.announce.domain.AnnounceParticipation;
 import com.jnulocker.organization.domain.Department;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -19,4 +20,6 @@ public interface AnnounceLoadPort {
 
     Optional<AnnounceParticipation> getByAnnounceIdAndDepartment(
             Long announceId, Department department);
+
+    List<Department> getParticipationDepartments(Announce announce);
 }

--- a/src/main/java/com/jnulocker/announce/application/port/out/AnnounceLoadPort.java
+++ b/src/main/java/com/jnulocker/announce/application/port/out/AnnounceLoadPort.java
@@ -3,7 +3,6 @@ package com.jnulocker.announce.application.port.out;
 import com.jnulocker.announce.domain.Announce;
 import com.jnulocker.announce.domain.AnnounceParticipation;
 import com.jnulocker.organization.domain.Department;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,7 +11,7 @@ public interface AnnounceLoadPort {
 
     Page<Announce> getAllAnnouncesByDepartment(Department department, Pageable pageable);
 
-    List<Announce> getAnnouncesByParticipationDepartment(Department department);
+    Page<Announce> getAnnouncesByParticipationDepartment(Department department, Pageable pageable);
 
     Optional<Announce> getById(Long announceId);
 

--- a/src/main/java/com/jnulocker/announce/application/service/AnnounceQueryService.java
+++ b/src/main/java/com/jnulocker/announce/application/service/AnnounceQueryService.java
@@ -86,7 +86,7 @@ public class AnnounceQueryService implements AnnounceQuery {
         List<Department> participatingDepartments =
                 announceLoadPort.getParticipationDepartments(announce);
 
-        return AnnounceDetailResponse.from(announce, participatingDepartments);
+        return AnnounceDetailResponse.of(announce, participatingDepartments);
     }
 
     @Override

--- a/src/main/java/com/jnulocker/announce/application/service/AnnounceQueryService.java
+++ b/src/main/java/com/jnulocker/announce/application/service/AnnounceQueryService.java
@@ -14,6 +14,7 @@ import com.jnulocker.auth.security.SecurityUtils;
 import com.jnulocker.member.application.port.in.MemberQuery;
 import com.jnulocker.member.domain.Member;
 import com.jnulocker.organization.domain.Department;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -80,7 +81,12 @@ public class AnnounceQueryService implements AnnounceQuery {
 
         // Member가 주관하는 공지사항 조회
         Announce announce = getByIdAndDepartmentOrThrow(announceId, member.getDepartment());
-        return AnnounceDetailResponse.from(announce);
+
+        // 공지사항에 참여하는 소속학과 조회
+        List<Department> participatingDepartments =
+                announceLoadPort.getParticipationDepartments(announce);
+
+        return AnnounceDetailResponse.from(announce, participatingDepartments);
     }
 
     @Override

--- a/src/main/java/com/jnulocker/announce/application/service/AnnounceQueryService.java
+++ b/src/main/java/com/jnulocker/announce/application/service/AnnounceQueryService.java
@@ -3,8 +3,8 @@ package com.jnulocker.announce.application.service;
 import com.jnulocker.announce.application.port.in.AnnounceQuery;
 import com.jnulocker.announce.application.port.in.response.AnnounceCustomPage;
 import com.jnulocker.announce.application.port.in.response.AnnounceDetailResponse;
+import com.jnulocker.announce.application.port.in.response.MyAnnounceCustomPage;
 import com.jnulocker.announce.application.port.in.response.MyAnnounceDetailResponse;
-import com.jnulocker.announce.application.port.in.response.MyAnnounceResponse;
 import com.jnulocker.announce.application.port.out.AnnounceLoadPort;
 import com.jnulocker.announce.domain.Announce;
 import com.jnulocker.announce.domain.AnnounceParticipation;
@@ -14,11 +14,11 @@ import com.jnulocker.auth.security.SecurityUtils;
 import com.jnulocker.member.application.port.in.MemberQuery;
 import com.jnulocker.member.domain.Member;
 import com.jnulocker.organization.domain.Department;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -38,15 +38,17 @@ public class AnnounceQueryService implements AnnounceQuery {
     }
 
     @Override
-    public List<MyAnnounceResponse> getMyAnnounces() {
+    @Transactional
+    public MyAnnounceCustomPage getMyAnnounces(Pageable pageable) {
         Long memberId = SecurityUtils.getCurrentMemberId();
-        Member member = memberQuery.findByIdOrThrow(memberId);
+        Member member = memberQuery.findByIdWithDepartmentOrThrow(memberId);
 
         // 사용자의 소속학과가 참여하는 공지사항 조회
-        List<Announce> announces =
-                announceLoadPort.getAnnouncesByParticipationDepartment(member.getDepartment());
+        Page<Announce> announces =
+                announceLoadPort.getAnnouncesByParticipationDepartment(
+                        member.getDepartment(), pageable);
 
-        return announces.stream().map(MyAnnounceResponse::from).toList();
+        return MyAnnounceCustomPage.from(announces);
     }
 
     @Override

--- a/src/main/java/com/jnulocker/announce/application/service/AnnounceQueryService.java
+++ b/src/main/java/com/jnulocker/announce/application/service/AnnounceQueryService.java
@@ -28,12 +28,12 @@ public class AnnounceQueryService implements AnnounceQuery {
     private final AnnounceLoadPort announceLoadPort;
 
     @Override
-    public AnnounceCustomPage getAllAnnounces(Pageable pageable) {
+    public AnnounceCustomPage getAnnounces(Pageable pageable) {
         Long memberId = SecurityUtils.getCurrentMemberId();
         Member member = memberQuery.findByIdWithDepartmentOrThrow(memberId);
 
         Page<Announce> announces =
-                announceLoadPort.getAllAnnouncesByDepartment(member.getDepartment(), pageable);
+                announceLoadPort.getAnnouncesByDepartment(member.getDepartment(), pageable);
         return AnnounceCustomPage.from(announces);
     }
 

--- a/src/main/java/com/jnulocker/announce/application/service/AnnounceQueryService.java
+++ b/src/main/java/com/jnulocker/announce/application/service/AnnounceQueryService.java
@@ -19,7 +19,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -39,7 +38,6 @@ public class AnnounceQueryService implements AnnounceQuery {
     }
 
     @Override
-    @Transactional
     public MyAnnounceCustomPage getMyAnnounces(Pageable pageable) {
         Long memberId = SecurityUtils.getCurrentMemberId();
         Member member = memberQuery.findByIdWithDepartmentOrThrow(memberId);

--- a/src/main/java/com/jnulocker/announce/application/service/AnnounceQueryService.java
+++ b/src/main/java/com/jnulocker/announce/application/service/AnnounceQueryService.java
@@ -2,13 +2,18 @@ package com.jnulocker.announce.application.service;
 
 import com.jnulocker.announce.application.port.in.AnnounceQuery;
 import com.jnulocker.announce.application.port.in.response.AnnounceCustomPage;
+import com.jnulocker.announce.application.port.in.response.AnnounceDetailResponse;
+import com.jnulocker.announce.application.port.in.response.MyAnnounceDetailResponse;
 import com.jnulocker.announce.application.port.in.response.MyAnnounceResponse;
 import com.jnulocker.announce.application.port.out.AnnounceLoadPort;
 import com.jnulocker.announce.domain.Announce;
+import com.jnulocker.announce.domain.AnnounceParticipation;
 import com.jnulocker.announce.exception.AnnounceNotFoundException;
+import com.jnulocker.announce.exception.AnnounceParticipationNotFoundException;
 import com.jnulocker.auth.security.SecurityUtils;
 import com.jnulocker.member.application.port.in.MemberQuery;
 import com.jnulocker.member.domain.Member;
+import com.jnulocker.organization.domain.Department;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -49,5 +54,42 @@ public class AnnounceQueryService implements AnnounceQuery {
         return announceLoadPort
                 .getById(announceId)
                 .orElseThrow(() -> AnnounceNotFoundException.EXCEPTION);
+    }
+
+    @Override
+    public Announce getByIdAndDepartmentOrThrow(Long announceId, Department department) {
+        return announceLoadPort
+                .getByIdAndDepartment(announceId, department)
+                .orElseThrow(() -> AnnounceNotFoundException.EXCEPTION);
+    }
+
+    @Override
+    public AnnounceParticipation getByAnnounceIdAndDepartmentOrThrow(
+            Long announceId, Department department) {
+        return announceLoadPort
+                .getByAnnounceIdAndDepartment(announceId, department)
+                .orElseThrow(() -> AnnounceParticipationNotFoundException.EXCEPTION);
+    }
+
+    @Override
+    public AnnounceDetailResponse getAnnounce(Long announceId) {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        Member member = memberQuery.findByIdOrThrow(memberId);
+
+        // Member가 주관하는 공지사항 조회
+        Announce announce = getByIdAndDepartmentOrThrow(announceId, member.getDepartment());
+        return AnnounceDetailResponse.from(announce);
+    }
+
+    @Override
+    public MyAnnounceDetailResponse getMyAnnounce(Long announceId) {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        Member member = memberQuery.findByIdOrThrow(memberId);
+
+        // Member가 참여하는 공지사항 조회
+        AnnounceParticipation announceParticipation =
+                getByAnnounceIdAndDepartmentOrThrow(announceId, member.getDepartment());
+
+        return MyAnnounceDetailResponse.from(announceParticipation.getAnnounce());
     }
 }

--- a/src/main/java/com/jnulocker/announce/exception/AnnounceErrorCode.java
+++ b/src/main/java/com/jnulocker/announce/exception/AnnounceErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum AnnounceErrorCode implements ErrorCode {
     ANNOUNCE_NOT_FOUND("AN001", HttpStatus.NOT_FOUND, "공지사항이 존재하지 않습니다."),
     ONLY_MANAGER_CAN_DELETE_ANNOUNCE("AN002", HttpStatus.FORBIDDEN, "공지사항 관리자만 삭제할 수 있습니다."),
+    ANNOUNCE_PARTICIPATION_NOT_FOUND("AN002", HttpStatus.NOT_FOUND, "공지사항 참여 정보가 존재하지 않습니다."),
     ONLY_MANAGER_CAN_UPDATE_ANNOUNCE("AN003", HttpStatus.FORBIDDEN, "공지사항 관리자만 수정할 수 있습니다."),
     ;
 

--- a/src/main/java/com/jnulocker/announce/exception/AnnounceErrorCode.java
+++ b/src/main/java/com/jnulocker/announce/exception/AnnounceErrorCode.java
@@ -10,8 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum AnnounceErrorCode implements ErrorCode {
     ANNOUNCE_NOT_FOUND("AN001", HttpStatus.NOT_FOUND, "공지사항이 존재하지 않습니다."),
     ONLY_MANAGER_CAN_DELETE_ANNOUNCE("AN002", HttpStatus.FORBIDDEN, "공지사항 관리자만 삭제할 수 있습니다."),
-    ANNOUNCE_PARTICIPATION_NOT_FOUND("AN002", HttpStatus.NOT_FOUND, "공지사항 참여 정보가 존재하지 않습니다."),
-    ONLY_MANAGER_CAN_UPDATE_ANNOUNCE("AN003", HttpStatus.FORBIDDEN, "공지사항 관리자만 수정할 수 있습니다."),
+    ANNOUNCE_PARTICIPATION_NOT_FOUND("AN003", HttpStatus.NOT_FOUND, "공지사항 참여 정보가 존재하지 않습니다."),
+    ONLY_MANAGER_CAN_UPDATE_ANNOUNCE("AN004", HttpStatus.FORBIDDEN, "공지사항 관리자만 수정할 수 있습니다."),
     ;
 
     private final String code;

--- a/src/main/java/com/jnulocker/announce/exception/AnnounceParticipationNotFoundException.java
+++ b/src/main/java/com/jnulocker/announce/exception/AnnounceParticipationNotFoundException.java
@@ -1,0 +1,11 @@
+package com.jnulocker.announce.exception;
+
+import com.jnulocker.common.exception.BusinessException;
+
+public class AnnounceParticipationNotFoundException extends BusinessException {
+    public static final BusinessException EXCEPTION = new AnnounceParticipationNotFoundException();
+
+    private AnnounceParticipationNotFoundException() {
+        super(AnnounceErrorCode.ANNOUNCE_PARTICIPATION_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/jnulocker/config/SecurityConfig.java
+++ b/src/main/java/com/jnulocker/config/SecurityConfig.java
@@ -89,11 +89,11 @@ public class SecurityConfig {
                                 .hasAuthority(Role.MANAGER.getRole())
                                 .requestMatchers(HttpMethod.POST, "/v1/announces")
                                 .hasAuthority(Role.MANAGER.getRole())
-                                .requestMatchers(HttpMethod.GET, "/v1/announces", "/v1/announces/*")
-                                .hasAuthority(Role.MANAGER.getRole())
                                 .requestMatchers(
                                         HttpMethod.GET, "/v1/announces/me", "/v1/announces/me/*")
                                 .hasAuthority(Role.USER.getRole())
+                                .requestMatchers(HttpMethod.GET, "/v1/announces", "/v1/announces/*")
+                                .hasAuthority(Role.MANAGER.getRole())
                                 .requestMatchers(HttpMethod.DELETE, "/v1/announces/*")
                                 .hasAuthority(Role.MANAGER.getRole())
                                 .requestMatchers(HttpMethod.PUT, "/v1/announces/*")

--- a/src/main/java/com/jnulocker/config/SecurityConfig.java
+++ b/src/main/java/com/jnulocker/config/SecurityConfig.java
@@ -89,9 +89,10 @@ public class SecurityConfig {
                                 .hasAuthority(Role.MANAGER.getRole())
                                 .requestMatchers(HttpMethod.POST, "/v1/announces")
                                 .hasAuthority(Role.MANAGER.getRole())
-                                .requestMatchers(HttpMethod.GET, "/v1/announces")
+                                .requestMatchers(HttpMethod.GET, "/v1/announces", "/v1/announces/*")
                                 .hasAuthority(Role.MANAGER.getRole())
-                                .requestMatchers(HttpMethod.GET, "/v1/announces/me")
+                                .requestMatchers(
+                                        HttpMethod.GET, "/v1/announces/me", "/v1/announces/me/*")
                                 .hasAuthority(Role.USER.getRole())
                                 .requestMatchers(HttpMethod.DELETE, "/v1/announces/*")
                                 .hasAuthority(Role.MANAGER.getRole())

--- a/src/test/java/com/jnulocker/announce/adapter/in/AnnounceControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/announce/adapter/in/AnnounceControllerIntegrationTest.java
@@ -386,7 +386,7 @@ public class AnnounceControllerIntegrationTest {
         assertThat(response.title()).isEqualTo(request.title());
         assertThat(response.content()).isEqualTo(request.content());
         assertThat(response.createdAt()).isNotNull();
-        assertThat(response.updateAt()).isNotNull();
+        assertThat(response.updatedAt()).isNotNull();
     }
 
     @Test

--- a/src/test/java/com/jnulocker/announce/adapter/in/AnnounceControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/announce/adapter/in/AnnounceControllerIntegrationTest.java
@@ -8,7 +8,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.jnulocker.announce.application.port.in.request.CreateAnnounceRequest;
 import com.jnulocker.announce.application.port.in.request.UpdateAnnounceRequest;
 import com.jnulocker.announce.application.port.in.response.AnnounceCustomPage;
-import com.jnulocker.announce.application.port.in.response.MyAnnounceResponse;
+import com.jnulocker.announce.application.port.in.response.AnnounceDetailResponse;
+import com.jnulocker.announce.application.port.in.response.MyAnnounceCustomPage;
+import com.jnulocker.announce.application.port.in.response.MyAnnounceDetailResponse;
 import com.jnulocker.announce.exception.AnnounceErrorCode;
 import com.jnulocker.announce.utils.AnnounceTestUtil;
 import com.jnulocker.auth.utils.AuthTestUtil;
@@ -122,31 +124,45 @@ public class AnnounceControllerIntegrationTest {
         assertThat(announceCustomPage.last()).isEqualTo(expectedLast);
     }
 
-    @Test
-    void 자신이_속한_학과가_참여하는_공지사항을_조회할_수_있다() {
+    // 공지사항 목록 조회 테스트
+    @ParameterizedTest(name = "[{index}] 조회[총: {0}, 크기: {1}, 페이지: {2}] -> 마지막: {3}")
+    @CsvSource({
+        "10, 5, 0, false", // 10개 생성, 5개씩, 0페이지(1~5), 마지막 아님
+        "10, 5, 1, true", // 10개 생성, 5개씩, 1페이지(6~10), 마지막
+        "8, 3, 0, false", // 8개 생성, 3개씩, 0페이지(1~3), 마지막 아님
+        "8, 3, 2, true", // 8개 생성, 3개씩, 2페이지(7~8), 마지막
+        "5, 10, 0, true" // 5개 생성, 10개씩, 0페이지(1~5), 마지막
+    })
+    void 자신이_속한_학과가_참여하는_공지사항을_조회할_수_있다(
+            int createCount, int pageSize, int page, boolean expectedLast) {
         // given
         Department department = organizationTestUtil.createCouncilDepartment();
         Member member = memberTestUtil.createMemberFromRoleWithDepartment(Role.USER, department);
 
         // 공지사항 생성
-        announceTestUtil.createAnnounceWithParticipationDepartment(department);
-
+        for (int i = 0; i < createCount; i++) {
+            announceTestUtil.createAnnounceWithParticipationDepartment(department);
+        }
         // when
         accessToken = authTestUtil.generateAccessTokenWithMember(member);
-        List<MyAnnounceResponse> myAnnounces =
-                getMyAnnounces(accessToken)
+        MyAnnounceCustomPage myAnnounceCustomPage =
+                getMyAnnounces(page, pageSize, accessToken)
                         .statusCode(HttpStatus.OK.value())
                         .extract()
-                        .jsonPath()
-                        .getList(".", MyAnnounceResponse.class);
+                        .as(MyAnnounceCustomPage.class);
 
         // then
-        assertThat(myAnnounces).hasSize(1);
+        int expectedSize = calculateExpectedSize(createCount, pageSize, page);
+        assertThat(myAnnounceCustomPage.content()).hasSize(expectedSize);
+        assertThat(myAnnounceCustomPage.totalElements()).isEqualTo(createCount);
+        assertThat(myAnnounceCustomPage.last()).isEqualTo(expectedLast);
     }
 
     @Test
     void 자신의_소속학과가_주관하지_않는_공지사항은_조회할_수_없다() {
         // given
+        int pageSize = 10;
+        int page = 0;
         Department department = organizationTestUtil.createCouncilDepartment();
         Member member = memberTestUtil.createMemberFromRoleWithDepartment(Role.USER, department);
         accessToken = authTestUtil.generateAccessTokenWithMember(member);
@@ -155,15 +171,14 @@ public class AnnounceControllerIntegrationTest {
         announceTestUtil.createAnnounce();
 
         // when
-        List<MyAnnounceResponse> myAnnounces =
-                getMyAnnounces(accessToken)
+        MyAnnounceCustomPage myAnnounces =
+                getMyAnnounces(page, pageSize, accessToken)
                         .statusCode(HttpStatus.OK.value())
                         .extract()
-                        .jsonPath()
-                        .getList(".", MyAnnounceResponse.class);
+                        .as(MyAnnounceCustomPage.class);
 
         // then
-        assertThat(myAnnounces).isEmpty();
+        assertThat(myAnnounces.content()).isEmpty();
     }
 
     @Test
@@ -178,15 +193,15 @@ public class AnnounceControllerIntegrationTest {
         deleteAnnounce(announceId).statusCode(HttpStatus.NO_CONTENT.value());
 
         // then
-        // 삭제된 공지사항이 더 이상 조회되지 않는지 확인
-        AnnounceCustomPage announceCustomPage =
-                getAnnounces(0, 10, accessToken)
-                        .statusCode(HttpStatus.OK.value())
+        // 삭제된 공지사항 조회 시 예외 발생
+        ErrorResponse errorResponse =
+                getAnnounce(announceId, accessToken)
+                        .statusCode(AnnounceErrorCode.ANNOUNCE_NOT_FOUND.getHttpStatus().value())
                         .extract()
-                        .as(AnnounceCustomPage.class);
+                        .as(ErrorResponse.class);
 
-        assertThat(announceCustomPage.content())
-                .noneMatch(announce -> announce.id().equals(announceId));
+        assertThat(errorResponse.message())
+                .isEqualTo(AnnounceErrorCode.ANNOUNCE_NOT_FOUND.getMessage());
     }
 
     @Test
@@ -249,7 +264,7 @@ public class AnnounceControllerIntegrationTest {
                         .build();
 
         // when
-        updateAnnounce(announceId, request).statusCode(HttpStatus.OK.value());
+        updateAnnounce(announceId, request).statusCode(HttpStatus.NO_CONTENT.value());
 
         // then
         // 수정된 공지사항 조회
@@ -261,7 +276,6 @@ public class AnnounceControllerIntegrationTest {
 
         assertThat(announceCustomPage.content()).hasSize(1);
         assertThat(announceCustomPage.content().getFirst().title()).isEqualTo("수정된 공지사항 제목");
-        assertThat(announceCustomPage.content().getFirst().content()).isEqualTo("수정된 공지사항 내용");
     }
 
     @Test
@@ -311,6 +325,91 @@ public class AnnounceControllerIntegrationTest {
                 .isEqualTo(AnnounceErrorCode.ONLY_MANAGER_CAN_UPDATE_ANNOUNCE.getMessage());
     }
 
+    @Test
+    void 공지사항_상세_내용을_조회할_수_있다() {
+        // given
+        createAnnounce();
+        Long announceId = getLastAnnounceId();
+
+        // when
+        AnnounceDetailResponse response =
+                getAnnounce(announceId, accessToken)
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .as(AnnounceDetailResponse.class);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.id()).isEqualTo(announceId);
+        assertThat(response.title()).isNotEmpty();
+        assertThat(response.content()).isNotEmpty();
+    }
+
+    @Test
+    void 자신이_속한_학과가_참여하는_공지사항_상세_내용을_조회할_수_있다() {
+        // given
+        Department department = organizationTestUtil.createCouncilDepartment();
+        Member member = memberTestUtil.createMemberFromRoleWithDepartment(Role.USER, department);
+        accessToken = authTestUtil.generateAccessTokenWithMember(member);
+
+        announceTestUtil.createAnnounceWithParticipationDepartment(department);
+        Long announceId = getMyLastAnnounceId();
+
+        // when
+        MyAnnounceDetailResponse response =
+                getMyAnnounce(announceId, accessToken)
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .as(MyAnnounceDetailResponse.class);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.id()).isEqualTo(announceId);
+        assertThat(response.title()).isNotEmpty();
+        assertThat(response.content()).isNotEmpty();
+    }
+
+    @Test
+    void 공지사항이_존재하지_않으면_Announce_Not_Found_에러_응답을_받는다() {
+        // given
+        Long announceId = 100L;
+
+        // when
+        ErrorResponse errorResponse =
+                getAnnounce(announceId, accessToken)
+                        .statusCode(AnnounceErrorCode.ANNOUNCE_NOT_FOUND.getHttpStatus().value())
+                        .extract()
+                        .as(ErrorResponse.class);
+
+        // then
+        assertThat(errorResponse.message())
+                .isEqualTo(AnnounceErrorCode.ANNOUNCE_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 공지사항_참여_정보가_존재하지_않으면_Announce_Participation_Not_Found_에러_응답을_받는다() {
+        // given
+        Department department = organizationTestUtil.createCouncilDepartment();
+        Member member = memberTestUtil.createMemberFromRoleWithDepartment(Role.USER, department);
+        accessToken = authTestUtil.generateAccessTokenWithMember(member);
+
+        Long announceId = 100L;
+
+        // when
+        ErrorResponse errorResponse =
+                getMyAnnounce(announceId, accessToken)
+                        .statusCode(
+                                AnnounceErrorCode.ANNOUNCE_PARTICIPATION_NOT_FOUND
+                                        .getHttpStatus()
+                                        .value())
+                        .extract()
+                        .as(ErrorResponse.class);
+
+        // then
+        assertThat(errorResponse.message())
+                .isEqualTo(AnnounceErrorCode.ANNOUNCE_PARTICIPATION_NOT_FOUND.getMessage());
+    }
+
     private void createAnnounce() {
         Department department = organizationTestUtil.createCouncilDepartment();
         createAnnounceWithDepartment(department);
@@ -355,9 +454,13 @@ public class AnnounceControllerIntegrationTest {
         return Math.min(remainingItems, pageSize);
     }
 
-    public static ValidatableResponse getMyAnnounces(String accessToken) {
+    public static ValidatableResponse getMyAnnounces(int page, int size, String accessToken) {
         return given().contentType(MediaType.APPLICATION_JSON_VALUE)
                 .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
+                .queryParam("page", page)
+                .queryParam("size", size)
+                .queryParam("direction", "DESC")
+                .queryParam("sort", "createdAt")
                 .when()
                 .get(ANNOUNCE_URL + "/me")
                 .then()
@@ -370,6 +473,16 @@ public class AnnounceControllerIntegrationTest {
                 .statusCode(HttpStatus.OK.value())
                 .extract()
                 .as(AnnounceCustomPage.class)
+                .content()
+                .getLast()
+                .id();
+    }
+
+    private Long getMyLastAnnounceId() {
+        return getMyAnnounces(0, 10, accessToken)
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(MyAnnounceCustomPage.class)
                 .content()
                 .getLast()
                 .id();
@@ -391,6 +504,26 @@ public class AnnounceControllerIntegrationTest {
                 .body(request)
                 .when()
                 .put(ANNOUNCE_URL + "/{announce-id}", announceId)
+                .then()
+                .log()
+                .all();
+    }
+
+    private ValidatableResponse getAnnounce(Long announceId, String accessToken) {
+        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
+                .when()
+                .get(ANNOUNCE_URL + "/{announce-id}", announceId)
+                .then()
+                .log()
+                .all();
+    }
+
+    private ValidatableResponse getMyAnnounce(Long announceId, String accessToken) {
+        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
+                .when()
+                .get(ANNOUNCE_URL + "/me/{announce-id}", announceId)
                 .then()
                 .log()
                 .all();

--- a/src/test/java/com/jnulocker/announce/adapter/in/AnnounceControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/announce/adapter/in/AnnounceControllerIntegrationTest.java
@@ -328,7 +328,14 @@ public class AnnounceControllerIntegrationTest {
     @Test
     void 공지사항_상세_내용을_조회할_수_있다() {
         // given
-        createAnnounce();
+        Department department = organizationTestUtil.createCouncilDepartment();
+        CreateAnnounceRequest request =
+                createAnnounceRequestBuilder()
+                        .withTitle("테스트 공지사항")
+                        .withContent("테스트 공지사항 내용")
+                        .withParticipationDepartmentIds(List.of(department.getId()))
+                        .build();
+        createAnnounceRequest(request);
         Long announceId = getLastAnnounceId();
 
         // when
@@ -341,14 +348,25 @@ public class AnnounceControllerIntegrationTest {
         // then
         assertThat(response).isNotNull();
         assertThat(response.id()).isEqualTo(announceId);
-        assertThat(response.title()).isNotEmpty();
-        assertThat(response.content()).isNotEmpty();
+        assertThat(response.title()).isEqualTo(request.title());
+        assertThat(response.content()).isEqualTo(request.content());
+        assertThat(response.departments()).hasSize(1);
+        assertThat(response.createdAt()).isNotNull();
+        assertThat(response.updatedAt()).isNotNull();
     }
 
     @Test
     void 자신이_속한_학과가_참여하는_공지사항_상세_내용을_조회할_수_있다() {
         // given
         Department department = organizationTestUtil.createCouncilDepartment();
+        CreateAnnounceRequest request =
+                createAnnounceRequestBuilder()
+                        .withTitle("테스트 공지사항")
+                        .withContent("테스트 공지사항 내용")
+                        .withParticipationDepartmentIds(List.of(department.getId()))
+                        .build();
+        createAnnounceRequest(request);
+
         Member member = memberTestUtil.createMemberFromRoleWithDepartment(Role.USER, department);
         accessToken = authTestUtil.generateAccessTokenWithMember(member);
 
@@ -365,8 +383,10 @@ public class AnnounceControllerIntegrationTest {
         // then
         assertThat(response).isNotNull();
         assertThat(response.id()).isEqualTo(announceId);
-        assertThat(response.title()).isNotEmpty();
-        assertThat(response.content()).isNotEmpty();
+        assertThat(response.title()).isEqualTo(request.title());
+        assertThat(response.content()).isEqualTo(request.content());
+        assertThat(response.createdAt()).isNotNull();
+        assertThat(response.updateAt()).isNotNull();
     }
 
     @Test
@@ -421,6 +441,10 @@ public class AnnounceControllerIntegrationTest {
                         .withParticipationDepartmentIds(List.of(department.getId()))
                         .build();
 
+        createAnnounceRequest(request);
+    }
+
+    private void createAnnounceRequest(CreateAnnounceRequest request) {
         given().contentType(MediaType.APPLICATION_JSON_VALUE)
                 .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
                 .body(request)


### PR DESCRIPTION
### 개요
close #98 

### 작업사항

공지사항 조회 API 응답 명세가 변경되었습니다.
- USER
  - 공지사항 목록 조회(페이지네이션) 
  - 공지사항 상세 조회
- MANAGER
  - 공지사항 목록 조회(페이지네이션)
  - 공지사항 상세 조회 
    - user와 다르게 공지사항을 관리하기 위해 공지사항 참여학과 목록을 응답으로 반환합니다.

### 변경로직
- 공지사항 목록 조회에 페이지네이션을 적용하고 공지사항 내용을 응답에서 제거하였습니다.

### 테스트 결과
<img width="514" alt="image" src="https://github.com/user-attachments/assets/d988a12e-7d8e-4df6-a9b7-556ce05150de" />

**추가된 테스트케이스**
<img width="487" alt="image" src="https://github.com/user-attachments/assets/5fa176f3-fcb2-422a-a993-11b7d7d73bd3" />
<img width="237" alt="image" src="https://github.com/user-attachments/assets/ebe79385-bb91-4371-addf-79da74ea1e96" />
<img width="413" alt="image" src="https://github.com/user-attachments/assets/0de26071-61be-4582-9351-5d100d6ee2db" />
<img width="435" alt="image" src="https://github.com/user-attachments/assets/9097d352-e1de-4d8d-ab03-04c5854c2306" />
<img width="577" alt="image" src="https://github.com/user-attachments/assets/795af289-b8a5-4f8f-b5d1-c02d36767c0f" />


### reference
- 메인페이지에서 이벤트 캐러셀 위에 보이는 user의 공지사항 중 가장 최근 공지사항 하나를 불러오는 것은 공지사항 목록 조회에서 제공하는 페이지네이션을 이용해 프론트에서 처리하기로 했습니다.

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 공지사항 상세 정보를 조회할 수 있는 엔드포인트가 추가되었습니다.
  - 내 부서의 공지사항 목록 및 상세 정보를 조회할 수 있는 엔드포인트가 추가되었습니다.
  - 내 공지사항 목록 조회 시 페이지네이션(페이징)이 지원됩니다.
  - 내 공지사항 조회 경로에 하위 경로 지원이 추가되어 접근성이 향상되었습니다.

- **버그 수정**
  - 삭제된 공지사항 접근 시 올바른 에러 메시지가 반환되도록 개선되었습니다.
  - 공지사항 수정 성공 시 HTTP 204 상태 코드가 반환되도록 변경되었습니다.

- **문서화**
  - 공지사항 관련 API 및 예외 상황에 대한 Swagger 문서가 보강되었습니다.

- **테스트**
  - 공지사항 상세 조회, 페이징, 에러 케이스 등 새로운 테스트가 추가되었습니다.
  - 내 부서 공지사항 조회 테스트가 다양한 페이징 시나리오를 포함하도록 확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->