### PR TITLE
[FEAT] JWT 토큰 응답 본문에 담아 전달

### DIFF
--- a/src/main/java/com/jnulocker/announce/application/port/in/response/AnnounceDetailResponse.java
+++ b/src/main/java/com/jnulocker/announce/application/port/in/response/AnnounceDetailResponse.java
@@ -14,7 +14,7 @@ public record AnnounceDetailResponse(
         @Schema(description = "등록 일자", example = "2025-08-01T15:00:00") LocalDateTime createdAt,
         @Schema(description = "수정 일자", example = "2025-08-10T15:00:00") LocalDateTime updatedAt,
         @Schema(description = "참여 학과 목록") List<DepartmentResponse> departments) {
-    public static AnnounceDetailResponse from(Announce announce, List<Department> departments) {
+    public static AnnounceDetailResponse of(Announce announce, List<Department> departments) {
         List<DepartmentResponse> departmentResponses =
                 departments.stream().map(DepartmentResponse::from).toList();
         return new AnnounceDetailResponse(

--- a/src/main/java/com/jnulocker/announce/application/service/AnnounceQueryService.java
+++ b/src/main/java/com/jnulocker/announce/application/service/AnnounceQueryService.java
@@ -86,7 +86,7 @@ public class AnnounceQueryService implements AnnounceQuery {
         List<Department> participatingDepartments =
                 announceLoadPort.getParticipationDepartments(announce);
 
-        return AnnounceDetailResponse.from(announce, participatingDepartments);
+        return AnnounceDetailResponse.of(announce, participatingDepartments);
     }
 
     @Override

--- a/src/main/java/com/jnulocker/auth/adapter/in/AuthController.java
+++ b/src/main/java/com/jnulocker/auth/adapter/in/AuthController.java
@@ -1,8 +1,8 @@
 package com.jnulocker.auth.adapter.in;
 
+import static com.jnulocker.auth.util.AuthUtil.getRefreshToken;
 import static com.jnulocker.auth.util.CookieUtil.addCookieFromAuthToken;
 import static com.jnulocker.auth.util.CookieUtil.clearAuthCookies;
-import static com.jnulocker.auth.util.CookieUtil.getCookieValueFromRefreshToken;
 
 import com.jnulocker.auth.adapter.in.docs.AuthApi;
 import com.jnulocker.auth.application.port.in.LoginCommand;
@@ -101,7 +101,7 @@ public class AuthController implements AuthApi {
     @Override
     @PostMapping("/reissue")
     public ResponseEntity<Void> reissue(HttpServletRequest request, HttpServletResponse response) {
-        String refreshToken = getCookieValueFromRefreshToken(request);
+        String refreshToken = getRefreshToken(request);
         AuthToken authToken = reissueCommand.reissue(refreshToken);
         addCookieFromAuthToken(response, authToken);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();

--- a/src/main/java/com/jnulocker/auth/adapter/in/AuthController.java
+++ b/src/main/java/com/jnulocker/auth/adapter/in/AuthController.java
@@ -21,6 +21,7 @@ import com.jnulocker.auth.application.port.in.request.SendEmailRequest;
 import com.jnulocker.auth.application.port.in.request.UserSignupRequest;
 import com.jnulocker.auth.application.port.in.request.VerifyCodeRequest;
 import com.jnulocker.auth.application.port.in.response.AuthToken;
+import com.jnulocker.auth.application.port.in.response.AuthTokenResponse;
 import com.jnulocker.auth.application.port.in.response.PendingManagerCustomPage;
 import com.jnulocker.auth.application.port.in.response.PendingManagerPageable;
 import jakarta.servlet.http.HttpServletRequest;
@@ -89,11 +90,12 @@ public class AuthController implements AuthApi {
 
     @Override
     @PostMapping("/login")
-    public ResponseEntity<Void> login(
+    public ResponseEntity<AuthTokenResponse> login(
             @Valid @RequestBody LoginRequest request, HttpServletResponse response) {
         AuthToken authToken = loginCommand.login(request);
         addCookieFromAuthToken(response, authToken);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(
+                AuthTokenResponse.of(authToken.accessToken(), authToken.refreshToken()));
     }
 
     @Override

--- a/src/main/java/com/jnulocker/auth/adapter/in/docs/AuthApi.java
+++ b/src/main/java/com/jnulocker/auth/adapter/in/docs/AuthApi.java
@@ -7,6 +7,7 @@ import com.jnulocker.auth.application.port.in.request.ManagerSignupRequest;
 import com.jnulocker.auth.application.port.in.request.SendEmailRequest;
 import com.jnulocker.auth.application.port.in.request.UserSignupRequest;
 import com.jnulocker.auth.application.port.in.request.VerifyCodeRequest;
+import com.jnulocker.auth.application.port.in.response.AuthTokenResponse;
 import com.jnulocker.auth.application.port.in.response.PendingManagerCustomPage;
 import com.jnulocker.auth.application.port.in.response.PendingManagerPageable;
 import com.jnulocker.common.swagger.ApiExceptionExamples;
@@ -61,7 +62,8 @@ public interface AuthApi {
     @ApiExceptionExamples(LoginExcepitonDocs.class)
     @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다.")
     @ApiResponse(responseCode = "200", description = "로그인 성공")
-    ResponseEntity<Void> login(@RequestBody LoginRequest request, HttpServletResponse response);
+    ResponseEntity<AuthTokenResponse> login(
+            @RequestBody LoginRequest request, HttpServletResponse response);
 
     @ApiExceptionExamples(ReissueExceptionDocs.class)
     @Operation(summary = "토큰 재발급", description = "refreshToken을 이용하여 토큰을 재발급합니다.")

--- a/src/main/java/com/jnulocker/auth/application/port/in/response/AuthTokenResponse.java
+++ b/src/main/java/com/jnulocker/auth/application/port/in/response/AuthTokenResponse.java
@@ -1,0 +1,7 @@
+package com.jnulocker.auth.application.port.in.response;
+
+public record AuthTokenResponse(String accessToken, String refreshToken) {
+    public static AuthTokenResponse of(String accessToken, String refreshToken) {
+        return new AuthTokenResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/jnulocker/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/jnulocker/auth/jwt/JwtFilter.java
@@ -59,14 +59,14 @@ public class JwtFilter extends OncePerRequestFilter {
     }
 
     private static final String MEDIA_TYPE = "application/json; charset=UTF-8";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String path = request.getRequestURI();
-
-        return EXCLUDE_URLS.stream()
-                .anyMatch(pattern -> pathMatcher.match(pattern, path)); // AntPathMatcher를 이용한 매칭
+        return EXCLUDE_URLS.stream().anyMatch(pattern -> pathMatcher.match(pattern, path));
     }
 
     @Override
@@ -74,7 +74,7 @@ public class JwtFilter extends OncePerRequestFilter {
             HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
         try {
-            String accessToken = getCookieValueFromAccessToken(request);
+            String accessToken = getAccessToken(request);
             if (accessToken == null) {
                 throw InvalidAccessTokenException.EXCEPTION;
             }
@@ -94,6 +94,17 @@ public class JwtFilter extends OncePerRequestFilter {
             request.setAttribute("exception", e);
             setErrorResponse(response, AuthErrorCode.FAIL_AUTHENTICATION);
         }
+    }
+
+    private String getAccessToken(HttpServletRequest request) {
+        // Try to get token from Authorization header first
+        String authHeader = request.getHeader(AUTHORIZATION_HEADER);
+        if (authHeader != null && authHeader.startsWith(BEARER_PREFIX)) {
+            return authHeader.substring(BEARER_PREFIX.length()).trim();
+        }
+
+        // Fallback to cookie if header is not present or invalid
+        return getCookieValueFromAccessToken(request);
     }
 
     private void setErrorResponse(HttpServletResponse response, ErrorCode errorCode)

--- a/src/main/java/com/jnulocker/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/jnulocker/auth/jwt/JwtFilter.java
@@ -1,6 +1,6 @@
 package com.jnulocker.auth.jwt;
 
-import static com.jnulocker.auth.util.CookieUtil.getCookieValueFromAccessToken;
+import static com.jnulocker.auth.util.AuthUtil.getAccessToken;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnulocker.auth.exception.AuthErrorCode;
@@ -94,15 +94,6 @@ public class JwtFilter extends OncePerRequestFilter {
             request.setAttribute("exception", e);
             setErrorResponse(response, AuthErrorCode.FAIL_AUTHENTICATION);
         }
-    }
-
-    private String getAccessToken(HttpServletRequest request) {
-        String authHeader = request.getHeader(AUTHORIZATION_HEADER);
-        if (authHeader != null && authHeader.startsWith(BEARER_PREFIX)) {
-            return authHeader.substring(BEARER_PREFIX.length()).trim();
-        }
-
-        return getCookieValueFromAccessToken(request);
     }
 
     private void setErrorResponse(HttpServletResponse response, ErrorCode errorCode)

--- a/src/main/java/com/jnulocker/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/jnulocker/auth/jwt/JwtFilter.java
@@ -97,13 +97,11 @@ public class JwtFilter extends OncePerRequestFilter {
     }
 
     private String getAccessToken(HttpServletRequest request) {
-        // Try to get token from Authorization header first
         String authHeader = request.getHeader(AUTHORIZATION_HEADER);
         if (authHeader != null && authHeader.startsWith(BEARER_PREFIX)) {
             return authHeader.substring(BEARER_PREFIX.length()).trim();
         }
 
-        // Fallback to cookie if header is not present or invalid
         return getCookieValueFromAccessToken(request);
     }
 

--- a/src/main/java/com/jnulocker/auth/util/AuthUtil.java
+++ b/src/main/java/com/jnulocker/auth/util/AuthUtil.java
@@ -1,5 +1,8 @@
 package com.jnulocker.auth.util;
 
+import static com.jnulocker.auth.util.CookieUtil.*;
+import static com.jnulocker.auth.util.CookieUtil.getCookieValueFromAccessToken;
+
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.experimental.UtilityClass;
 
@@ -10,30 +13,24 @@ public class AuthUtil {
     private static final String BEARER_PREFIX = "Bearer ";
 
     public static String getAccessToken(HttpServletRequest request) {
-        String accessToken = CookieUtil.getCookieValueFromAccessToken(request);
-        if (accessToken != null) {
-            return accessToken;
-        }
+        String accessToken = getCookieValueFromAccessToken(request);
 
         String authHeader = request.getHeader(AUTHORIZATION_HEADER);
         if (authHeader != null && authHeader.startsWith(BEARER_PREFIX)) {
-            return authHeader.substring(BEARER_PREFIX.length()).trim();
+            accessToken = authHeader.substring(BEARER_PREFIX.length()).trim();
         }
 
-        return null;
+        return accessToken;
     }
 
     public static String getRefreshToken(HttpServletRequest request) {
-        String refreshToken = CookieUtil.getCookieValueFromRefreshToken(request);
-        if (refreshToken != null) {
-            return refreshToken;
-        }
+        String refreshToken = getCookieValueFromRefreshToken(request);
 
         String authHeader = request.getHeader(AUTHORIZATION_HEADER);
         if (authHeader != null && authHeader.startsWith(BEARER_PREFIX)) {
-            return authHeader.substring(BEARER_PREFIX.length()).trim();
+            refreshToken = authHeader.substring(BEARER_PREFIX.length()).trim();
         }
 
-        return null;
+        return refreshToken;
     }
 }

--- a/src/main/java/com/jnulocker/auth/util/AuthUtil.java
+++ b/src/main/java/com/jnulocker/auth/util/AuthUtil.java
@@ -1,0 +1,39 @@
+package com.jnulocker.auth.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class AuthUtil {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    public static String getAccessToken(HttpServletRequest request) {
+        String accessToken = CookieUtil.getCookieValueFromAccessToken(request);
+        if (accessToken != null) {
+            return accessToken;
+        }
+
+        String authHeader = request.getHeader(AUTHORIZATION_HEADER);
+        if (authHeader != null && authHeader.startsWith(BEARER_PREFIX)) {
+            return authHeader.substring(BEARER_PREFIX.length()).trim();
+        }
+
+        return null;
+    }
+
+    public static String getRefreshToken(HttpServletRequest request) {
+        String refreshToken = CookieUtil.getCookieValueFromRefreshToken(request);
+        if (refreshToken != null) {
+            return refreshToken;
+        }
+
+        String authHeader = request.getHeader(AUTHORIZATION_HEADER);
+        if (authHeader != null && authHeader.startsWith(BEARER_PREFIX)) {
+            return authHeader.substring(BEARER_PREFIX.length()).trim();
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/jnulocker/events/application/port/in/response/EventResponse.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/response/EventResponse.java
@@ -19,7 +19,7 @@ public record EventResponse(
         @Schema(description = "이벤트 게시 여부", example = "true") Boolean publish,
         @Schema(description = "층 정보 목록") List<FloorInfo> floors) {
 
-    public static EventResponse from(Event event, List<FloorInfo> floors) {
+    public static EventResponse of(Event event, List<FloorInfo> floors) {
         List<EventDepartmentResponse> departmentIds =
                 event.getEventParticipations() == null
                         ? List.of()

--- a/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
+++ b/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
@@ -73,7 +73,7 @@ public class EventQueryService implements EventQuery {
         // 층 정보를 FloorInfo 형태로 변환 (LockerMapper 사용)
         List<FloorInfo> floors = toFloorInfos(floorWithLockers);
 
-        return EventResponse.from(event, floors);
+        return EventResponse.of(event, floors);
     }
 
     @Override

--- a/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
@@ -315,9 +315,13 @@ class AuthControllerIntegrationTest {
         Cookies cookies = response.detailedCookies();
         String accessToken = getCookieValue(cookies, ACCESS_TOKEN);
         String refreshToken = getCookieValue(cookies, REFRESH_TOKEN);
+        String accessTokenFromBody = response.jsonPath().getString("accessToken");
+        String refreshTokenFromBody = response.jsonPath().getString("refreshToken");
 
         assertThat(accessToken).isNotBlank();
         assertThat(refreshToken).isNotBlank();
+        assertThat(accessTokenFromBody).isNotBlank();
+        assertThat(refreshTokenFromBody).isNotBlank();
     }
 
     @Test

--- a/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
@@ -693,13 +693,15 @@ public class EventControllerIntegrationTest {
     }
 
     /** 지정된 접두사와 범위의 모든 번호가 응답에 포함되어 있는지 확인합니다. */
-    private boolean areAllNumbersInRange(List<PrefixInfo> prefixes, String targetPrefix, int start, int end) {
+    private boolean areAllNumbersInRange(
+            List<PrefixInfo> prefixes, String targetPrefix, int start, int end) {
         // 접두사가 일치하는 범위들 수집
-        List<LockerRange> ranges = prefixes.stream()
-                .filter(p -> Objects.equals(p.lockerPrefix(), targetPrefix))
-                .flatMap(p -> p.ranges().stream())
-                .sorted(Comparator.comparing(LockerRange::lockerStartNumber))
-                .toList();
+        List<LockerRange> ranges =
+                prefixes.stream()
+                        .filter(p -> Objects.equals(p.lockerPrefix(), targetPrefix))
+                        .flatMap(p -> p.ranges().stream())
+                        .sorted(Comparator.comparing(LockerRange::lockerStartNumber))
+                        .toList();
 
         // 현재까지 검증된 범위의 끝점
         int covered = start - 1;


### PR DESCRIPTION
### 개요
close #119 

### 작업사항
JWT 토큰을 응답 본문에 담아 전달하도록 하였습니다.

### 변경로직
JwtFilter에서 헤더로부터 토큰을 추출하는 방식을 추가하였습니다.

### 테스트 결과
<img width="370" alt="image" src="https://github.com/user-attachments/assets/c6b2d2d7-8803-476f-831d-b4e9e521b043" />

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 로그인 시 인증 토큰(accessToken, refreshToken)이 응답 본문에 포함되어 반환됩니다.
    - 인증 토큰을 요청에서 쿠키뿐 아니라 Authorization 헤더의 Bearer 토큰으로도 추출할 수 있습니다.

- **버그 수정**
    - 없음

- **리팩터**
    - 일부 응답 객체의 정적 팩토리 메서드 명칭이 일관성 있게 변경되었습니다.
    - JWT 필터가 Authorization 헤더의 Bearer 토큰을 우선적으로 인식하도록 개선되었습니다.

- **테스트**
    - 로그인 성공 시 응답 본문에 포함된 토큰 값에 대한 검증이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->