### PR TITLE
[FEAT] 이벤트 상세조회 API 사물함 정보 추가

### DIFF
--- a/src/main/java/com/jnulocker/events/application/port/in/response/EventResponse.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/response/EventResponse.java
@@ -1,5 +1,6 @@
 package com.jnulocker.events.application.port.in.response;
 
+import com.jnulocker.events.application.port.in.request.FloorInfo;
 import com.jnulocker.events.domain.Event;
 import com.jnulocker.events.domain.EventStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -15,10 +16,10 @@ public record EventResponse(
         @Schema(description = "이벤트 시작 시간", example = "2025-08-01T15:00:00") LocalDateTime startAt,
         @Schema(description = "이벤트 종료 시간", example = "2025-08-01T16:00:00") LocalDateTime endAt,
         @Schema(description = "이벤트 상태", example = "OPEN") EventStatus status,
-        @Schema(description = "이벤트 게시 여부", example = "true") Boolean publish) {
+        @Schema(description = "이벤트 게시 여부", example = "true") Boolean publish,
+        @Schema(description = "층 정보 목록") List<FloorInfo> floors) {
 
-    public static EventResponse from(Event event) {
-
+    public static EventResponse from(Event event, List<FloorInfo> floors) {
         List<EventDepartmentResponse> departmentIds =
                 event.getEventParticipations() == null
                         ? List.of()
@@ -39,6 +40,7 @@ public record EventResponse(
                 event.getEventSchedule().getStartAt(),
                 event.getEventSchedule().getEndAt(),
                 event.getEventStatus(),
-                event.getPublish());
+                event.getPublish(),
+                floors);
     }
 }

--- a/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
+++ b/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
@@ -1,7 +1,10 @@
 package com.jnulocker.events.application.service;
 
+import static com.jnulocker.events.infrastructure.mapper.LockerMapper.*;
+
 import com.jnulocker.auth.security.SecurityUtils;
 import com.jnulocker.events.application.port.in.EventQuery;
+import com.jnulocker.events.application.port.in.request.FloorInfo;
 import com.jnulocker.events.application.port.in.response.EventCustomPage;
 import com.jnulocker.events.application.port.in.response.EventResponse;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
@@ -18,8 +21,7 @@ import com.jnulocker.events.exception.LockerNotFoundException;
 import com.jnulocker.events.exception.OnlyDepartmentMemberCanSeeEventException;
 import com.jnulocker.member.application.port.in.MemberQuery;
 import com.jnulocker.member.domain.Member;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -65,7 +67,13 @@ public class EventQueryService implements EventQuery {
             throw OnlyDepartmentMemberCanSeeEventException.EXCEPTION;
         }
 
-        return EventResponse.from(event);
+        // 이벤트에 속한 층과 사물함 정보 조회
+        List<FloorWithLockersResponse> floorWithLockers = getLockersByEventId(eventId);
+
+        // 층 정보를 FloorInfo 형태로 변환 (LockerMapper 사용)
+        List<FloorInfo> floors = toFloorInfos(floorWithLockers);
+
+        return EventResponse.from(event, floors);
     }
 
     @Override

--- a/src/main/java/com/jnulocker/events/infrastructure/mapper/LockerCodeInfo.java
+++ b/src/main/java/com/jnulocker/events/infrastructure/mapper/LockerCodeInfo.java
@@ -1,0 +1,3 @@
+package com.jnulocker.events.infrastructure.mapper;
+
+record LockerCodeInfo(String prefix, Integer number) {}

--- a/src/main/java/com/jnulocker/events/infrastructure/mapper/LockerMapper.java
+++ b/src/main/java/com/jnulocker/events/infrastructure/mapper/LockerMapper.java
@@ -91,7 +91,7 @@ public class LockerMapper {
         }
 
         List<LockerRange> ranges = new ArrayList<>();
-        int start = sortedNumbers.get(0);
+        int start = sortedNumbers.getFirst();
         int prev = start;
 
         for (int i = 1; i < sortedNumbers.size(); i++) {

--- a/src/main/java/com/jnulocker/events/infrastructure/mapper/LockerMapper.java
+++ b/src/main/java/com/jnulocker/events/infrastructure/mapper/LockerMapper.java
@@ -1,0 +1,133 @@
+package com.jnulocker.events.infrastructure.mapper;
+
+import com.jnulocker.events.application.port.in.request.FloorInfo;
+import com.jnulocker.events.application.port.in.request.LockerRange;
+import com.jnulocker.events.application.port.in.request.PrefixInfo;
+import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
+import com.jnulocker.events.application.port.in.response.LockerResponse;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.experimental.UtilityClass;
+
+/** 사물함 정보를 다양한 형태로 변환하는 매퍼 클래스입니다. 주로 사물함 데이터를 API 요청/응답 형식으로 변환하는 기능을 담당합니다. */
+@UtilityClass
+public class LockerMapper {
+
+    /**
+     * 사물함 코드 패턴: prefix-number 또는 number 예: "A-123", "123", "B-456", "789" </br> 정규표현식 설명 -
+     * (?:([A-Za-z]+)-)? : 선택적 접두사 (영문자)와 하이픈 </br> - ([A-Za-zㄱ-ㅣ가-힣]+) : 접두사 (영문자) </br> - - : 하이픈
+     * </br> - ?:(...): 캡쳐하지 않고 그룹화 </br> - ...?: 0회 또는 1회 반복 </br> - 위 내용 해석: 문자와 하이픈을 포함한 접두사가 있거나
+     * 없을 수 있고, 있다면 하이픈을 포함하지 않고 문자만 캡쳐 </br> - (\\d+) : 필수 숫자 부분
+     */
+    private static final Pattern LOCKER_CODE_PATTERN =
+            Pattern.compile("^(?:([A-Za-zㄱ-ㅣ가-힣]+)-)?(\\d+)$");
+
+    /**
+     * FloorWithLockersResponse 목록을 FloorInfo 목록으로 변환합니다. 이 메소드는 사물함 코드를 분석하여 prefix, 숫자 범위를 추출하고
+     * 그룹화합니다.
+     */
+    public static List<FloorInfo> toFloorInfos(List<FloorWithLockersResponse> floorWithLockers) {
+        return floorWithLockers.stream().map(LockerMapper::toFloorInfo).toList();
+    }
+
+    /** 단일 FloorWithLockersResponse를 FloorInfo로 변환합니다. */
+    private static FloorInfo toFloorInfo(FloorWithLockersResponse floorWithLockers) {
+        // 같은 prefix를 가진 사물함을 그룹화
+        Map<String, List<LockerResponse>> lockersByPrefix =
+                groupLockersByPrefix(floorWithLockers.lockers());
+
+        // 각 prefix 그룹을 PrefixInfo로 변환
+        List<PrefixInfo> prefixes =
+                lockersByPrefix.entrySet().stream()
+                        .map(entry -> toPrefixInfo(entry.getKey(), entry.getValue()))
+                        .toList();
+
+        return new FloorInfo(floorWithLockers.floorNumber(), prefixes);
+    }
+
+    /** 사물함 목록을 prefix별로 그룹화합니다. */
+    private static Map<String, List<LockerResponse>> groupLockersByPrefix(
+            List<LockerResponse> lockers) {
+        Map<String, List<LockerResponse>> result = new HashMap<>();
+
+        for (LockerResponse locker : lockers) {
+            // 사물함 코드에서 prefix와 number 추출
+            LockerCodeInfo codeInfo = extractLockerCodeInfo(locker.code());
+
+            // prefix별로 그룹화
+            String prefix = codeInfo.prefix() != null ? codeInfo.prefix() : "";
+            result.computeIfAbsent(prefix, k -> new ArrayList<>()).add(locker);
+        }
+
+        return result;
+    }
+
+    /** prefix와 사물함 목록을 PrefixInfo로 변환합니다. */
+    private static PrefixInfo toPrefixInfo(String prefix, List<LockerResponse> lockers) {
+        // 각 사물함 코드의 숫자 부분 추출
+        List<Integer> numbers =
+                lockers.stream()
+                        .map(locker -> extractLockerCodeInfo(locker.code()).number())
+                        .sorted()
+                        .toList();
+
+        // 연속된 숫자 범위를 LockerRange로 변환
+        List<LockerRange> ranges = toLockerRanges(numbers);
+
+        // prefix가 빈 문자열이면 null로 설정 (사물함 코드가 숫자만 있는 경우)
+        String actualPrefix = prefix.isEmpty() ? null : prefix;
+
+        return new PrefixInfo(actualPrefix, ranges);
+    }
+
+    /** 정렬된 숫자 목록을 연속된 범위로 그룹화하여 LockerRange 목록으로 변환합니다. */
+    private static List<LockerRange> toLockerRanges(List<Integer> sortedNumbers) {
+        if (sortedNumbers.isEmpty()) {
+            return List.of();
+        }
+
+        List<LockerRange> ranges = new ArrayList<>();
+        int start = sortedNumbers.get(0);
+        int prev = start;
+
+        for (int i = 1; i < sortedNumbers.size(); i++) {
+            int current = sortedNumbers.get(i);
+
+            // 연속되지 않은 숫자를 만나면 새로운 범위 시작
+            if (current > prev + 1) {
+                ranges.add(new LockerRange(start, prev));
+                start = current;
+            }
+
+            prev = current;
+        }
+
+        // 마지막 범위 추가
+        ranges.add(new LockerRange(start, prev));
+
+        return ranges;
+    }
+
+    /** 사물함 코드에서 prefix와 숫자 부분을 추출합니다. */
+    private static LockerCodeInfo extractLockerCodeInfo(String code) {
+        Matcher matcher = LOCKER_CODE_PATTERN.matcher(code);
+
+        if (matcher.matches()) {
+            String prefix = matcher.group(1); // prefix (optional)
+            int number = Integer.parseInt(matcher.group(2)); // number
+            return new LockerCodeInfo(prefix, number);
+        }
+
+        // 패턴이 일치하지 않으면 코드 전체를 숫자로 파싱 시도
+        try {
+            return new LockerCodeInfo(null, Integer.parseInt(code));
+        } catch (NumberFormatException e) {
+            // 숫자로 파싱할 수 없으면 prefix가 있는 것으로 간주하고 처리
+            return new LockerCodeInfo(code, 0);
+        }
+    }
+}

--- a/src/main/java/com/jnulocker/events/infrastructure/mapper/LockerMapper.java
+++ b/src/main/java/com/jnulocker/events/infrastructure/mapper/LockerMapper.java
@@ -12,8 +12,10 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
 
 /** 사물함 정보를 다양한 형태로 변환하는 매퍼 클래스입니다. 주로 사물함 데이터를 API 요청/응답 형식으로 변환하는 기능을 담당합니다. */
+@Slf4j
 @UtilityClass
 public class LockerMapper {
 
@@ -127,6 +129,7 @@ public class LockerMapper {
             return new LockerCodeInfo(null, Integer.parseInt(code));
         } catch (NumberFormatException e) {
             // 숫자로 파싱할 수 없으면 prefix가 있는 것으로 간주하고 처리
+            log.warn("유효하지 않은 사물함 코드 형식: {}", code);
             return new LockerCodeInfo(code, 0);
         }
     }

--- a/src/test/java/com/jnulocker/announce/adapter/in/AnnounceControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/announce/adapter/in/AnnounceControllerIntegrationTest.java
@@ -480,7 +480,7 @@ public class AnnounceControllerIntegrationTest {
                 .get(ANNOUNCE_URL)
                 .then()
                 .log()
-                .all();
+                .ifError();
     }
 
     // 유틸 메서드들
@@ -504,7 +504,7 @@ public class AnnounceControllerIntegrationTest {
                 .get(ANNOUNCE_URL + "/me")
                 .then()
                 .log()
-                .all();
+                .ifError();
     }
 
     private Long getLastAnnounceId() {
@@ -534,7 +534,7 @@ public class AnnounceControllerIntegrationTest {
                 .delete(ANNOUNCE_URL + "/{announce-id}", announceId)
                 .then()
                 .log()
-                .all();
+                .ifError();
     }
 
     private ValidatableResponse updateAnnounce(Long announceId, UpdateAnnounceRequest request) {
@@ -545,7 +545,7 @@ public class AnnounceControllerIntegrationTest {
                 .put(ANNOUNCE_URL + "/{announce-id}", announceId)
                 .then()
                 .log()
-                .all();
+                .ifError();
     }
 
     private ValidatableResponse getAnnounce(Long announceId, String accessToken) {
@@ -555,7 +555,7 @@ public class AnnounceControllerIntegrationTest {
                 .get(ANNOUNCE_URL + "/{announce-id}", announceId)
                 .then()
                 .log()
-                .all();
+                .ifError();
     }
 
     private ValidatableResponse getMyAnnounce(Long announceId, String accessToken) {
@@ -565,6 +565,6 @@ public class AnnounceControllerIntegrationTest {
                 .get(ANNOUNCE_URL + "/me/{announce-id}", announceId)
                 .then()
                 .log()
-                .all();
+                .ifError();
     }
 }

--- a/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
@@ -751,7 +751,7 @@ class AuthControllerIntegrationTest {
                 .delete(AUTH_URL + "/managers/approve")
                 .then()
                 .log()
-                .all();
+                .ifError();
     }
 
     private ValidatableResponse approveManagerSignup(
@@ -765,7 +765,7 @@ class AuthControllerIntegrationTest {
                 .post(AUTH_URL + "/managers/approve")
                 .then()
                 .log()
-                .all();
+                .ifError();
     }
 
     public static ValidatableResponse login(LoginRequest request) {
@@ -775,7 +775,7 @@ class AuthControllerIntegrationTest {
                 .post(AUTH_URL + "/login")
                 .then()
                 .log()
-                .all();
+                .ifError();
     }
 
     public static ValidatableResponse reissueToken(String refreshToken) {
@@ -785,7 +785,7 @@ class AuthControllerIntegrationTest {
                 .post(AUTH_URL + "/reissue")
                 .then()
                 .log()
-                .all();
+                .ifError();
     }
 
     private String getCookieValue(Cookies cookies, String name) {
@@ -799,7 +799,7 @@ class AuthControllerIntegrationTest {
                 .post(AUTH_URL + path)
                 .then()
                 .log()
-                .all();
+                .ifError();
     }
 
     private ValidatableResponse signupUser(UserSignupRequest request) {
@@ -827,7 +827,7 @@ class AuthControllerIntegrationTest {
                 .post(AUTH_URL + "/send-email")
                 .then()
                 .log()
-                .all();
+                .ifError();
     }
 
     public static ValidatableResponse verify(VerifyCodeRequest request) {
@@ -837,7 +837,7 @@ class AuthControllerIntegrationTest {
                 .post(AUTH_URL + "/verify")
                 .then()
                 .log()
-                .all();
+                .ifError();
     }
 
     public static String createExpiredToken(Long userId, String secretKey) {
@@ -860,6 +860,6 @@ class AuthControllerIntegrationTest {
                 .get(AUTH_URL + "/managers/pending")
                 .then()
                 .log()
-                .all();
+                .ifError();
     }
 }

--- a/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
@@ -35,6 +35,7 @@ import io.restassured.response.ValidatableResponse;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -687,43 +688,34 @@ public class EventControllerIntegrationTest {
     private Optional<PrefixInfo> findMatchingPrefixInfo(
             List<PrefixInfo> prefixes, String targetPrefix) {
         return prefixes.stream()
-                .filter(
-                        p -> {
-                            if (targetPrefix == null) {
-                                return p.lockerPrefix() == null;
-                            } else {
-                                return targetPrefix.equals(p.lockerPrefix());
-                            }
-                        })
+                .filter(p -> Objects.equals(targetPrefix, p.lockerPrefix()))
                 .findFirst();
     }
 
     /** 지정된 접두사와 범위의 모든 번호가 응답에 포함되어 있는지 확인합니다. */
-    private boolean areAllNumbersInRange(
-            List<PrefixInfo> prefixes, String targetPrefix, int start, int end) {
-        for (int num = start; num <= end; num++) {
-            final int lockerNumber = num;
-            boolean found =
-                    prefixes.stream()
-                            .filter(
-                                    p -> {
-                                        if (targetPrefix == null) {
-                                            return p.lockerPrefix() == null;
-                                        } else {
-                                            return targetPrefix.equals(p.lockerPrefix());
-                                        }
-                                    })
-                            .flatMap(p -> p.ranges().stream())
-                            .anyMatch(
-                                    r ->
-                                            r.lockerStartNumber() <= lockerNumber
-                                                    && lockerNumber <= r.lockerEndNumber());
+    private boolean areAllNumbersInRange(List<PrefixInfo> prefixes, String targetPrefix, int start, int end) {
+        // 접두사가 일치하는 범위들 수집
+        List<LockerRange> ranges = prefixes.stream()
+                .filter(p -> Objects.equals(p.lockerPrefix(), targetPrefix))
+                .flatMap(p -> p.ranges().stream())
+                .sorted(Comparator.comparing(LockerRange::lockerStartNumber))
+                .toList();
 
-            if (!found) {
-                return false;
+        // 현재까지 검증된 범위의 끝점
+        int covered = start - 1;
+
+        // 모든 범위를 순회하며 간격 없이 end까지 커버되는지 확인
+        for (LockerRange range : ranges) {
+            if (range.lockerStartNumber() > covered + 1) {
+                return false; // 커버되지 않는 간격 발견
+            }
+            covered = Math.max(covered, range.lockerEndNumber());
+            if (covered >= end) {
+                return true; // 목표 범위를 모두 커버함
             }
         }
-        return true;
+
+        return covered >= end; // 마지막 범위까지 확인 후 결과
     }
 
     // 다양한 층과 접두사, 범위를 가진 이벤트 생성 요청 준비
@@ -778,7 +770,7 @@ public class EventControllerIntegrationTest {
                 .get(EVENT_URL + "/{event-id}", eventId)
                 .then()
                 .log()
-                .all();
+                .ifError();
     }
 
     // 파라미터 제공 메서드
@@ -889,7 +881,7 @@ public class EventControllerIntegrationTest {
                 .delete(EVENT_URL + "/{event-id}", eventId)
                 .then()
                 .log()
-                .all();
+                .ifError();
     }
 
     private ValidatableResponse publishEvent(UUID eventId, PublishEventRequest request) {
@@ -900,7 +892,7 @@ public class EventControllerIntegrationTest {
                 .put(EVENT_URL + "/{event-id}/publish", eventId)
                 .then()
                 .log()
-                .all();
+                .ifError();
     }
 
     private ValidatableResponse updateEvent(UUID eventId, UpdateEventRequest request) {
@@ -911,6 +903,6 @@ public class EventControllerIntegrationTest {
                 .put(EVENT_URL + "/{event-id}", eventId)
                 .then()
                 .log()
-                .all();
+                .ifError();
     }
 }

--- a/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
@@ -8,6 +8,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.jnulocker.auth.utils.AuthTestUtil;
 import com.jnulocker.common.exception.ErrorResponse;
 import com.jnulocker.events.application.port.in.request.CreateEventRequest;
+import com.jnulocker.events.application.port.in.request.FloorInfo;
+import com.jnulocker.events.application.port.in.request.LockerRange;
+import com.jnulocker.events.application.port.in.request.PrefixInfo;
 import com.jnulocker.events.application.port.in.request.PublishEventRequest;
 import com.jnulocker.events.application.port.in.request.UpdateEventRequest;
 import com.jnulocker.events.application.port.in.response.EventCustomPage;
@@ -29,7 +32,10 @@ import com.jnulocker.organization.utils.OrganizationTestUtil;
 import io.restassured.RestAssured;
 import io.restassured.http.Cookie;
 import io.restassured.response.ValidatableResponse;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
@@ -211,7 +217,7 @@ public class EventControllerIntegrationTest {
         createEvent();
 
         // 생성된 이벤트 조회
-        UUID eventId = getLastEventId();
+        UUID eventId = getFirstEventId();
 
         // when
         deleteEvent(eventId).statusCode(HttpStatus.NO_CONTENT.value());
@@ -249,7 +255,7 @@ public class EventControllerIntegrationTest {
         createEvent();
 
         // 생성된 이벤트 조회
-        UUID eventId = getLastEventId();
+        UUID eventId = getFirstEventId();
 
         // 비조직원으로 로그인
         accessToken = authTestUtil.generateAccessTokenWithAnotherDepartment(Role.MANAGER);
@@ -275,7 +281,7 @@ public class EventControllerIntegrationTest {
         createEvent();
 
         // 생성된 이벤트 조회
-        UUID eventId = getLastEventId();
+        UUID eventId = getFirstEventId();
 
         PublishEventRequest request = new PublishEventRequest(true);
 
@@ -293,7 +299,7 @@ public class EventControllerIntegrationTest {
         createEvent();
 
         // 생성된 이벤트 조회
-        UUID eventId = getLastEventId();
+        UUID eventId = getFirstEventId();
 
         PublishEventRequest request = new PublishEventRequest(false);
 
@@ -315,7 +321,7 @@ public class EventControllerIntegrationTest {
         // 이벤트 생성
         createEventWithDepartment(department);
 
-        UUID eventId = getLastEventId();
+        UUID eventId = getFirstEventId();
 
         // 수정 요청 데이터 생성
         String updateTitle = "수정된 이벤트";
@@ -368,7 +374,7 @@ public class EventControllerIntegrationTest {
         // 이벤트 생성
         createEventWithDepartment(department);
 
-        UUID eventId = getLastEventId();
+        UUID eventId = getFirstEventId();
 
         // 다른 부서의 사용자로 로그인
         accessToken = authTestUtil.generateAccessTokenWithAnotherDepartment(Role.MANAGER);
@@ -559,6 +565,44 @@ public class EventControllerIntegrationTest {
         assertThat(eventResponse.endAt()).isEqualTo(myDepartmentEvent.endAt());
         assertThat(eventResponse.title()).isEqualTo(myDepartmentEvent.title());
         assertThat(eventResponse.publish()).isTrue();
+
+        // 층 정보 검증
+        assertThat(eventResponse.floors()).isNotNull();
+        assertThat(eventResponse.floors()).isNotEmpty();
+
+        // 층 내 사물함 정보 검증
+        eventResponse
+                .floors()
+                .forEach(
+                        floor -> {
+                            assertThat(floor.floorNumber()).isNotNull();
+                            assertThat(floor.prefixes()).isNotEmpty();
+
+                            floor.prefixes()
+                                    .forEach(
+                                            prefix -> {
+                                                assertThat(prefix.ranges()).isNotEmpty();
+
+                                                prefix.ranges()
+                                                        .forEach(
+                                                                range -> {
+                                                                    assertThat(
+                                                                                    range
+                                                                                            .lockerStartNumber())
+                                                                            .isNotNull();
+                                                                    assertThat(
+                                                                                    range
+                                                                                            .lockerEndNumber())
+                                                                            .isNotNull();
+                                                                    assertThat(
+                                                                                    range
+                                                                                            .lockerEndNumber())
+                                                                            .isGreaterThanOrEqualTo(
+                                                                                    range
+                                                                                            .lockerStartNumber());
+                                                                });
+                                            });
+                        });
     }
 
     @Test
@@ -577,6 +621,156 @@ public class EventControllerIntegrationTest {
         assertThat(errorResponse.message()).isEqualTo(EventErrorCode.EVENT_NOT_FOUND.getMessage());
     }
 
+    @Test
+    void 다양한_층과_접두사_범위로_생성된_이벤트_상세조회시_정확히_반환된다() {
+        // given
+        Department department = organizationTestUtil.createCouncilDepartment();
+        Member member = memberTestUtil.createMemberFromRoleWithDepartment(Role.MANAGER, department);
+        accessToken = authTestUtil.generateAccessTokenWithMember(member);
+
+        // 다양한 층과 접두사, 범위를 가진 이벤트 생성 요청 준비
+        CreateEventRequest request = prepareComplexEventRequest(department.getId());
+
+        // 이벤트 생성
+        createCustomEvent(request);
+        UUID eventId = getFirstEventId();
+
+        // when
+        EventResponse eventResponse =
+                getEventDetail(eventId, accessToken)
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .as(EventResponse.class);
+
+        // then
+        // 기본 정보 검증
+        assertThat(eventResponse.title()).isEqualTo(request.title());
+
+        // 층 개수가 일치하는지 검증
+        assertThat(eventResponse.floors()).hasSameSizeAs(request.floors());
+
+        // 층 정보 비교를 위한 정렬
+        List<FloorInfo> requestFloors = new ArrayList<>(request.floors());
+        List<FloorInfo> responseFloors = new ArrayList<>(eventResponse.floors());
+        requestFloors.sort(Comparator.comparing(FloorInfo::floorNumber));
+        responseFloors.sort(Comparator.comparing(FloorInfo::floorNumber));
+
+        // 각 층별로 세부 검증
+        for (int i = 0; i < requestFloors.size(); i++) {
+            FloorInfo requestFloor = requestFloors.get(i);
+            FloorInfo responseFloor = responseFloors.get(i);
+            int floorNumber = requestFloor.floorNumber();
+
+            // 2.1 층 번호 일치 검증
+            assertThat(responseFloor.floorNumber()).isEqualTo(floorNumber);
+
+            // 2.2 각 접두사별 검증
+            for (PrefixInfo requestPrefix : requestFloor.prefixes()) {
+                String prefix = requestPrefix.lockerPrefix();
+
+                // 2.2.1 해당 접두사가 응답에 존재하는지 검증
+                assertThat(findMatchingPrefixInfo(responseFloor.prefixes(), prefix)).isPresent();
+
+                // 2.2.2 모든 사물함 번호 범위가 응답에 포함되어 있는지 검증
+                for (LockerRange requestRange : requestPrefix.ranges()) {
+                    int start = requestRange.lockerStartNumber();
+                    int end = requestRange.lockerEndNumber();
+
+                    assertThat(areAllNumbersInRange(responseFloor.prefixes(), prefix, start, end))
+                            .isTrue();
+                }
+            }
+        }
+    }
+
+    /** 특정 접두사와 일치하는 PrefixInfo를 찾습니다. null 접두사는 null과 일치시킵니다. */
+    private Optional<PrefixInfo> findMatchingPrefixInfo(
+            List<PrefixInfo> prefixes, String targetPrefix) {
+        return prefixes.stream()
+                .filter(
+                        p -> {
+                            if (targetPrefix == null) {
+                                return p.lockerPrefix() == null;
+                            } else {
+                                return targetPrefix.equals(p.lockerPrefix());
+                            }
+                        })
+                .findFirst();
+    }
+
+    /** 지정된 접두사와 범위의 모든 번호가 응답에 포함되어 있는지 확인합니다. */
+    private boolean areAllNumbersInRange(
+            List<PrefixInfo> prefixes, String targetPrefix, int start, int end) {
+        for (int num = start; num <= end; num++) {
+            final int lockerNumber = num;
+            boolean found =
+                    prefixes.stream()
+                            .filter(
+                                    p -> {
+                                        if (targetPrefix == null) {
+                                            return p.lockerPrefix() == null;
+                                        } else {
+                                            return targetPrefix.equals(p.lockerPrefix());
+                                        }
+                                    })
+                            .flatMap(p -> p.ranges().stream())
+                            .anyMatch(
+                                    r ->
+                                            r.lockerStartNumber() <= lockerNumber
+                                                    && lockerNumber <= r.lockerEndNumber());
+
+            if (!found) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // 다양한 층과 접두사, 범위를 가진 이벤트 생성 요청 준비
+    private CreateEventRequest prepareComplexEventRequest(Long departmentId) {
+        // 서로 다른 층, 접두사, 연속/불연속 범위를 포함한 복잡한 이벤트 요청 생성
+
+        // 1층: 접두사 "A"와 "B", 각각 연속적인 범위
+        List<LockerRange> rangesA =
+                List.of(
+                        new LockerRange(1, 5), // A-001 ~ A-005
+                        new LockerRange(10, 15) // A-010 ~ A-015
+                        );
+        List<LockerRange> rangesB =
+                List.of(
+                        new LockerRange(1, 3) // B-001 ~ B-003
+                        );
+        List<PrefixInfo> prefixes1 =
+                List.of(new PrefixInfo("A", rangesA), new PrefixInfo("B", rangesB));
+
+        // 2층: 접두사 없음, 불연속적인 범위
+        List<LockerRange> rangesNoPrefix =
+                List.of(
+                        new LockerRange(101, 103), // 101 ~ 103
+                        new LockerRange(201, 205) // 201 ~ 205
+                        );
+        List<PrefixInfo> prefixes2 = List.of(new PrefixInfo(null, rangesNoPrefix));
+
+        // 3층: 접두사 "X", 단일 범위
+        List<LockerRange> rangesX =
+                List.of(
+                        new LockerRange(50, 55) // X-050 ~ X-055
+                        );
+        List<PrefixInfo> prefixes3 = List.of(new PrefixInfo("X", rangesX));
+
+        List<FloorInfo> floors =
+                List.of(
+                        new FloorInfo(1, prefixes1),
+                        new FloorInfo(2, prefixes2),
+                        new FloorInfo(3, prefixes3));
+
+        return createEventRequestBuilder()
+                .withTitle("다양한 층과 접두사를 가진 이벤트")
+                .withParticipationDepartmentIds(List.of(departmentId))
+                .withFloors(floors)
+                .build();
+    }
+
     private static ValidatableResponse getEventDetail(UUID eventId, String accessToken) {
         return given().contentType(MediaType.APPLICATION_JSON_VALUE)
                 .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
@@ -584,7 +778,7 @@ public class EventControllerIntegrationTest {
                 .get(EVENT_URL + "/{event-id}", eventId)
                 .then()
                 .log()
-                .ifError();
+                .all();
     }
 
     // 파라미터 제공 메서드
@@ -603,7 +797,7 @@ public class EventControllerIntegrationTest {
                 .get(EVENT_URL + "/{event-id}/lockers", eventId)
                 .then()
                 .log()
-                .all();
+                .ifError();
     }
 
     public static ValidatableResponse getEvents(int page, int size, String accessToken) {
@@ -617,7 +811,7 @@ public class EventControllerIntegrationTest {
                 .get(EVENT_URL)
                 .then()
                 .log()
-                .all();
+                .ifError();
     }
 
     public static ValidatableResponse getMyEventsWithPageable(
@@ -639,6 +833,17 @@ public class EventControllerIntegrationTest {
     private void createEvent() {
         Department department = organizationTestUtil.createCouncilDepartment();
         createEventWithDepartment(department);
+    }
+
+    // 커스텀 이벤트 요청으로 이벤트 생성
+    private void createCustomEvent(CreateEventRequest request) {
+        given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
+                .body(request)
+                .when()
+                .post(EVENT_URL)
+                .then()
+                .statusCode(HttpStatus.CREATED.value());
     }
 
     private void createEventWithDepartment(Department department) {
@@ -666,13 +871,13 @@ public class EventControllerIntegrationTest {
         return Math.min(remainingItems, pageSize);
     }
 
-    private UUID getLastEventId() {
+    private UUID getFirstEventId() {
         return getEvents(0, 10, accessToken)
                 .statusCode(HttpStatus.OK.value())
                 .extract()
                 .as(EventCustomPage.class)
                 .content()
-                .getLast()
+                .getFirst()
                 .id();
     }
 

--- a/src/test/java/com/jnulocker/member/adapter/in/MemberControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/member/adapter/in/MemberControllerIntegrationTest.java
@@ -138,6 +138,6 @@ public class MemberControllerIntegrationTest {
                 .get(MEMBER_URL + "/info")
                 .then()
                 .log()
-                .all();
+                .ifError();
     }
 }


### PR DESCRIPTION
### 개요
close #116 

### 작업사항
- 이벤트 상세조회 API 사물함 정보 추가
- 상세조회에서 사물함 정보의 경우 이벤트 수정에서 사용하기 위함이기 때문에 응답 본문을 요청 본문과 일치시켜 관리하기 위해 `FloorInfo` 를 사용했습니다.

### 변경로직
- 이벤트에 대한 사물함 목록 조회
- 사물함 목록을 기반으로 층, 접두사, 사물함 범위를 파싱해 반환

### 테스트 결과
<img width="315" alt="image" src="https://github.com/user-attachments/assets/28bbd984-0eca-4a9d-bf05-0f21b0d87e0d" />

#### 추가된 테스트케이스
<img width="377" alt="image" src="https://github.com/user-attachments/assets/876599a1-fa69-4be9-acf7-2e7c665f52b3" />

### reference

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 이벤트 상세 조회 시 층별 사물함 정보(층, 접두사, 사물함 번호 범위 등)가 포함되어 더 상세한 정보를 확인할 수 있습니다.

- **버그 수정**
    - 이벤트 상세 응답의 층 및 사물함 정보가 누락되지 않고 정확하게 반환됩니다.

- **테스트**
    - 다양한 층, 접두사, 사물함 번호 범위를 가진 이벤트에 대한 상세 조회 통합 테스트가 추가되어 응답의 정확성이 검증됩니다.
    - 테스트 코드 내 이벤트 ID 조회 방식 및 로깅 방식이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->