### PR TITLE
[FIX] 공지사항 목록 조회 API 작성자 필드 올바른 값 할당

### DIFF
--- a/src/main/java/com/jnulocker/announce/application/port/in/response/AnnounceListItem.java
+++ b/src/main/java/com/jnulocker/announce/application/port/in/response/AnnounceListItem.java
@@ -13,7 +13,7 @@ public record AnnounceListItem(
         return new AnnounceListItem(
                 announce.getId(),
                 announce.getTitle(),
-                announce.getContent(),
+                announce.getWriter(),
                 announce.getCreatedAt());
     }
 }

--- a/src/main/java/com/jnulocker/auth/adapter/in/docs/ApproveManagerExceptionDocs.java
+++ b/src/main/java/com/jnulocker/auth/adapter/in/docs/ApproveManagerExceptionDocs.java
@@ -1,8 +1,8 @@
 package com.jnulocker.auth.adapter.in.docs;
 
+import com.jnulocker.auth.exception.DepartmentMismatchAuthorizationException;
 import com.jnulocker.auth.exception.ManagerAuthorizationRequiredException;
 import com.jnulocker.auth.exception.OnlyGuestCanBeManagerException;
-import com.jnulocker.auth.exception.DepartmentMismatchAuthorizationException;
 import com.jnulocker.common.exception.BusinessException;
 import com.jnulocker.common.swagger.ExceptionDoc;
 import com.jnulocker.common.swagger.ExplainError;

--- a/src/main/java/com/jnulocker/auth/exception/DepartmentMismatchAuthorizationException.java
+++ b/src/main/java/com/jnulocker/auth/exception/DepartmentMismatchAuthorizationException.java
@@ -4,7 +4,8 @@ import com.jnulocker.common.exception.BusinessException;
 
 public class DepartmentMismatchAuthorizationException extends BusinessException {
 
-    public static final BusinessException EXCEPTION = new DepartmentMismatchAuthorizationException();
+    public static final BusinessException EXCEPTION =
+            new DepartmentMismatchAuthorizationException();
 
     private DepartmentMismatchAuthorizationException() {
         super(AuthErrorCode.DEPARTMENT_MISMATCH_AUTHORIZATION);

--- a/src/main/java/com/jnulocker/member/domain/Member.java
+++ b/src/main/java/com/jnulocker/member/domain/Member.java
@@ -1,8 +1,8 @@
 package com.jnulocker.member.domain;
 
-import com.jnulocker.auth.exception.OnlyGuestCanBeManagerException;
-import com.jnulocker.auth.exception.ManagerAuthorizationRequiredException;
 import com.jnulocker.auth.exception.DepartmentMismatchAuthorizationException;
+import com.jnulocker.auth.exception.ManagerAuthorizationRequiredException;
+import com.jnulocker.auth.exception.OnlyGuestCanBeManagerException;
 import com.jnulocker.auth.exception.StudentNumberRequiredException;
 import com.jnulocker.common.persistence.BaseEntity;
 import com.jnulocker.organization.domain.Department;

--- a/src/test/java/com/jnulocker/announce/adapter/in/AnnounceControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/announce/adapter/in/AnnounceControllerIntegrationTest.java
@@ -9,6 +9,7 @@ import com.jnulocker.announce.application.port.in.request.CreateAnnounceRequest;
 import com.jnulocker.announce.application.port.in.request.UpdateAnnounceRequest;
 import com.jnulocker.announce.application.port.in.response.AnnounceCustomPage;
 import com.jnulocker.announce.application.port.in.response.AnnounceDetailResponse;
+import com.jnulocker.announce.application.port.in.response.AnnounceListItem;
 import com.jnulocker.announce.application.port.in.response.MyAnnounceCustomPage;
 import com.jnulocker.announce.application.port.in.response.MyAnnounceDetailResponse;
 import com.jnulocker.announce.exception.AnnounceErrorCode;
@@ -88,7 +89,13 @@ public class AnnounceControllerIntegrationTest {
                         .as(AnnounceCustomPage.class);
 
         // 생성된 공지사항이 목록에 포함되어 있는지 확인
-        assertThat(announceCustomPage.content()).hasSize(1);
+        List<AnnounceListItem> content = announceCustomPage.content();
+        AnnounceListItem announceListItem = content.getFirst();
+
+        assertThat(content).hasSize(1);
+        assertThat(announceCustomPage.totalElements()).isEqualTo(1);
+        assertThat(announceListItem.title()).isEqualTo("백도 사물함 신청 안내");
+        assertThat(announceListItem.writer()).isEqualTo("테스트 학과 학생회 별칭");
     }
 
     // 공지사항 목록 조회 테스트
@@ -153,9 +160,17 @@ public class AnnounceControllerIntegrationTest {
 
         // then
         int expectedSize = calculateExpectedSize(createCount, pageSize, page);
-        assertThat(myAnnounceCustomPage.content()).hasSize(expectedSize);
+        List<AnnounceListItem> content = myAnnounceCustomPage.content();
+
+        AnnounceListItem announceListItem = content.getFirst();
+
+        assertThat(content).hasSize(expectedSize);
         assertThat(myAnnounceCustomPage.totalElements()).isEqualTo(createCount);
         assertThat(myAnnounceCustomPage.last()).isEqualTo(expectedLast);
+
+        // 공지사항 제목과 내용이 일치하는지 확인
+        assertThat(announceListItem.title()).isEqualTo("테스트 공지사항");
+        assertThat(announceListItem.writer()).isEqualTo("테스트 학과 학생회 별칭");
     }
 
     @Test

--- a/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
@@ -679,7 +679,7 @@ class AuthControllerIntegrationTest {
         ErrorResponse errorResponse =
                 approveManagerSignup(accessToken, approveRequest)
                         .statusCode(
-                                AuthErrorCode.ONLY_SAME_DEPARTMENT_CAN_APPROVE
+                                AuthErrorCode.DEPARTMENT_MISMATCH_AUTHORIZATION
                                         .getHttpStatus()
                                         .value())
                         .extract()
@@ -687,7 +687,7 @@ class AuthControllerIntegrationTest {
 
         // then
         assertThat(errorResponse.message())
-                .isEqualTo(AuthErrorCode.ONLY_SAME_DEPARTMENT_CAN_APPROVE.getMessage());
+                .isEqualTo(AuthErrorCode.DEPARTMENT_MISMATCH_AUTHORIZATION.getMessage());
     }
 
     @Test
@@ -729,7 +729,7 @@ class AuthControllerIntegrationTest {
         ErrorResponse errorResponse =
                 rejectManagerSignup(accessToken, rejectRequest)
                         .statusCode(
-                                AuthErrorCode.ONLY_SAME_DEPARTMENT_CAN_APPROVE
+                                AuthErrorCode.DEPARTMENT_MISMATCH_AUTHORIZATION
                                         .getHttpStatus()
                                         .value())
                         .extract()
@@ -737,7 +737,7 @@ class AuthControllerIntegrationTest {
 
         // then
         assertThat(errorResponse.message())
-                .isEqualTo(AuthErrorCode.ONLY_SAME_DEPARTMENT_CAN_APPROVE.getMessage());
+                .isEqualTo(AuthErrorCode.DEPARTMENT_MISMATCH_AUTHORIZATION.getMessage());
     }
 
     private ValidatableResponse rejectManagerSignup(


### PR DESCRIPTION
### 개요
close #110 

### 작업사항
- 공지사항 목록 페이지네이션 API `writer` 필드에 `content`가 들어가있어 이를 수정

### 변경로직
- `AnnounceListItem`의 `writer` 필드에 `getContent()` 대신 `getWriter()` 호출
- 테스트코드에서 해당 내용 검증

### 테스트 결과
<img width="379" alt="image" src="https://github.com/user-attachments/assets/3cf663de-e3b0-40a8-8583-cbdbaa0f2289" />


### reference

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 공지사항 목록에 작성자 정보가 올바르게 표시됩니다.
  - 부서가 다른 관리자의 승인/거절 시 올바른 에러 메시지와 코드가 반환됩니다.

- **테스트**
  - 공지사항 및 인증 관련 통합 테스트가 더욱 세밀한 검증을 수행하도록 개선되었습니다.

- **스타일**
  - 일부 코드의 import 구문 및 선언 형식이 정렬 및 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->