### PR TITLE
[FEAT] 이벤트 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/jnulocker/announce/application/service/AnnounceQueryService.java
+++ b/src/main/java/com/jnulocker/announce/application/service/AnnounceQueryService.java
@@ -19,9 +19,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AnnounceQueryService implements AnnounceQuery {
 
     private final MemberQuery memberQuery;

--- a/src/main/java/com/jnulocker/auth/application/service/AuthQueryService.java
+++ b/src/main/java/com/jnulocker/auth/application/service/AuthQueryService.java
@@ -10,9 +10,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AuthQueryService implements ManagerQuery {
 
     private final MemberQuery memberQuery;

--- a/src/main/java/com/jnulocker/config/SecurityConfig.java
+++ b/src/main/java/com/jnulocker/config/SecurityConfig.java
@@ -72,31 +72,34 @@ public class SecurityConfig {
                                         "/v1/auth/send-email",
                                         "/v1/auth/verify")
                                 .permitAll()
-                                .requestMatchers(HttpMethod.GET, "/v1/events/*/registrations/me")
+                                .requestMatchers(
+                                        HttpMethod.GET,
+                                        "/v1/events/*/registrations/me",
+                                        "/v1/events/me",
+                                        "/v1/announces/me",
+                                        "/v1/announces/me/*")
                                 .hasAuthority(Role.USER.getRole())
                                 .requestMatchers(HttpMethod.POST, "/v1/events/*/registrations")
                                 .hasAuthority(Role.USER.getRole())
-                                .requestMatchers(HttpMethod.GET, "/v1/auth/managers/pending")
-                                .hasAuthority(Role.MANAGER.getRole())
-                                .requestMatchers(HttpMethod.GET, "/v1/events")
+                                .requestMatchers(
+                                        HttpMethod.GET,
+                                        "/v1/auth/managers/pending",
+                                        "/v1/events",
+                                        "/v1/events/*",
+                                        "/v1/announces",
+                                        "/v1/announces/*")
                                 .hasAuthority(Role.MANAGER.getRole())
                                 .requestMatchers(
-                                        HttpMethod.POST, "/v1/events", "/v1/auth/managers/approve")
-                                .hasAuthority(Role.MANAGER.getRole())
-                                .requestMatchers(HttpMethod.DELETE, "/v1/events/*")
-                                .hasAuthority(Role.MANAGER.getRole())
-                                .requestMatchers(HttpMethod.PUT, "/v1/events/*/publish")
-                                .hasAuthority(Role.MANAGER.getRole())
-                                .requestMatchers(HttpMethod.POST, "/v1/announces")
+                                        HttpMethod.POST,
+                                        "/v1/events",
+                                        "/v1/announces",
+                                        "/v1/auth/managers/approve")
                                 .hasAuthority(Role.MANAGER.getRole())
                                 .requestMatchers(
-                                        HttpMethod.GET, "/v1/announces/me", "/v1/announces/me/*")
-                                .hasAuthority(Role.USER.getRole())
-                                .requestMatchers(HttpMethod.GET, "/v1/announces", "/v1/announces/*")
+                                        HttpMethod.DELETE, "/v1/events/*", "/v1/announces/*")
                                 .hasAuthority(Role.MANAGER.getRole())
-                                .requestMatchers(HttpMethod.DELETE, "/v1/announces/*")
-                                .hasAuthority(Role.MANAGER.getRole())
-                                .requestMatchers(HttpMethod.PUT, "/v1/announces/*")
+                                .requestMatchers(
+                                        HttpMethod.PUT, "/v1/events/*/publish", "/v1/announces/*")
                                 .hasAuthority(Role.MANAGER.getRole())
                                 // 토큰의 role과 db의 role과 다른 문제 고려
                                 .anyRequest()

--- a/src/main/java/com/jnulocker/events/adapter/in/EventController.java
+++ b/src/main/java/com/jnulocker/events/adapter/in/EventController.java
@@ -7,6 +7,7 @@ import com.jnulocker.events.application.port.in.request.CreateEventRequest;
 import com.jnulocker.events.application.port.in.request.PublishEventRequest;
 import com.jnulocker.events.application.port.in.response.EventCustomPage;
 import com.jnulocker.events.application.port.in.response.EventPageable;
+import com.jnulocker.events.application.port.in.response.EventResponse;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
 import com.jnulocker.events.application.port.in.response.MyEventCustomPage;
 import jakarta.validation.Valid;
@@ -40,6 +41,11 @@ public class EventController implements EventApi {
             @Valid @ParameterObject EventPageable eventPageable) {
         Pageable pageable = eventPageable.toPageable();
         return ResponseEntity.ok(eventQuery.getAllEvents(pageable));
+    }
+
+    @GetMapping("/{event-id}")
+    public ResponseEntity<EventResponse> getEvent(@PathVariable("event-id") UUID eventId) {
+        return ResponseEntity.ok(eventQuery.getEvent(eventId));
     }
 
     @Override

--- a/src/main/java/com/jnulocker/events/adapter/in/EventController.java
+++ b/src/main/java/com/jnulocker/events/adapter/in/EventController.java
@@ -43,6 +43,7 @@ public class EventController implements EventApi {
         return ResponseEntity.ok(eventQuery.getAllEvents(pageable));
     }
 
+    @Override
     @GetMapping("/{event-id}")
     public ResponseEntity<EventResponse> getEvent(@PathVariable("event-id") UUID eventId) {
         return ResponseEntity.ok(eventQuery.getEvent(eventId));

--- a/src/main/java/com/jnulocker/events/adapter/in/docs/EventApi.java
+++ b/src/main/java/com/jnulocker/events/adapter/in/docs/EventApi.java
@@ -5,6 +5,7 @@ import com.jnulocker.events.application.port.in.request.CreateEventRequest;
 import com.jnulocker.events.application.port.in.request.PublishEventRequest;
 import com.jnulocker.events.application.port.in.response.EventCustomPage;
 import com.jnulocker.events.application.port.in.response.EventPageable;
+import com.jnulocker.events.application.port.in.response.EventResponse;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
 import com.jnulocker.events.application.port.in.response.MyEventCustomPage;
 import io.swagger.v3.oas.annotations.Operation;
@@ -35,6 +36,17 @@ public interface EventApi {
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = EventCustomPage.class)))
     ResponseEntity<EventCustomPage> getEvents(@Valid @ParameterObject EventPageable eventPageable);
+
+    @ApiExceptionExamples(GetEventExceptionDocs.class)
+    @Operation(summary = "이벤트 상세 조회", description = "이벤트의 상세 정보를 조회합니다. 이벤트 ID를 통해 조회합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "이벤트 상세 조회 성공",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = EventResponse.class)))
+    ResponseEntity<EventResponse> getEvent(@PathVariable("event-id") UUID eventId);
 
     @ApiExceptionExamples(GetMyEventsExceptionDocs.class)
     @Operation(summary = "자신의 소속학과 대상 이벤트 목록 조회", description = "자신의 소속학과가 참여한 이벤트 목록을 조회합니다.")

--- a/src/main/java/com/jnulocker/events/adapter/in/docs/GetEventExceptionDocs.java
+++ b/src/main/java/com/jnulocker/events/adapter/in/docs/GetEventExceptionDocs.java
@@ -5,6 +5,7 @@ import com.jnulocker.common.swagger.ExceptionDoc;
 import com.jnulocker.common.swagger.ExplainError;
 import com.jnulocker.common.swagger.SwaggerExceptionDoc;
 import com.jnulocker.events.exception.EventNotFoundException;
+import com.jnulocker.events.exception.OnlyDepartmentMemberCanSeeEventException;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -14,4 +15,8 @@ public class GetEventExceptionDocs implements SwaggerExceptionDoc {
 
     @ExplainError("이벤트가 존재하지 않을 때 발생하는 예외입니다")
     public static final BusinessException 이벤트가_존재하지_않을_때 = EventNotFoundException.EXCEPTION;
+
+    @ExplainError("이벤트 주최 학과의 구성원이 아닐 때 발생하는 예외입니다")
+    public static final BusinessException 이벤트_주최_학과의_구성원이_아닐_때 =
+            OnlyDepartmentMemberCanSeeEventException.EXCEPTION;
 }

--- a/src/main/java/com/jnulocker/events/adapter/in/docs/GetEventExceptionDocs.java
+++ b/src/main/java/com/jnulocker/events/adapter/in/docs/GetEventExceptionDocs.java
@@ -1,0 +1,17 @@
+package com.jnulocker.events.adapter.in.docs;
+
+import com.jnulocker.common.exception.BusinessException;
+import com.jnulocker.common.swagger.ExceptionDoc;
+import com.jnulocker.common.swagger.ExplainError;
+import com.jnulocker.common.swagger.SwaggerExceptionDoc;
+import com.jnulocker.events.exception.EventNotFoundException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@ExceptionDoc
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetEventExceptionDocs implements SwaggerExceptionDoc {
+
+    @ExplainError("이벤트가 존재하지 않을 때 발생하는 예외입니다")
+    public static final BusinessException 이벤트가_존재하지_않을_때 = EventNotFoundException.EXCEPTION;
+}

--- a/src/main/java/com/jnulocker/events/adapter/out/EventPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/EventPersistenceAdapter.java
@@ -47,7 +47,7 @@ public class EventPersistenceAdapter implements EventLoadPort, EventRecordPort {
     }
 
     @Override
-    public Optional<Event> getEventsByIdWithEventParticipation(UUID eventId) {
+    public Optional<Event> getEventByIdWithEventParticipation(UUID eventId) {
         return eventRepository.findByIdWithEventParticipations(eventId);
     }
 

--- a/src/main/java/com/jnulocker/events/adapter/out/EventPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/EventPersistenceAdapter.java
@@ -47,6 +47,11 @@ public class EventPersistenceAdapter implements EventLoadPort, EventRecordPort {
     }
 
     @Override
+    public Optional<Event> getEventsByIdWithEventParticipation(UUID eventId) {
+        return eventRepository.findByIdWithEventParticipations(eventId);
+    }
+
+    @Override
     public Event saveEvent(Event event) {
         return eventRepository.save(event);
     }

--- a/src/main/java/com/jnulocker/events/adapter/out/EventRepository.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/EventRepository.java
@@ -14,6 +14,6 @@ public interface EventRepository extends JpaRepository<Event, UUID>, EventReposi
 
     Page<Event> findAllByDepartment(Department department, Pageable pageable);
 
-    @Query("SELECT e FROM Event e LEFT JOIN FETCH e.eventParticipations WHERE e.id = :eventId")
+    @Query("SELECT e FROM Event e JOIN FETCH e.eventParticipations WHERE e.id = :eventId")
     Optional<Event> findByIdWithEventParticipations(@Param("eventId") UUID eventId);
 }

--- a/src/main/java/com/jnulocker/events/adapter/out/EventRepository.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/EventRepository.java
@@ -14,6 +14,7 @@ public interface EventRepository extends JpaRepository<Event, UUID>, EventReposi
 
     Page<Event> findAllByDepartment(Department department, Pageable pageable);
 
-    @Query("SELECT e FROM Event e JOIN FETCH e.eventParticipations WHERE e.id = :eventId")
+    @Query(
+            "SELECT e FROM Event e JOIN FETCH e.eventParticipations ep JOIN FETCH ep.department WHERE e.id = :eventId")
     Optional<Event> findByIdWithEventParticipations(@Param("eventId") UUID eventId);
 }

--- a/src/main/java/com/jnulocker/events/adapter/out/EventRepository.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/EventRepository.java
@@ -2,12 +2,18 @@ package com.jnulocker.events.adapter.out;
 
 import com.jnulocker.events.domain.Event;
 import com.jnulocker.organization.domain.Department;
+import io.lettuce.core.dynamic.annotation.Param;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface EventRepository extends JpaRepository<Event, UUID>, EventRepositoryCustom {
 
     Page<Event> findAllByDepartment(Department department, Pageable pageable);
+
+    @Query("SELECT e FROM Event e LEFT JOIN FETCH e.eventParticipations WHERE e.id = :eventId")
+    Optional<Event> findByIdWithEventParticipations(@Param("eventId") UUID eventId);
 }

--- a/src/main/java/com/jnulocker/events/adapter/out/EventRepository.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/EventRepository.java
@@ -2,13 +2,13 @@ package com.jnulocker.events.adapter.out;
 
 import com.jnulocker.events.domain.Event;
 import com.jnulocker.organization.domain.Department;
-import io.lettuce.core.dynamic.annotation.Param;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface EventRepository extends JpaRepository<Event, UUID>, EventRepositoryCustom {
 

--- a/src/main/java/com/jnulocker/events/application/port/in/EventQuery.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/EventQuery.java
@@ -1,6 +1,7 @@
 package com.jnulocker.events.application.port.in;
 
 import com.jnulocker.events.application.port.in.response.EventCustomPage;
+import com.jnulocker.events.application.port.in.response.EventResponse;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
 import com.jnulocker.events.application.port.in.response.MyEventCustomPage;
 import com.jnulocker.events.domain.Event;
@@ -20,4 +21,6 @@ public interface EventQuery {
     Locker getLockerByIdOrThrow(Long lockerId);
 
     List<FloorWithLockersResponse> getLockersByEventId(UUID eventId);
+
+    EventResponse getEvent(UUID eventId);
 }

--- a/src/main/java/com/jnulocker/events/application/port/in/response/EventDepartmentResponse.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/response/EventDepartmentResponse.java
@@ -1,0 +1,7 @@
+package com.jnulocker.events.application.port.in.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record EventDepartmentResponse(
+        @Schema(description = "학과 ID", example = "1") Long id,
+        @Schema(description = "학과 이름", example = "전자컴퓨터공학부") String name) {}

--- a/src/main/java/com/jnulocker/events/application/port/in/response/EventResponse.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/response/EventResponse.java
@@ -1,0 +1,31 @@
+package com.jnulocker.events.application.port.in.response;
+
+import com.jnulocker.events.domain.Event;
+import com.jnulocker.events.domain.EventStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record EventResponse(
+        @Schema(description = "이벤트 ID", example = "2b0c4f8e-3d2a-4f5b-8c1e-6f7a2d3e4b5a") UUID id,
+        @Schema(description = "이벤트 제목", example = "전자컴퓨터공학부 2025-2 사물함 신청") String title,
+        @Schema(description = "이벤트 참여 학과 ID", example = "[1, 2, 3]") List<Long> departmentIds,
+        @Schema(description = "이벤트 시작 시간", example = "2025-08-01T15:00:00") LocalDateTime startAt,
+        @Schema(description = "이벤트 종료 시간", example = "2025-08-01T16:00:00") LocalDateTime endAt,
+        @Schema(description = "이벤트 상태", example = "OPEN") EventStatus status,
+        @Schema(description = "이벤트 게시 여부", example = "true") Boolean publish) {
+
+    public static EventResponse from(Event event) {
+        return new EventResponse(
+                event.getId(),
+                event.getTitle(),
+                event.getEventParticipations().stream()
+                        .map(eventParticipation -> eventParticipation.getDepartment().getId())
+                        .toList(),
+                event.getEventSchedule().getStartAt(),
+                event.getEventSchedule().getEndAt(),
+                event.getEventStatus(),
+                event.getPublish());
+    }
+}

--- a/src/main/java/com/jnulocker/events/application/port/in/response/EventResponse.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/response/EventResponse.java
@@ -10,7 +10,8 @@ import java.util.UUID;
 public record EventResponse(
         @Schema(description = "이벤트 ID", example = "2b0c4f8e-3d2a-4f5b-8c1e-6f7a2d3e4b5a") UUID id,
         @Schema(description = "이벤트 제목", example = "전자컴퓨터공학부 2025-2 사물함 신청") String title,
-        @Schema(description = "이벤트 참여 학과 ID", example = "[1, 2, 3]") List<Long> departmentIds,
+        @Schema(description = "이벤트 참여 학과 목록")
+                List<EventDepartmentResponse> participationDepartments,
         @Schema(description = "이벤트 시작 시간", example = "2025-08-01T15:00:00") LocalDateTime startAt,
         @Schema(description = "이벤트 종료 시간", example = "2025-08-01T16:00:00") LocalDateTime endAt,
         @Schema(description = "이벤트 상태", example = "OPEN") EventStatus status,
@@ -18,13 +19,17 @@ public record EventResponse(
 
     public static EventResponse from(Event event) {
 
-        List<Long> departmentIds =
+        List<EventDepartmentResponse> departmentIds =
                 event.getEventParticipations() == null
                         ? List.of()
                         : event.getEventParticipations().stream()
                                 .map(
                                         eventParticipation ->
-                                                eventParticipation.getDepartment().getId())
+                                                new EventDepartmentResponse(
+                                                        eventParticipation.getDepartment().getId(),
+                                                        eventParticipation
+                                                                .getDepartment()
+                                                                .getName()))
                                 .toList();
 
         return new EventResponse(

--- a/src/main/java/com/jnulocker/events/application/port/in/response/EventResponse.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/response/EventResponse.java
@@ -17,12 +17,20 @@ public record EventResponse(
         @Schema(description = "이벤트 게시 여부", example = "true") Boolean publish) {
 
     public static EventResponse from(Event event) {
+
+        List<Long> departmentIds =
+                event.getEventParticipations() == null
+                        ? List.of()
+                        : event.getEventParticipations().stream()
+                                .map(
+                                        eventParticipation ->
+                                                eventParticipation.getDepartment().getId())
+                                .toList();
+
         return new EventResponse(
                 event.getId(),
                 event.getTitle(),
-                event.getEventParticipations().stream()
-                        .map(eventParticipation -> eventParticipation.getDepartment().getId())
-                        .toList(),
+                departmentIds,
                 event.getEventSchedule().getStartAt(),
                 event.getEventSchedule().getEndAt(),
                 event.getEventStatus(),

--- a/src/main/java/com/jnulocker/events/application/port/out/EventLoadPort.java
+++ b/src/main/java/com/jnulocker/events/application/port/out/EventLoadPort.java
@@ -17,4 +17,6 @@ public interface EventLoadPort {
     Page<Event> getAllEventsByDepartment(Department department, Pageable pageable);
 
     MyEventCustomPage getEventsByParticipationDepartment(Department department, Pageable pageable);
+
+    Optional<Event> getEventsByIdWithEventParticipation(UUID eventId);
 }

--- a/src/main/java/com/jnulocker/events/application/port/out/EventLoadPort.java
+++ b/src/main/java/com/jnulocker/events/application/port/out/EventLoadPort.java
@@ -18,5 +18,5 @@ public interface EventLoadPort {
 
     MyEventCustomPage getEventsByParticipationDepartment(Department department, Pageable pageable);
 
-    Optional<Event> getEventsByIdWithEventParticipation(UUID eventId);
+    Optional<Event> getEventByIdWithEventParticipation(UUID eventId);
 }

--- a/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
+++ b/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
@@ -52,7 +52,7 @@ public class EventQueryService implements EventQuery {
     public EventResponse getEvent(UUID eventId) {
         Event event =
                 eventLoadPort
-                        .getEventsByIdWithEventParticipation(eventId)
+                        .getEventByIdWithEventParticipation(eventId)
                         .orElseThrow(() -> EventNotFoundException.EXCEPTION);
         return EventResponse.from(event);
     }

--- a/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
+++ b/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
@@ -15,6 +15,7 @@ import com.jnulocker.events.domain.Floor;
 import com.jnulocker.events.domain.Locker;
 import com.jnulocker.events.exception.EventNotFoundException;
 import com.jnulocker.events.exception.LockerNotFoundException;
+import com.jnulocker.events.exception.OnlyDepartmentMemberCanSeeEventException;
 import com.jnulocker.member.application.port.in.MemberQuery;
 import com.jnulocker.member.domain.Member;
 import java.util.List;
@@ -23,9 +24,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class EventQueryService implements EventQuery {
 
     private final EventLoadPort eventLoadPort;
@@ -50,10 +53,18 @@ public class EventQueryService implements EventQuery {
 
     @Override
     public EventResponse getEvent(UUID eventId) {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        Member member = memberQuery.findByIdOrThrow(memberId);
+
         Event event =
                 eventLoadPort
                         .getEventByIdWithEventParticipation(eventId)
                         .orElseThrow(() -> EventNotFoundException.EXCEPTION);
+
+        if (!event.isSameDepartment(member.getDepartment())) {
+            throw OnlyDepartmentMemberCanSeeEventException.EXCEPTION;
+        }
+
         return EventResponse.from(event);
     }
 

--- a/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
+++ b/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
@@ -3,6 +3,7 @@ package com.jnulocker.events.application.service;
 import com.jnulocker.auth.security.SecurityUtils;
 import com.jnulocker.events.application.port.in.EventQuery;
 import com.jnulocker.events.application.port.in.response.EventCustomPage;
+import com.jnulocker.events.application.port.in.response.EventResponse;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
 import com.jnulocker.events.application.port.in.response.LockerResponse;
 import com.jnulocker.events.application.port.in.response.MyEventCustomPage;
@@ -45,6 +46,15 @@ public class EventQueryService implements EventQuery {
         Page<Event> events =
                 eventLoadPort.getAllEventsByDepartment(member.getDepartment(), pageable);
         return EventCustomPage.from(events);
+    }
+
+    @Override
+    public EventResponse getEvent(UUID eventId) {
+        Event event =
+                eventLoadPort
+                        .getEventsByIdWithEventParticipation(eventId)
+                        .orElseThrow(() -> EventNotFoundException.EXCEPTION);
+        return EventResponse.from(event);
     }
 
     @Override

--- a/src/main/java/com/jnulocker/events/domain/Event.java
+++ b/src/main/java/com/jnulocker/events/domain/Event.java
@@ -116,13 +116,17 @@ public class Event extends BaseEntity {
     }
 
     public void validateDeletable(Department department) {
-        if (!this.department.equals(department)) {
+        if (!isSameDepartment(department)) {
             throw OnlyManagerCanDeleteEventException.EXCEPTION;
         }
 
         if (eventStatus == EventStatus.OPEN) {
             throw OpenEventCannotBeDeletedException.EXCEPTION;
         }
+    }
+
+    public boolean isSameDepartment(Department department) {
+        return this.department.equals(department);
     }
 
     public void openEvent() {

--- a/src/main/java/com/jnulocker/events/exception/EventErrorCode.java
+++ b/src/main/java/com/jnulocker/events/exception/EventErrorCode.java
@@ -16,6 +16,8 @@ public enum EventErrorCode implements ErrorCode {
     ONLY_MANAGER_CAN_DELETE_EVENT("E006", HttpStatus.FORBIDDEN, "이벤트 관리자만 삭제할 수 있습니다"),
     OPEN_EVENT_CAN_NOT_BE_DELETED("E007", HttpStatus.BAD_REQUEST, "진행중인 이벤트는 삭제할 수 없습니다"),
     ONLY_PARTICIPATION_DEPARTMENT_CAN_REGISTER("E008", HttpStatus.BAD_REQUEST, "참여학과만 신청할 수 있습니다"),
+    ONLY_DEPARTMENT_MEMBER_CAN_SEE_EVENT(
+            "E009", HttpStatus.FORBIDDEN, "주최 학과의 구성원만 이벤트 상세정보를 볼 수 있습니다"),
     ;
 
     private final String code;

--- a/src/main/java/com/jnulocker/events/exception/OnlyDepartmentMemberCanSeeEventException.java
+++ b/src/main/java/com/jnulocker/events/exception/OnlyDepartmentMemberCanSeeEventException.java
@@ -1,0 +1,13 @@
+package com.jnulocker.events.exception;
+
+import com.jnulocker.common.exception.BusinessException;
+
+public class OnlyDepartmentMemberCanSeeEventException extends BusinessException {
+
+    public static final BusinessException EXCEPTION =
+            new OnlyDepartmentMemberCanSeeEventException();
+
+    private OnlyDepartmentMemberCanSeeEventException() {
+        super(EventErrorCode.ONLY_DEPARTMENT_MEMBER_CAN_SEE_EVENT);
+    }
+}

--- a/src/main/java/com/jnulocker/member/application/service/MemberQueryService.java
+++ b/src/main/java/com/jnulocker/member/application/service/MemberQueryService.java
@@ -46,7 +46,6 @@ public class MemberQueryService implements MemberQuery {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public MemberInfoResponse getMemberInfo() {
         Long memberId = SecurityUtils.getCurrentMemberId();
         Member member = findByIdOrThrow(memberId);

--- a/src/main/java/com/jnulocker/member/application/service/MemberQueryService.java
+++ b/src/main/java/com/jnulocker/member/application/service/MemberQueryService.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MemberQueryService implements MemberQuery {
 
     private final MemberLoadPort memberLoadPort;

--- a/src/main/java/com/jnulocker/organization/application/service/OrganizationQueryService.java
+++ b/src/main/java/com/jnulocker/organization/application/service/OrganizationQueryService.java
@@ -13,9 +13,11 @@ import com.jnulocker.organization.exception.OrganizationNotFoundException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class OrganizationQueryService implements OrganizationQuery, DepartmentQuery {
     private final OrganizationLoadPort organizationLoadPort;
     private final DepartmentLoadPort departmentLoadPort;

--- a/src/main/java/com/jnulocker/registration/application/service/RegistrationQueryService.java
+++ b/src/main/java/com/jnulocker/registration/application/service/RegistrationQueryService.java
@@ -14,9 +14,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class RegistrationQueryService implements RegistrationQuery {
 
     private final EventQuery eventQuery;

--- a/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
@@ -9,6 +9,7 @@ import com.jnulocker.common.exception.ErrorResponse;
 import com.jnulocker.events.application.port.in.request.CreateEventRequest;
 import com.jnulocker.events.application.port.in.request.PublishEventRequest;
 import com.jnulocker.events.application.port.in.response.EventCustomPage;
+import com.jnulocker.events.application.port.in.response.EventDepartmentResponse;
 import com.jnulocker.events.application.port.in.response.EventListItem;
 import com.jnulocker.events.application.port.in.response.EventPageable;
 import com.jnulocker.events.application.port.in.response.EventResponse;
@@ -403,7 +404,9 @@ public class EventControllerIntegrationTest {
         // then
         // 자신의 소속 학과가 참여하는 이벤트가 조회되었는지 확인
         assertThat(eventResponse.status()).isEqualTo(EventStatus.OPEN);
-        assertThat(eventResponse.departmentIds()).containsExactly(department.getId());
+        assertThat(eventResponse.participationDepartments())
+                .containsExactly(
+                        new EventDepartmentResponse(department.getId(), department.getName()));
         assertThat(eventResponse.startAt()).isEqualTo(myDepartmentEvent.startAt());
         assertThat(eventResponse.endAt()).isEqualTo(myDepartmentEvent.endAt());
         assertThat(eventResponse.title()).isEqualTo(myDepartmentEvent.title());

--- a/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
@@ -405,6 +405,10 @@ public class EventControllerIntegrationTest {
         // 자신의 소속 학과가 참여하는 이벤트가 조회되었는지 확인
         assertThat(eventResponse.status()).isEqualTo(EventStatus.OPEN);
         assertThat(eventResponse.departmentIds()).containsExactly(department.getId());
+        assertThat(eventResponse.startAt()).isEqualTo(myEvent.startAt());
+        assertThat(eventResponse.endAt()).isEqualTo(myEvent.endAt());
+        assertThat(eventResponse.title()).isEqualTo(myEvent.title());
+        assertThat(eventResponse.publish()).isTrue();
     }
 
     @Test
@@ -430,7 +434,7 @@ public class EventControllerIntegrationTest {
                 .get(EVENT_URL + "/{event-id}", eventId)
                 .then()
                 .log()
-                .all();
+                .ifError();
     }
 
     // 파라미터 제공 메서드

--- a/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
@@ -10,8 +10,10 @@ import com.jnulocker.events.application.port.in.request.CreateEventRequest;
 import com.jnulocker.events.application.port.in.request.PublishEventRequest;
 import com.jnulocker.events.application.port.in.response.EventCustomPage;
 import com.jnulocker.events.application.port.in.response.EventPageable;
+import com.jnulocker.events.application.port.in.response.EventResponse;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
 import com.jnulocker.events.application.port.in.response.MyEventCustomPage;
+import com.jnulocker.events.application.port.in.response.MyEventListItem;
 import com.jnulocker.events.domain.Event;
 import com.jnulocker.events.domain.EventStatus;
 import com.jnulocker.events.exception.EventErrorCode;
@@ -370,6 +372,49 @@ public class EventControllerIntegrationTest {
         assertThat(myEvents.content()).isEmpty();
         assertThat(myEvents.totalElements()).isZero();
         assertThat(myEvents.last()).isTrue();
+    }
+
+    @Test
+    void 이벤트_상세조회가_가능하다() {
+        // given
+        Department department = organizationTestUtil.createCouncilDepartment();
+        Member member = memberTestUtil.createMemberFromRoleWithDepartment(Role.USER, department);
+
+        // 이벤트 생성: 짝수번 사물함은 사용 가능, 홀수번 사물함은 사용 불가능
+        // 15개 중 가능한 사물함 수는 2, 4, 6, 8, 10, 12, 14 (총 7개)
+        eventTestUtil.createEventWithParticipationDepartment(
+                List.of(5, 10), department, EventStatus.OPEN, true);
+
+        // when
+        accessToken = authTestUtil.generateAccessTokenWithMember(member);
+        EventPageable eventPageable = new EventPageable(0, 10, DIRECTION, SORT);
+        MyEventCustomPage myEvents =
+                getMyEventsWithPageable(accessToken, eventPageable)
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .as(MyEventCustomPage.class);
+
+        MyEventListItem myEvent = myEvents.content().getFirst();
+        EventResponse eventResponse =
+                getEventDetail(myEvent.id(), accessToken)
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .as(EventResponse.class);
+
+        // then
+        // 자신의 소속 학과가 참여하는 이벤트가 조회되었는지 확인
+        assertThat(eventResponse.status()).isEqualTo(EventStatus.OPEN);
+        assertThat(eventResponse.departmentIds()).containsExactly(department.getId());
+    }
+
+    private static ValidatableResponse getEventDetail(UUID eventId, String accessToken) {
+        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
+                .when()
+                .get(EVENT_URL + "/{event-id}", eventId)
+                .then()
+                .log()
+                .all();
     }
 
     // 파라미터 제공 메서드

--- a/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
@@ -9,11 +9,11 @@ import com.jnulocker.common.exception.ErrorResponse;
 import com.jnulocker.events.application.port.in.request.CreateEventRequest;
 import com.jnulocker.events.application.port.in.request.PublishEventRequest;
 import com.jnulocker.events.application.port.in.response.EventCustomPage;
+import com.jnulocker.events.application.port.in.response.EventListItem;
 import com.jnulocker.events.application.port.in.response.EventPageable;
 import com.jnulocker.events.application.port.in.response.EventResponse;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
 import com.jnulocker.events.application.port.in.response.MyEventCustomPage;
-import com.jnulocker.events.application.port.in.response.MyEventListItem;
 import com.jnulocker.events.domain.Event;
 import com.jnulocker.events.domain.EventStatus;
 import com.jnulocker.events.exception.EventErrorCode;
@@ -378,7 +378,7 @@ public class EventControllerIntegrationTest {
     void 이벤트_상세조회가_가능하다() {
         // given
         Department department = organizationTestUtil.createCouncilDepartment();
-        Member member = memberTestUtil.createMemberFromRoleWithDepartment(Role.USER, department);
+        Member member = memberTestUtil.createMemberFromRoleWithDepartment(Role.MANAGER, department);
 
         // 이벤트 생성: 짝수번 사물함은 사용 가능, 홀수번 사물함은 사용 불가능
         // 15개 중 가능한 사물함 수는 2, 4, 6, 8, 10, 12, 14 (총 7개)
@@ -387,16 +387,15 @@ public class EventControllerIntegrationTest {
 
         // when
         accessToken = authTestUtil.generateAccessTokenWithMember(member);
-        EventPageable eventPageable = new EventPageable(0, 10, DIRECTION, SORT);
-        MyEventCustomPage myEvents =
-                getMyEventsWithPageable(accessToken, eventPageable)
+        EventCustomPage eventCustomPage =
+                getEvents(0, 10, accessToken)
                         .statusCode(HttpStatus.OK.value())
                         .extract()
-                        .as(MyEventCustomPage.class);
+                        .as(EventCustomPage.class);
 
-        MyEventListItem myEvent = myEvents.content().getFirst();
+        EventListItem myDepartmentEvent = eventCustomPage.content().getFirst();
         EventResponse eventResponse =
-                getEventDetail(myEvent.id(), accessToken)
+                getEventDetail(myDepartmentEvent.id(), accessToken)
                         .statusCode(HttpStatus.OK.value())
                         .extract()
                         .as(EventResponse.class);
@@ -405,9 +404,9 @@ public class EventControllerIntegrationTest {
         // 자신의 소속 학과가 참여하는 이벤트가 조회되었는지 확인
         assertThat(eventResponse.status()).isEqualTo(EventStatus.OPEN);
         assertThat(eventResponse.departmentIds()).containsExactly(department.getId());
-        assertThat(eventResponse.startAt()).isEqualTo(myEvent.startAt());
-        assertThat(eventResponse.endAt()).isEqualTo(myEvent.endAt());
-        assertThat(eventResponse.title()).isEqualTo(myEvent.title());
+        assertThat(eventResponse.startAt()).isEqualTo(myDepartmentEvent.startAt());
+        assertThat(eventResponse.endAt()).isEqualTo(myDepartmentEvent.endAt());
+        assertThat(eventResponse.title()).isEqualTo(myDepartmentEvent.title());
         assertThat(eventResponse.publish()).isTrue();
     }
 

--- a/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
@@ -407,6 +407,22 @@ public class EventControllerIntegrationTest {
         assertThat(eventResponse.departmentIds()).containsExactly(department.getId());
     }
 
+    @Test
+    void 존재하지_않는_이벤트는_상세조회가_불가능하다() {
+        // given
+        UUID nonExistentEventId = UUID.randomUUID();
+
+        // when
+        ErrorResponse errorResponse =
+                getEventDetail(nonExistentEventId, accessToken)
+                        .statusCode(EventErrorCode.EVENT_NOT_FOUND.getHttpStatus().value())
+                        .extract()
+                        .as(ErrorResponse.class);
+
+        // then
+        assertThat(errorResponse.message()).isEqualTo(EventErrorCode.EVENT_NOT_FOUND.getMessage());
+    }
+
     private static ValidatableResponse getEventDetail(UUID eventId, String accessToken) {
         return given().contentType(MediaType.APPLICATION_JSON_VALUE)
                 .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())


### PR DESCRIPTION
### 개요
close #106 

### 작업사항
- 이벤트 상세 조회 API 구현

### 변경로직
- 이벤트 상세 조회 API 구현
- 테스트케이스 작성

### 테스트 결과

<img width="349" alt="image" src="https://github.com/user-attachments/assets/bfafb33a-0407-41a9-b2f3-b1e33604de7d" />

#### 추가된 테스트케이스

<img width="253" alt="image" src="https://github.com/user-attachments/assets/59a3c322-6ee1-40dd-b891-a996be3df3f2" />
<img width="302" alt="image" src="https://github.com/user-attachments/assets/7affd746-14be-4c28-824f-de3258af532e" />


### reference

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
  - 이벤트 상세 정보를 조회할 수 있는 API 엔드포인트가 추가되었습니다.
  - 이벤트 상세 응답 구조와 예시가 문서화되었습니다.
  - 이벤트 상세 조회 시 주최 학과 구성원만 접근 가능하도록 권한 제한이 적용되었습니다.
  - 이벤트 조회 관련 예외 상황이 API 문서에 명확히 명시되었습니다.

- **테스트**
  - 이벤트 상세 조회 기능에 대한 통합 테스트가 추가되었습니다.

- **문서화**
  - 이벤트 미존재 및 권한 부족 시 발생하는 예외 상황이 API 문서에 명시되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->