### PR TITLE
[FEAT] USER 소속학과 대상 이벤트 목록 조회 API 페이지네이션 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ repositories {
     mavenCentral()
 }
 
+def querydslVersion = '6.11'
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
@@ -34,6 +36,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // querydsl
+    implementation "io.github.openfeign.querydsl:querydsl-jpa:${querydslVersion}"
+    annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:${querydslVersion}:jpa"
 
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'

--- a/src/main/java/com/jnulocker/common/persistence/querydsl/PathProvider.java
+++ b/src/main/java/com/jnulocker/common/persistence/querydsl/PathProvider.java
@@ -1,0 +1,22 @@
+package com.jnulocker.common.persistence.querydsl;
+
+import com.querydsl.core.types.Path;
+import java.util.Map;
+
+/** QueryDSL Path 매핑을 제공하는 인터페이스 엔티티별 정렬 필드와 경로를 매핑하기 위해 사용됩니다. */
+public interface PathProvider {
+
+    /**
+     * 필드명과 Path 객체의 매핑을 반환합니다.
+     *
+     * @return 필드명과 Path 객체의 Map
+     */
+    Map<String, Path<?>> getPathMap();
+
+    /**
+     * 기본 정렬에 사용될 Path를 반환합니다.
+     *
+     * @return 기본 정렬 Path
+     */
+    Path<?> getDefaultPath();
+}

--- a/src/main/java/com/jnulocker/common/persistence/querydsl/QueryDslOrderUtils.java
+++ b/src/main/java/com/jnulocker/common/persistence/querydsl/QueryDslOrderUtils.java
@@ -1,0 +1,73 @@
+package com.jnulocker.common.persistence.querydsl;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import lombok.experimental.UtilityClass;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+/** QueryDSL 정렬 유틸리티 클래스 Pageable 객체의 정렬 정보를 QueryDSL OrderSpecifier로 변환합니다. */
+@UtilityClass
+public class QueryDslOrderUtils {
+
+    /**
+     * PathProvider를 사용하여 Pageable의 정렬 정보를 기반으로 QueryDSL OrderSpecifier 배열을 생성합니다.
+     *
+     * @param pageable 정렬 정보를 포함한 Pageable 객체
+     * @param pathProvider Path 매핑을 제공하는 PathProvider
+     * @return OrderSpecifier 배열
+     */
+    public static OrderSpecifier<?>[] getOrderSpecifiers(
+            Pageable pageable, PathProvider pathProvider) {
+        return getOrderSpecifiers(
+                pageable, pathProvider.getPathMap(), pathProvider.getDefaultPath(), Order.ASC);
+    }
+
+    /**
+     * Pageable의 정렬 정보를 기반으로 QueryDSL OrderSpecifier 배열을 생성합니다.
+     *
+     * @param pageable 정렬 정보를 포함한 Pageable 객체
+     * @param pathMap 속성 이름과 Path 객체의 매핑
+     * @param defaultPath 기본 정렬에 사용할 대상 Path
+     * @param defaultDirection 기본 정렬 방향 (기본값은 ASC)
+     * @return OrderSpecifier 배열
+     */
+    private static OrderSpecifier<?>[] getOrderSpecifiers(
+            Pageable pageable,
+            Map<String, Path<?>> pathMap,
+            Path<?> defaultPath,
+            Order defaultDirection) {
+
+        // 기본 정렬 방향이 지정되지 않은 경우 ASC로 설정
+        if (defaultDirection == null) {
+            defaultDirection = Order.ASC;
+        }
+
+        // 정렬이 지정되지 않은 경우 기본 정렬 반환
+        if (pageable == null || !pageable.getSort().isSorted()) {
+            return new OrderSpecifier[] {new OrderSpecifier(defaultDirection, defaultPath)};
+        }
+
+        List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+
+        for (Sort.Order order : pageable.getSort()) {
+            Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+            String property = order.getProperty();
+
+            // Map에서 Path 찾기
+            Path<?> path = pathMap.get(property);
+            if (path != null) {
+                orderSpecifiers.add(new OrderSpecifier(direction, path));
+            }
+        }
+
+        // 정렬 지정자가 없는 경우 기본 정렬 반환
+        return orderSpecifiers.isEmpty()
+                ? new OrderSpecifier[] {new OrderSpecifier(defaultDirection, defaultPath)}
+                : orderSpecifiers.toArray(new OrderSpecifier[0]);
+    }
+}

--- a/src/main/java/com/jnulocker/config/JpaAuditingConfig.java
+++ b/src/main/java/com/jnulocker/config/JpaAuditingConfig.java
@@ -1,8 +1,0 @@
-package com.jnulocker.config;
-
-import org.springframework.context.annotation.Configuration;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-
-@Configuration
-@EnableJpaAuditing
-public class JpaAuditingConfig {}

--- a/src/main/java/com/jnulocker/config/JpaConfig.java
+++ b/src/main/java/com/jnulocker/config/JpaConfig.java
@@ -1,0 +1,20 @@
+package com.jnulocker.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+    @PersistenceContext private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory queryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/jnulocker/events/adapter/in/EventController.java
+++ b/src/main/java/com/jnulocker/events/adapter/in/EventController.java
@@ -8,7 +8,7 @@ import com.jnulocker.events.application.port.in.request.PublishEventRequest;
 import com.jnulocker.events.application.port.in.response.EventCustomPage;
 import com.jnulocker.events.application.port.in.response.EventPageable;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
-import com.jnulocker.events.application.port.in.response.MyEventResponse;
+import com.jnulocker.events.application.port.in.response.MyEventCustomPage;
 import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
@@ -44,8 +44,10 @@ public class EventController implements EventApi {
 
     @Override
     @GetMapping("/me")
-    public ResponseEntity<List<MyEventResponse>> getMyEvents() {
-        return ResponseEntity.ok(eventQuery.getMyEvents());
+    public ResponseEntity<MyEventCustomPage> getMyEvents(
+            @Valid @ParameterObject EventPageable eventPageable) {
+        Pageable pageable = eventPageable.toPageable();
+        return ResponseEntity.ok(eventQuery.getMyEvents(pageable));
     }
 
     @Override

--- a/src/main/java/com/jnulocker/events/adapter/in/docs/EventApi.java
+++ b/src/main/java/com/jnulocker/events/adapter/in/docs/EventApi.java
@@ -6,7 +6,7 @@ import com.jnulocker.events.application.port.in.request.PublishEventRequest;
 import com.jnulocker.events.application.port.in.response.EventCustomPage;
 import com.jnulocker.events.application.port.in.response.EventPageable;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
-import com.jnulocker.events.application.port.in.response.MyEventResponse;
+import com.jnulocker.events.application.port.in.response.MyEventCustomPage;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -44,13 +44,9 @@ public interface EventApi {
             content =
                     @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            array =
-                                    @ArraySchema(
-                                            schema =
-                                                    @Schema(
-                                                            implementation =
-                                                                    MyEventResponse.class))))
-    ResponseEntity<List<MyEventResponse>> getMyEvents();
+                            schema = @Schema(implementation = MyEventCustomPage.class)))
+    ResponseEntity<MyEventCustomPage> getMyEvents(
+            @Valid @ParameterObject EventPageable eventPageable);
 
     @ApiExceptionExamples(CreateEventExceptionDocs.class)
     @Operation(

--- a/src/main/java/com/jnulocker/events/adapter/out/EventPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/EventPersistenceAdapter.java
@@ -1,6 +1,7 @@
 package com.jnulocker.events.adapter.out;
 
 import com.jnulocker.common.annotation.PersistenceAdapter;
+import com.jnulocker.events.application.port.in.response.MyEventCustomPage;
 import com.jnulocker.events.application.port.out.EventLoadPort;
 import com.jnulocker.events.application.port.out.EventRecordPort;
 import com.jnulocker.events.domain.Event;
@@ -40,8 +41,9 @@ public class EventPersistenceAdapter implements EventLoadPort, EventRecordPort {
     }
 
     @Override
-    public List<Event> getEventsByParticipationDepartment(Department department) {
-        return eventRepository.findAllByPublishTrueAndEventParticipations_Department(department);
+    public MyEventCustomPage getEventsByParticipationDepartment(
+            Department department, Pageable pageable) {
+        return eventRepository.findEventsByParticipationDepartment(department, pageable);
     }
 
     @Override

--- a/src/main/java/com/jnulocker/events/adapter/out/EventRepository.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/EventRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface EventRepository extends JpaRepository<Event, UUID> {
+public interface EventRepository extends JpaRepository<Event, UUID>, EventRepositoryCustom {
 
     @EntityGraph(attributePaths = {"department"})
     List<Event> findAllByPublishTrueAndEventParticipations_Department(Department department);

--- a/src/main/java/com/jnulocker/events/adapter/out/EventRepository.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/EventRepository.java
@@ -2,17 +2,12 @@ package com.jnulocker.events.adapter.out;
 
 import com.jnulocker.events.domain.Event;
 import com.jnulocker.organization.domain.Department;
-import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EventRepository extends JpaRepository<Event, UUID>, EventRepositoryCustom {
-
-    @EntityGraph(attributePaths = {"department"})
-    List<Event> findAllByPublishTrueAndEventParticipations_Department(Department department);
 
     Page<Event> findAllByDepartment(Department department, Pageable pageable);
 }

--- a/src/main/java/com/jnulocker/events/adapter/out/EventRepositoryCustom.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/EventRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.jnulocker.events.adapter.out;
+
+import com.jnulocker.events.application.port.in.response.MyEventCustomPage;
+import com.jnulocker.organization.domain.Department;
+import org.springframework.data.domain.Pageable;
+
+public interface EventRepositoryCustom {
+    MyEventCustomPage findEventsByParticipationDepartment(Department department, Pageable pageable);
+}

--- a/src/main/java/com/jnulocker/events/adapter/out/EventRepositoryCustomImpl.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/EventRepositoryCustomImpl.java
@@ -1,0 +1,64 @@
+package com.jnulocker.events.adapter.out;
+
+import static com.jnulocker.events.domain.QEvent.event;
+import static com.jnulocker.events.domain.QEventParticipation.eventParticipation;
+import static com.jnulocker.events.domain.QLocker.locker;
+
+import com.jnulocker.events.application.port.in.response.MyEventCustomPage;
+import com.jnulocker.events.application.port.in.response.MyEventListItem;
+import com.jnulocker.events.application.port.in.response.QMyEventListItem;
+import com.jnulocker.organization.domain.Department;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+
+@RequiredArgsConstructor
+public class EventRepositoryCustomImpl implements EventRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public MyEventCustomPage findEventsByParticipationDepartment(
+            Department department, Pageable pageable) {
+        int pageSize = pageable.getPageSize();
+        int pageNumber = pageable.getPageNumber();
+        long offset = pageable.getOffset();
+
+        Long totalElements =
+                queryFactory
+                        .select(event.count())
+                        .from(event)
+                        .join(event.eventParticipations, eventParticipation)
+                        .where(eventParticipation.department.eq(department))
+                        .fetchOne();
+
+        List<MyEventListItem> content =
+                queryFactory
+                        .select(
+                                new QMyEventListItem(
+                                        event.id,
+                                        event.title,
+                                        event.department.nickname,
+                                        event.eventSchedule.startAt,
+                                        event.eventSchedule.endAt,
+                                        // availableLockerCount
+                                        JPAExpressions.select(locker.count())
+                                                .from(locker)
+                                                .where(
+                                                        locker.available.isTrue(),
+                                                        locker.floor.event.id.eq(event.id))))
+                        .from(event)
+                        .join(event.eventParticipations, eventParticipation)
+                        .where(eventParticipation.department.eq(department))
+                        .offset(offset)
+                        .limit(pageSize)
+                        .fetch();
+
+        long totalPage = (totalElements + pageSize - 1) / pageSize;
+        boolean last = pageNumber >= totalPage - 1;
+
+        return MyEventCustomPage.of(content, totalElements, last);
+    }
+}

--- a/src/main/java/com/jnulocker/events/adapter/out/EventRepositoryCustomImpl.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/EventRepositoryCustomImpl.java
@@ -4,9 +4,11 @@ import static com.jnulocker.events.domain.QEvent.event;
 import static com.jnulocker.events.domain.QEventParticipation.eventParticipation;
 import static com.jnulocker.events.domain.QLocker.locker;
 
+import com.jnulocker.common.persistence.querydsl.QueryDslOrderUtils;
 import com.jnulocker.events.application.port.in.response.MyEventCustomPage;
 import com.jnulocker.events.application.port.in.response.MyEventListItem;
 import com.jnulocker.events.application.port.in.response.QMyEventListItem;
+import com.jnulocker.events.infrastructure.querydsl.EventPathMap;
 import com.jnulocker.organization.domain.Department;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -31,7 +33,7 @@ public class EventRepositoryCustomImpl implements EventRepositoryCustom {
                         .select(event.count())
                         .from(event)
                         .join(event.eventParticipations, eventParticipation)
-                        .where(eventParticipation.department.eq(department))
+                        .where(eventParticipation.department.eq(department), event.publish.isTrue())
                         .fetchOne();
 
         List<MyEventListItem> content =
@@ -51,7 +53,10 @@ public class EventRepositoryCustomImpl implements EventRepositoryCustom {
                                                         locker.floor.event.id.eq(event.id))))
                         .from(event)
                         .join(event.eventParticipations, eventParticipation)
-                        .where(eventParticipation.department.eq(department))
+                        .where(eventParticipation.department.eq(department), event.publish.isTrue())
+                        .orderBy(
+                                QueryDslOrderUtils.getOrderSpecifiers(
+                                        pageable, EventPathMap.getInstance()))
                         .offset(offset)
                         .limit(pageSize)
                         .fetch();

--- a/src/main/java/com/jnulocker/events/adapter/out/EventRepositoryCustomImpl.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/EventRepositoryCustomImpl.java
@@ -36,6 +36,10 @@ public class EventRepositoryCustomImpl implements EventRepositoryCustom {
                         .where(eventParticipation.department.eq(department), event.publish.isTrue())
                         .fetchOne();
 
+        if (totalElements == null) {
+            totalElements = 0L;
+        }
+
         List<MyEventListItem> content =
                 queryFactory
                         .select(

--- a/src/main/java/com/jnulocker/events/application/port/in/EventQuery.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/EventQuery.java
@@ -2,7 +2,7 @@ package com.jnulocker.events.application.port.in;
 
 import com.jnulocker.events.application.port.in.response.EventCustomPage;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
-import com.jnulocker.events.application.port.in.response.MyEventResponse;
+import com.jnulocker.events.application.port.in.response.MyEventCustomPage;
 import com.jnulocker.events.domain.Event;
 import com.jnulocker.events.domain.Locker;
 import java.util.List;
@@ -13,7 +13,7 @@ public interface EventQuery {
 
     Event getByIdOrThrow(UUID eventId);
 
-    List<MyEventResponse> getMyEvents();
+    MyEventCustomPage getMyEvents(Pageable pageable);
 
     EventCustomPage getAllEvents(Pageable pageable);
 

--- a/src/main/java/com/jnulocker/events/application/port/in/response/EventPageable.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/response/EventPageable.java
@@ -1,11 +1,9 @@
 package com.jnulocker.events.application.port.in.response;
 
 import com.jnulocker.common.swagger.model.AbstractPageable;
-import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.AssertTrue;
 import java.util.Set;
 
-@Schema()
 public class EventPageable extends AbstractPageable {
 
     public static final String DEFAULT_SORT = "eventSchedule.startAt";

--- a/src/main/java/com/jnulocker/events/application/port/in/response/MyEventCustomPage.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/response/MyEventCustomPage.java
@@ -1,0 +1,15 @@
+package com.jnulocker.events.application.port.in.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record MyEventCustomPage(
+        @Schema(description = "이벤트 목록") List<MyEventListItem> content,
+        @Schema(description = "이벤트 전체 개수", example = "10") Long totalElements,
+        @Schema(description = "마지막 페이지 여부", example = "false") Boolean last) {
+
+    public static MyEventCustomPage of(
+            List<MyEventListItem> content, Long totalElements, Boolean last) {
+        return new MyEventCustomPage(content, totalElements, last);
+    }
+}

--- a/src/main/java/com/jnulocker/events/application/port/in/response/MyEventListItem.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/response/MyEventListItem.java
@@ -1,25 +1,18 @@
 package com.jnulocker.events.application.port.in.response;
 
-import com.jnulocker.events.domain.Event;
+import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-public record MyEventResponse(
+public record MyEventListItem(
         @Schema(description = "이벤트 ID", example = "2b0c4f8e-3d2a-4f5b-8c1e-6f7a2d3e4b5a") UUID id,
         @Schema(description = "이벤트 제목", example = "전자컴퓨터공학부 2025-2 사물함 신청") String title,
         @Schema(description = "이벤트 주최 조직이름", example = "전자컴퓨터공학부 학생회") String departmentNickname,
         @Schema(description = "이벤트 시작 시간", example = "2025-08-01T15:00:00") LocalDateTime startAt,
         @Schema(description = "이벤트 종료 시간", example = "2025-08-01T16:00:00") LocalDateTime endAt,
-        @Schema(description = "신청 가능한 사물함 개수", example = "5") Integer availableLockerCount) {
+        @Schema(description = "신청 가능한 사물함 개수", example = "5") Long availableLockerCount) {
 
-    public static MyEventResponse of(Event event, Integer availableLockerCount) {
-        return new MyEventResponse(
-                event.getId(),
-                event.getTitle(),
-                event.getDepartment().getNickname(),
-                event.getEventSchedule().getStartAt(),
-                event.getEventSchedule().getEndAt(),
-                availableLockerCount);
-    }
+    @QueryProjection
+    public MyEventListItem {}
 }

--- a/src/main/java/com/jnulocker/events/application/port/out/EventLoadPort.java
+++ b/src/main/java/com/jnulocker/events/application/port/out/EventLoadPort.java
@@ -1,8 +1,8 @@
 package com.jnulocker.events.application.port.out;
 
+import com.jnulocker.events.application.port.in.response.MyEventCustomPage;
 import com.jnulocker.events.domain.Event;
 import com.jnulocker.organization.domain.Department;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -16,5 +16,5 @@ public interface EventLoadPort {
 
     Page<Event> getAllEventsByDepartment(Department department, Pageable pageable);
 
-    List<Event> getEventsByParticipationDepartment(Department department);
+    MyEventCustomPage getEventsByParticipationDepartment(Department department, Pageable pageable);
 }

--- a/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
+++ b/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
@@ -5,7 +5,7 @@ import com.jnulocker.events.application.port.in.EventQuery;
 import com.jnulocker.events.application.port.in.response.EventCustomPage;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
 import com.jnulocker.events.application.port.in.response.LockerResponse;
-import com.jnulocker.events.application.port.in.response.MyEventResponse;
+import com.jnulocker.events.application.port.in.response.MyEventCustomPage;
 import com.jnulocker.events.application.port.out.EventLoadPort;
 import com.jnulocker.events.application.port.out.FloorLoadPort;
 import com.jnulocker.events.application.port.out.LockerLoadPort;
@@ -48,23 +48,11 @@ public class EventQueryService implements EventQuery {
     }
 
     @Override
-    public List<MyEventResponse> getMyEvents() {
+    public MyEventCustomPage getMyEvents(Pageable pageable) {
         Long memberId = SecurityUtils.getCurrentMemberId();
         Member member = memberQuery.findByIdOrThrow(memberId);
 
-        // 사용자의 소속학과가 참여하는 이벤트 조회
-        List<Event> events =
-                eventLoadPort.getEventsByParticipationDepartment(member.getDepartment());
-
-        // 각 이벤트에 대해 사용 가능한 사물함 개수 조회
-        return events.stream()
-                .map(
-                        event -> {
-                            Integer availableLockerCount =
-                                    lockerLoadPort.getAvailableLockerCountOfEvent(event);
-                            return MyEventResponse.of(event, availableLockerCount);
-                        })
-                .toList();
+        return eventLoadPort.getEventsByParticipationDepartment(member.getDepartment(), pageable);
     }
 
     @Override

--- a/src/main/java/com/jnulocker/events/infrastructure/querydsl/EventPathMap.java
+++ b/src/main/java/com/jnulocker/events/infrastructure/querydsl/EventPathMap.java
@@ -1,0 +1,49 @@
+package com.jnulocker.events.infrastructure.querydsl;
+
+import static com.jnulocker.events.domain.QEvent.event;
+
+import com.jnulocker.common.persistence.querydsl.PathProvider;
+import com.querydsl.core.types.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Event 엔티티의 Path 매핑을 제공하는 클래스 싱글톤 패턴으로 구현하여 인스턴스 생성 비용을 줄입니다. */
+public class EventPathMap implements PathProvider {
+
+    private static final EventPathMap INSTANCE = new EventPathMap();
+    private static final Map<String, Path<?>> pathMap = new HashMap<>();
+
+    static {
+        pathMap.put("id", event.id);
+        pathMap.put("title", event.title);
+        pathMap.put("publish", event.publish);
+        pathMap.put("eventStatus", event.eventStatus);
+        pathMap.put("eventSchedule.startAt", event.eventSchedule.startAt);
+        pathMap.put("eventSchedule.endAt", event.eventSchedule.endAt);
+        pathMap.put("createdAt", event.createdAt);
+        pathMap.put("updatedAt", event.updatedAt);
+    }
+
+    private EventPathMap() {
+        // 싱글톤 패턴을 위한 private 생성자
+    }
+
+    /**
+     * EventPathMap의 싱글톤 인스턴스를 반환합니다.
+     *
+     * @return EventPathMap 인스턴스
+     */
+    public static EventPathMap getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public Map<String, Path<?>> getPathMap() {
+        return pathMap;
+    }
+
+    @Override
+    public Path<?> getDefaultPath() {
+        return event.eventSchedule.startAt;
+    }
+}

--- a/src/test/java/com/jnulocker/common/persistence/querydsl/QueryDslOrderUtilsTest.java
+++ b/src/test/java/com/jnulocker/common/persistence/querydsl/QueryDslOrderUtilsTest.java
@@ -31,6 +31,7 @@ class QueryDslOrderUtilsTest {
 
         StringPath titlePath = mock(StringPath.class);
         StringPath createdAtPath = mock(StringPath.class);
+        defaultPath = mock(StringPath.class);
 
         pathMap.put("title", titlePath);
         pathMap.put("createdAt", createdAtPath);

--- a/src/test/java/com/jnulocker/common/persistence/querydsl/QueryDslOrderUtilsTest.java
+++ b/src/test/java/com/jnulocker/common/persistence/querydsl/QueryDslOrderUtilsTest.java
@@ -1,0 +1,139 @@
+package com.jnulocker.common.persistence.querydsl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.StringPath;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+class QueryDslOrderUtilsTest {
+
+    private PathProvider pathProvider;
+    private Path<?> defaultPath;
+    private Map<String, Path<?>> pathMap;
+
+    @BeforeEach
+    void setUp() {
+        pathMap = new HashMap<>();
+
+        StringPath titlePath = mock(StringPath.class);
+        StringPath createdAtPath = mock(StringPath.class);
+
+        pathMap.put("title", titlePath);
+        pathMap.put("createdAt", createdAtPath);
+
+        pathProvider = mock(PathProvider.class);
+        when(pathProvider.getPathMap()).thenReturn(pathMap);
+
+        doReturn(defaultPath).when(pathProvider).getDefaultPath();
+    }
+
+    @Test
+    @DisplayName("정렬이 없는 Pageable로 OrderSpecifier 생성 시 기본 정렬이 적용되어야 한다")
+    void getOrderSpecifiersWithUnsortedPageable() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        OrderSpecifier<?>[] orderSpecifiers =
+                QueryDslOrderUtils.getOrderSpecifiers(pageable, pathProvider);
+
+        // then
+        assertNotNull(orderSpecifiers);
+        assertEquals(1, orderSpecifiers.length);
+        assertEquals(Order.ASC, orderSpecifiers[0].getOrder());
+        assertEquals(defaultPath, orderSpecifiers[0].getTarget());
+    }
+
+    @Test
+    @DisplayName("정렬이 있는 Pageable로 OrderSpecifier 생성 시 해당 정렬이 적용되어야 한다")
+    void getOrderSpecifiersWithSortedPageable() {
+        // given
+        Sort sort = Sort.by(Sort.Direction.DESC, "title");
+        Pageable pageable = PageRequest.of(0, 10, sort);
+
+        // when
+        OrderSpecifier<?>[] orderSpecifiers =
+                QueryDslOrderUtils.getOrderSpecifiers(pageable, pathProvider);
+
+        // then
+        assertNotNull(orderSpecifiers);
+        assertEquals(1, orderSpecifiers.length);
+        assertEquals(Order.DESC, orderSpecifiers[0].getOrder());
+        assertEquals(pathMap.get("title"), orderSpecifiers[0].getTarget());
+    }
+
+    @Test
+    @DisplayName("여러 정렬 조건이 있는 Pageable로 OrderSpecifier 생성 시 모든 정렬이 적용되어야 한다")
+    void getOrderSpecifiersWithMultipleSortCriteria() {
+        // given
+        Sort sort = Sort.by(Sort.Order.desc("title"), Sort.Order.asc("createdAt"));
+        Pageable pageable = PageRequest.of(0, 10, sort);
+
+        // when
+        OrderSpecifier<?>[] orderSpecifiers =
+                QueryDslOrderUtils.getOrderSpecifiers(pageable, pathProvider);
+
+        // then
+        assertNotNull(orderSpecifiers);
+        assertEquals(2, orderSpecifiers.length);
+
+        assertEquals(Order.DESC, orderSpecifiers[0].getOrder());
+        assertEquals(pathMap.get("title"), orderSpecifiers[0].getTarget());
+
+        assertEquals(Order.ASC, orderSpecifiers[1].getOrder());
+        assertEquals(pathMap.get("createdAt"), orderSpecifiers[1].getTarget());
+    }
+
+    @Test
+    @DisplayName("매핑되지 않은 정렬 속성이 있는 경우 해당 속성은 무시되어야 한다")
+    void getOrderSpecifiersWithUnmappedSortProperty() {
+        // given
+        Sort sort = Sort.by(Sort.Order.desc("title"), Sort.Order.asc("nonExistentProperty"));
+        Pageable pageable = PageRequest.of(0, 10, sort);
+
+        // when
+        OrderSpecifier<?>[] orderSpecifiers =
+                QueryDslOrderUtils.getOrderSpecifiers(pageable, pathProvider);
+
+        // then
+        assertNotNull(orderSpecifiers);
+        assertEquals(1, orderSpecifiers.length);
+        assertEquals(Order.DESC, orderSpecifiers[0].getOrder());
+        assertEquals(pathMap.get("title"), orderSpecifiers[0].getTarget());
+    }
+
+    @Test
+    @DisplayName("모든 정렬 속성이 매핑되지 않은 경우 기본 정렬이 적용되어야 한다")
+    void getOrderSpecifiersWithAllUnmappedSortProperties() {
+        // given
+        Sort sort =
+                Sort.by(
+                        Sort.Order.desc("nonExistentProperty1"),
+                        Sort.Order.asc("nonExistentProperty2"));
+        Pageable pageable = PageRequest.of(0, 10, sort);
+
+        // when
+        OrderSpecifier<?>[] orderSpecifiers =
+                QueryDslOrderUtils.getOrderSpecifiers(pageable, pathProvider);
+
+        // then
+        assertNotNull(orderSpecifiers);
+        assertEquals(1, orderSpecifiers.length);
+        assertEquals(Order.ASC, orderSpecifiers[0].getOrder());
+        assertEquals(defaultPath, orderSpecifiers[0].getTarget());
+    }
+}

--- a/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
@@ -9,8 +9,9 @@ import com.jnulocker.common.exception.ErrorResponse;
 import com.jnulocker.events.application.port.in.request.CreateEventRequest;
 import com.jnulocker.events.application.port.in.request.PublishEventRequest;
 import com.jnulocker.events.application.port.in.response.EventCustomPage;
+import com.jnulocker.events.application.port.in.response.EventPageable;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
-import com.jnulocker.events.application.port.in.response.MyEventResponse;
+import com.jnulocker.events.application.port.in.response.MyEventCustomPage;
 import com.jnulocker.events.domain.Event;
 import com.jnulocker.events.domain.EventStatus;
 import com.jnulocker.events.exception.EventErrorCode;
@@ -51,6 +52,8 @@ public class EventControllerIntegrationTest {
 
     private static final String EVENT_URL = "/v1/events";
     private static final String ACCESS_TOKEN = "access_token";
+    private static final String DIRECTION = "DESC";
+    private static final String SORT = "createdAt";
 
     @LocalServerPort private int port;
 
@@ -123,15 +126,17 @@ public class EventControllerIntegrationTest {
         eventTestUtil.createEventWithFloorAndLockers(List.of(5, 10), EventStatus.OPEN, true);
 
         // when
-        List<MyEventResponse> myEvents =
-                getMyEvents(accessToken)
+        accessToken = authTestUtil.generateAccessToken(Role.MANAGER);
+        EventCustomPage events =
+                getEvents(0, 10, accessToken)
                         .statusCode(HttpStatus.OK.value())
                         .extract()
-                        .jsonPath()
-                        .getList(".", MyEventResponse.class);
+                        .as(EventCustomPage.class);
 
         // then
-        assertThat(myEvents).isEmpty();
+        assertThat(events.content()).isEmpty();
+        assertThat(events.totalElements()).isZero();
+        assertThat(events.last()).isTrue();
     }
 
     @ParameterizedTest(name = "층별 사물함 수: {0}")
@@ -326,18 +331,19 @@ public class EventControllerIntegrationTest {
 
         // when
         accessToken = authTestUtil.generateAccessTokenWithMember(member);
-        List<MyEventResponse> myEvents =
-                getMyEvents(accessToken)
+        EventPageable eventPageable = new EventPageable(0, 10, DIRECTION, SORT);
+        MyEventCustomPage myEvents =
+                getMyEventsWithPageable(accessToken, eventPageable)
                         .statusCode(HttpStatus.OK.value())
                         .extract()
-                        .jsonPath()
-                        .getList(".", MyEventResponse.class);
-
-        MyEventResponse myEventResponse = myEvents.getFirst();
+                        .as(MyEventCustomPage.class);
 
         // then
-        assertThat(myEvents).hasSize(1);
-        assertThat(myEventResponse.availableLockerCount()).isEqualTo(7);
+        // 자신의 소속 학과가 참여하는 이벤트가 조회되었는지 확인
+        assertThat(myEvents.content()).hasSize(1);
+        assertThat(myEvents.totalElements()).isEqualTo(1);
+        assertThat(myEvents.last()).isTrue();
+        assertThat(myEvents.content().getFirst().availableLockerCount()).isEqualTo(7);
     }
 
     @Test
@@ -353,15 +359,17 @@ public class EventControllerIntegrationTest {
 
         // when
         accessToken = authTestUtil.generateAccessTokenWithMember(member);
-        List<MyEventResponse> myEvents =
-                getMyEvents(accessToken)
+        EventPageable eventPageable = new EventPageable(0, 10, DIRECTION, SORT);
+        MyEventCustomPage myEvents =
+                getMyEventsWithPageable(accessToken, eventPageable)
                         .statusCode(HttpStatus.OK.value())
                         .extract()
-                        .jsonPath()
-                        .getList(".", MyEventResponse.class);
+                        .as(MyEventCustomPage.class);
 
         // then
-        assertThat(myEvents).isEmpty();
+        assertThat(myEvents.content()).isEmpty();
+        assertThat(myEvents.totalElements()).isZero();
+        assertThat(myEvents.last()).isTrue();
     }
 
     // 파라미터 제공 메서드
@@ -388,8 +396,8 @@ public class EventControllerIntegrationTest {
                 .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
                 .queryParam("page", page)
                 .queryParam("size", size)
-                .queryParam("direction", "DESC")
-                .queryParam("sort", "createdAt")
+                .queryParam("direction", DIRECTION)
+                .queryParam("sort", SORT)
                 .when()
                 .get(EVENT_URL)
                 .then()
@@ -397,14 +405,19 @@ public class EventControllerIntegrationTest {
                 .all();
     }
 
-    public static ValidatableResponse getMyEvents(String accessToken) {
+    public static ValidatableResponse getMyEventsWithPageable(
+            String accessToken, EventPageable eventPageable) {
         return given().contentType(MediaType.APPLICATION_JSON_VALUE)
                 .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
+                .queryParam("page", eventPageable.getPage())
+                .queryParam("size", eventPageable.getSize())
+                .queryParam("direction", eventPageable.getDirection())
+                .queryParam("sort", eventPageable.getSort())
                 .when()
                 .get(EVENT_URL + "/me")
                 .then()
                 .log()
-                .all();
+                .ifError();
     }
 
     // 이벤트 생성 메서드들

--- a/src/test/java/com/jnulocker/events/infrastructure/querydsl/EventPathMapTest.java
+++ b/src/test/java/com/jnulocker/events/infrastructure/querydsl/EventPathMapTest.java
@@ -1,0 +1,75 @@
+package com.jnulocker.events.infrastructure.querydsl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.jnulocker.events.domain.QEvent;
+import com.querydsl.core.types.Path;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class EventPathMapTest {
+
+    @Test
+    @DisplayName("EventPathMap은 싱글톤 인스턴스를 제공해야 한다")
+    void getInstance() {
+        // when
+        EventPathMap instance1 = EventPathMap.getInstance();
+        EventPathMap instance2 = EventPathMap.getInstance();
+
+        // then
+        assertNotNull(instance1);
+        assertSame(instance1, instance2);
+    }
+
+    @Test
+    @DisplayName("EventPathMap은 필요한 모든 Path 매핑을 제공해야 한다")
+    void getPathMap() {
+        // given
+        EventPathMap instance = EventPathMap.getInstance();
+        QEvent event = QEvent.event;
+
+        // when
+        Map<String, Path<?>> pathMap = instance.getPathMap();
+
+        // then
+        assertNotNull(pathMap);
+        assertEquals(8, pathMap.size());
+
+        assertTrue(pathMap.containsKey("id"));
+        assertTrue(pathMap.containsKey("title"));
+        assertTrue(pathMap.containsKey("publish"));
+        assertTrue(pathMap.containsKey("eventStatus"));
+        assertTrue(pathMap.containsKey("eventSchedule.startAt"));
+        assertTrue(pathMap.containsKey("eventSchedule.endAt"));
+        assertTrue(pathMap.containsKey("createdAt"));
+        assertTrue(pathMap.containsKey("updatedAt"));
+
+        assertEquals(event.id, pathMap.get("id"));
+        assertEquals(event.title, pathMap.get("title"));
+        assertEquals(event.publish, pathMap.get("publish"));
+        assertEquals(event.eventStatus, pathMap.get("eventStatus"));
+        assertEquals(event.eventSchedule.startAt, pathMap.get("eventSchedule.startAt"));
+        assertEquals(event.eventSchedule.endAt, pathMap.get("eventSchedule.endAt"));
+        assertEquals(event.createdAt, pathMap.get("createdAt"));
+        assertEquals(event.updatedAt, pathMap.get("updatedAt"));
+    }
+
+    @Test
+    @DisplayName("EventPathMap은 기본 정렬 Path를 제공해야 한다")
+    void getDefaultPath() {
+        // given
+        EventPathMap instance = EventPathMap.getInstance();
+        QEvent event = QEvent.event;
+
+        // when
+        Path<?> defaultPath = instance.getDefaultPath();
+
+        // then
+        assertNotNull(defaultPath);
+        assertEquals(event.eventSchedule.startAt, defaultPath);
+    }
+}

--- a/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
@@ -1,15 +1,17 @@
 package com.jnulocker.registration.adapter.in;
 
 import static com.jnulocker.events.adapter.in.EventControllerIntegrationTest.getEventLockers;
-import static com.jnulocker.events.adapter.in.EventControllerIntegrationTest.getMyEvents;
+import static com.jnulocker.events.adapter.in.EventControllerIntegrationTest.getMyEventsWithPageable;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.jnulocker.auth.jwt.exception.JwtErrorCode;
 import com.jnulocker.auth.utils.AuthTestUtil;
 import com.jnulocker.common.exception.ErrorResponse;
+import com.jnulocker.events.application.port.in.response.EventPageable;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
-import com.jnulocker.events.application.port.in.response.MyEventResponse;
+import com.jnulocker.events.application.port.in.response.MyEventCustomPage;
+import com.jnulocker.events.application.port.in.response.MyEventListItem;
 import com.jnulocker.events.domain.Event;
 import com.jnulocker.events.domain.EventStatus;
 import com.jnulocker.events.exception.EventErrorCode;
@@ -493,32 +495,31 @@ class RegistrationControllerIntegrationTest {
         RegisterForEventRequest request = createRequestForAvailableLocker(event);
 
         // 신청 전 조회
-        List<MyEventResponse> myEventsBeforeRegistration =
-                getMyEvents(accessToken)
+        EventPageable eventPageable = new EventPageable(0, 10, "DESC", "createdAt");
+        MyEventCustomPage myEventsBeforeRegistration =
+                getMyEventsWithPageable(accessToken, eventPageable)
                         .statusCode(HttpStatus.OK.value())
                         .extract()
-                        .jsonPath()
-                        .getList(".", MyEventResponse.class);
+                        .as(MyEventCustomPage.class);
 
-        Integer availableLockerCountBefore =
-                myEventsBeforeRegistration.getFirst().availableLockerCount();
+        Long availableLockerCountBefore =
+                myEventsBeforeRegistration.content().getFirst().availableLockerCount();
 
         // 신청
         registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
 
         // when
-        List<MyEventResponse> myEventsAfterRegistration =
-                getMyEvents(accessToken)
+        MyEventCustomPage myEventsAfterRegistration =
+                getMyEventsWithPageable(accessToken, eventPageable)
                         .statusCode(HttpStatus.OK.value())
                         .extract()
-                        .jsonPath()
-                        .getList(".", MyEventResponse.class);
+                        .as(MyEventCustomPage.class);
 
-        MyEventResponse myEventResponse = myEventsAfterRegistration.getFirst();
+        MyEventListItem eventAfterRegistration = myEventsAfterRegistration.content().getFirst();
 
         // then
-        assertThat(myEventsAfterRegistration).hasSize(1);
-        assertThat(myEventResponse.availableLockerCount())
+        assertThat(myEventsAfterRegistration.content()).hasSize(1);
+        assertThat(eventAfterRegistration.availableLockerCount())
                 .isEqualTo(availableLockerCountBefore - 1);
     }
 


### PR DESCRIPTION
### 개요
close #101 

### 작업사항
- 기존의 리스트(`[]`)로만 반환하던 이벤트 목록 조회 API를 페이지네이션을 적용해 응답하도록 변경

### 변경로직
- `QueryDSL` 의존성 추가
- `QueryProjection`을 이용한 쿼리 작성
- API 명세 수정 및 문서화, 테스트케이스 수정

### 테스트 결과
<img width="389" alt="image" src="https://github.com/user-attachments/assets/f183f451-c03a-4491-99c3-0c6a0c84ab6f" />


### reference
- 기존의 `QueryDSL`은 `5.1.0` 이후 유지보수가 안되는 상황입니다.
- 따라서 `OpenFeign`에서 해당 리파지토리를 `fork`해 유지보수를 진행하고있으며 이를 사용했습니다.
- [Maven Repository](https://mvnrepository.com/artifact/io.github.openfeign.querydsl)
- [2025 QueryDSL 근황](https://yeoon.tistory.com/167)

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 이벤트 목록 및 "내 이벤트" 조회에 페이지네이션(페이징) 기능이 추가되었습니다.
  - 이벤트 정렬 기준 및 방향을 쿼리 파라미터로 지정할 수 있습니다.
  - 이벤트 목록 응답이 페이지 정보(totalElements, last 등)를 포함하는 구조로 개선되었습니다.
  - QueryDSL 기반의 정렬 및 페이징 지원이 강화되었습니다.
  - JPA 및 QueryDSL 설정이 개선되어 쿼리 작성 및 실행 효율성이 향상되었습니다.

- **버그 수정**
  - 이벤트 목록 및 "내 이벤트" 관련 API 및 테스트에서 페이징 및 정렬 처리 오류가 수정되었습니다.

- **문서화**
  - Swagger 문서에 페이지네이션 및 응답 구조 관련 설명이 추가·수정되었습니다.

- **테스트**
  - 페이징 및 정렬 기능과 관련된 단위/통합 테스트가 추가 및 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->