### PR TITLE
[FEAT] 로그아웃 API 구현

### DIFF
--- a/src/main/java/com/jnulocker/announce/application/port/in/response/AnnounceDetailResponse.java
+++ b/src/main/java/com/jnulocker/announce/application/port/in/response/AnnounceDetailResponse.java
@@ -14,7 +14,7 @@ public record AnnounceDetailResponse(
         @Schema(description = "등록 일자", example = "2025-08-01T15:00:00") LocalDateTime createdAt,
         @Schema(description = "수정 일자", example = "2025-08-10T15:00:00") LocalDateTime updatedAt,
         @Schema(description = "참여 학과 목록") List<DepartmentResponse> departments) {
-    public static AnnounceDetailResponse of(Announce announce, List<Department> departments) {
+    public static AnnounceDetailResponse from(Announce announce, List<Department> departments) {
         List<DepartmentResponse> departmentResponses =
                 departments.stream().map(DepartmentResponse::from).toList();
         return new AnnounceDetailResponse(

--- a/src/main/java/com/jnulocker/announce/application/service/AnnounceQueryService.java
+++ b/src/main/java/com/jnulocker/announce/application/service/AnnounceQueryService.java
@@ -86,7 +86,7 @@ public class AnnounceQueryService implements AnnounceQuery {
         List<Department> participatingDepartments =
                 announceLoadPort.getParticipationDepartments(announce);
 
-        return AnnounceDetailResponse.of(announce, participatingDepartments);
+        return AnnounceDetailResponse.from(announce, participatingDepartments);
     }
 
     @Override

--- a/src/main/java/com/jnulocker/auth/adapter/in/AuthController.java
+++ b/src/main/java/com/jnulocker/auth/adapter/in/AuthController.java
@@ -119,6 +119,7 @@ public class AuthController implements AuthApi {
         return ResponseEntity.ok().build();
     }
 
+    @Override
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(HttpServletResponse response) {
         logoutCommand.logout();

--- a/src/main/java/com/jnulocker/auth/adapter/in/AuthController.java
+++ b/src/main/java/com/jnulocker/auth/adapter/in/AuthController.java
@@ -1,10 +1,12 @@
 package com.jnulocker.auth.adapter.in;
 
 import static com.jnulocker.auth.util.CookieUtil.addCookieFromAuthToken;
+import static com.jnulocker.auth.util.CookieUtil.clearAuthCookies;
 import static com.jnulocker.auth.util.CookieUtil.getCookieValueFromRefreshToken;
 
 import com.jnulocker.auth.adapter.in.docs.AuthApi;
 import com.jnulocker.auth.application.port.in.LoginCommand;
+import com.jnulocker.auth.application.port.in.LogoutCommand;
 import com.jnulocker.auth.application.port.in.ManagerQuery;
 import com.jnulocker.auth.application.port.in.ManagerSignupCommand;
 import com.jnulocker.auth.application.port.in.ReissueCommand;
@@ -47,6 +49,7 @@ public class AuthController implements AuthApi {
     private final ReissueCommand reissueCommand;
     private final SendEmailCommand sendEmailCommand;
     private final VerifyCodeCommand verifyCodeCommand;
+    private final LogoutCommand logoutCommand;
 
     @Override
     @PostMapping("/users/signup")
@@ -114,5 +117,12 @@ public class AuthController implements AuthApi {
     public ResponseEntity<Void> verify(@Valid @RequestBody VerifyCodeRequest request) {
         verifyCodeCommand.verify(request);
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(HttpServletResponse response) {
+        logoutCommand.logout();
+        clearAuthCookies(response);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/com/jnulocker/auth/adapter/in/AuthController.java
+++ b/src/main/java/com/jnulocker/auth/adapter/in/AuthController.java
@@ -102,7 +102,7 @@ public class AuthController implements AuthApi {
         String refreshToken = getCookieValueFromRefreshToken(request);
         AuthToken authToken = reissueCommand.reissue(refreshToken);
         addCookieFromAuthToken(response, authToken);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
     @Override

--- a/src/main/java/com/jnulocker/auth/adapter/in/docs/AuthApi.java
+++ b/src/main/java/com/jnulocker/auth/adapter/in/docs/AuthApi.java
@@ -65,7 +65,7 @@ public interface AuthApi {
 
     @ApiExceptionExamples(ReissueExceptionDocs.class)
     @Operation(summary = "토큰 재발급", description = "refreshToken을 이용하여 토큰을 재발급합니다.")
-    @ApiResponse(responseCode = "200", description = "토큰 재발급 성공")
+    @ApiResponse(responseCode = "204", description = "토큰 재발급 성공")
     ResponseEntity<Void> reissue(HttpServletRequest request, HttpServletResponse response);
 
     @ApiExceptionExamples(MailSendExceptionDocs.class)
@@ -77,4 +77,8 @@ public interface AuthApi {
     @Operation(summary = "인증 코드 검증", description = "메일 전송에 포함된 인증 코드의 일치 여부를 확인합니다.")
     @ApiResponse(responseCode = "200", description = "메일 인증 성공")
     ResponseEntity<Void> verify(@Valid @RequestBody VerifyCodeRequest request);
+
+    @Operation(summary = "로그아웃", description = "로그아웃합니다.")
+    @ApiResponse(responseCode = "204", description = "로그아웃 성공")
+    ResponseEntity<Void> logout(HttpServletResponse response);
 }

--- a/src/main/java/com/jnulocker/auth/application/port/in/LogoutCommand.java
+++ b/src/main/java/com/jnulocker/auth/application/port/in/LogoutCommand.java
@@ -1,0 +1,5 @@
+package com.jnulocker.auth.application.port.in;
+
+public interface LogoutCommand {
+    void logout();
+}

--- a/src/main/java/com/jnulocker/auth/application/service/AuthCommandService.java
+++ b/src/main/java/com/jnulocker/auth/application/service/AuthCommandService.java
@@ -158,6 +158,7 @@ public class AuthCommandService
     }
 
     @Override
+    @Transactional
     public void logout() {
         Long memberId = SecurityUtils.getCurrentMemberId();
         tokenRepository.deleteById(memberId);

--- a/src/main/java/com/jnulocker/auth/application/service/AuthCommandService.java
+++ b/src/main/java/com/jnulocker/auth/application/service/AuthCommandService.java
@@ -1,6 +1,8 @@
 package com.jnulocker.auth.application.service;
 
+import com.jnulocker.auth.adapter.out.TokenRepository;
 import com.jnulocker.auth.application.port.in.LoginCommand;
+import com.jnulocker.auth.application.port.in.LogoutCommand;
 import com.jnulocker.auth.application.port.in.ManagerSignupCommand;
 import com.jnulocker.auth.application.port.in.ReissueCommand;
 import com.jnulocker.auth.application.port.in.UserSignupCommand;
@@ -31,7 +33,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class AuthCommandService
-        implements UserSignupCommand, ManagerSignupCommand, LoginCommand, ReissueCommand {
+        implements UserSignupCommand,
+                ManagerSignupCommand,
+                LoginCommand,
+                ReissueCommand,
+                LogoutCommand {
     private final AuthenticationManager authenticationManager;
     private final PasswordEncoder passwordEncoder;
     private final MemberQuery memberQuery;
@@ -39,6 +45,7 @@ public class AuthCommandService
     private final DepartmentQuery departmentQuery;
     private final TokenProvider tokenProvider;
     private final RedisUtil redisUtil;
+    private final TokenRepository tokenRepository;
 
     @Override
     @Transactional
@@ -148,6 +155,12 @@ public class AuthCommandService
         Member member = memberQuery.findByIdOrThrow(memberId);
 
         return tokenProvider.createAuthToken(memberId, member.getRole());
+    }
+
+    @Override
+    public void logout() {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        tokenRepository.deleteById(memberId);
     }
 
     public void validateDuplicateEmail(String email) {

--- a/src/main/java/com/jnulocker/auth/application/service/AuthCommandService.java
+++ b/src/main/java/com/jnulocker/auth/application/service/AuthCommandService.java
@@ -140,7 +140,6 @@ public class AuthCommandService
     }
 
     @Override
-    @Transactional
     public AuthToken reissue(String refreshToken) {
         if (refreshToken == null) {
             throw InvalidRefreshTokenException.EXCEPTION;
@@ -158,7 +157,6 @@ public class AuthCommandService
     }
 
     @Override
-    @Transactional
     public void logout() {
         Long memberId = SecurityUtils.getCurrentMemberId();
         tokenRepository.deleteById(memberId);

--- a/src/main/java/com/jnulocker/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/jnulocker/auth/jwt/JwtFilter.java
@@ -45,7 +45,6 @@ public class JwtFilter extends OncePerRequestFilter {
                         "/v1/auth/*/signup",
                         "/v1/auth/login",
                         "/v1/auth/reissue",
-                        "/v1/auth/logout",
                         "/v1/auth/send-email",
                         "/v1/auth/verify",
                         "/swagger-ui/**",

--- a/src/main/java/com/jnulocker/auth/util/CookieUtil.java
+++ b/src/main/java/com/jnulocker/auth/util/CookieUtil.java
@@ -59,4 +59,9 @@ public class CookieUtil {
                 authToken.refreshToken(),
                 Math.toIntExact(authToken.refreshTokenExpiresIn()));
     }
+
+    public static void clearAuthCookies(HttpServletResponse response) {
+        addCookie(response, ACCESS_TOKEN, null, 0);
+        addCookie(response, REFRESH_TOKEN, null, 0);
+    }
 }

--- a/src/main/java/com/jnulocker/config/SecurityConfig.java
+++ b/src/main/java/com/jnulocker/config/SecurityConfig.java
@@ -68,7 +68,6 @@ public class SecurityConfig {
                                         "/v1/auth/*/signup",
                                         "/v1/auth/login",
                                         "/v1/auth/reissue",
-                                        "/v1/auth/logout",
                                         "/v1/auth/send-email",
                                         "/v1/auth/verify")
                                 .permitAll()

--- a/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
@@ -740,6 +740,23 @@ class AuthControllerIntegrationTest {
                 .isEqualTo(AuthErrorCode.DEPARTMENT_MISMATCH_AUTHORIZATION.getMessage());
     }
 
+    @Test
+    void 로그아웃할_수_있다() {
+        // when
+        String accessToken = authTestUtil.generateAccessToken(Role.USER);
+
+        ExtractableResponse<Response> response =
+                logout(accessToken).statusCode(HttpStatus.NO_CONTENT.value()).extract();
+
+        // then
+        Cookies cookies = response.detailedCookies();
+        String accessTokenResponse = getCookieValue(cookies, ACCESS_TOKEN);
+        String refreshTokenResponse = getCookieValue(cookies, REFRESH_TOKEN);
+
+        assertThat(accessTokenResponse).isBlank();
+        assertThat(refreshTokenResponse).isBlank();
+    }
+
     private ValidatableResponse rejectManagerSignup(
             String accessToken, ManagerRejectRequest request) {
         return given().contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -858,6 +875,16 @@ class AuthControllerIntegrationTest {
                 .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
                 .when()
                 .get(AUTH_URL + "/managers/pending")
+                .then()
+                .log()
+                .all();
+    }
+
+    public static ValidatableResponse logout(String accessToken) {
+        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
+                .when()
+                .post(AUTH_URL + "/logout")
                 .then()
                 .log()
                 .all();

--- a/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
@@ -336,7 +336,7 @@ class AuthControllerIntegrationTest {
 
         // when
         ExtractableResponse<Response> response =
-                reissueToken(refreshToken).statusCode(HttpStatus.OK.value()).extract();
+                reissueToken(refreshToken).statusCode(HttpStatus.NO_CONTENT.value()).extract();
 
         // then
         String newAccessToken = getCookieValue(response.detailedCookies(), ACCESS_TOKEN);


### PR DESCRIPTION
### 개요
close #113 

### 작업사항
- 로그아웃 API를 구현하였습니다.

### 변경로직
- reissue API의 응답 본문을 NO_CONTENT로 수정하였습니다.

### 테스트 결과
<img width="400" alt="image" src="https://github.com/user-attachments/assets/d4cb5bfb-0273-477f-9ade-a446e7692803" />

**추가된 테스트케이스**
<img width="120" alt="image" src="https://github.com/user-attachments/assets/8b22375c-56ec-4304-94f0-ed67fe64d7e3" />

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
	- 로그아웃 엔드포인트가 추가되어 인증된 사용자가 로그아웃할 수 있습니다.
- **버그 수정**
	- 토큰 재발급 시 응답 코드가 200(OK)에서 204(No Content)로 변경되었습니다.
- **테스트**
	- 로그아웃 기능에 대한 통합 테스트가 추가되었습니다.
	- 토큰 재발급 테스트가 새로운 응답 코드(204)를 반영하도록 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->