### PR TITLE
[FEAT] 회원탈퇴 API 구현

### DIFF
--- a/src/main/java/com/jnulocker/auth/adapter/in/AuthController.java
+++ b/src/main/java/com/jnulocker/auth/adapter/in/AuthController.java
@@ -131,6 +131,7 @@ public class AuthController implements AuthApi {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
+    @Override
     @DeleteMapping("/withdraw")
     public ResponseEntity<Void> withdraw() {
         withdrawCommand.withdraw();

--- a/src/main/java/com/jnulocker/auth/adapter/in/AuthController.java
+++ b/src/main/java/com/jnulocker/auth/adapter/in/AuthController.java
@@ -13,6 +13,7 @@ import com.jnulocker.auth.application.port.in.ReissueCommand;
 import com.jnulocker.auth.application.port.in.SendEmailCommand;
 import com.jnulocker.auth.application.port.in.UserSignupCommand;
 import com.jnulocker.auth.application.port.in.VerifyCodeCommand;
+import com.jnulocker.auth.application.port.in.WithdrawCommand;
 import com.jnulocker.auth.application.port.in.request.LoginRequest;
 import com.jnulocker.auth.application.port.in.request.ManagerApproveRequest;
 import com.jnulocker.auth.application.port.in.request.ManagerRejectRequest;
@@ -51,6 +52,7 @@ public class AuthController implements AuthApi {
     private final SendEmailCommand sendEmailCommand;
     private final VerifyCodeCommand verifyCodeCommand;
     private final LogoutCommand logoutCommand;
+    private final WithdrawCommand withdrawCommand;
 
     @Override
     @PostMapping("/users/signup")
@@ -126,6 +128,12 @@ public class AuthController implements AuthApi {
     public ResponseEntity<Void> logout(HttpServletResponse response) {
         logoutCommand.logout();
         clearAuthCookies(response);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<Void> withdraw() {
+        withdrawCommand.withdraw();
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/com/jnulocker/auth/adapter/in/docs/AuthApi.java
+++ b/src/main/java/com/jnulocker/auth/adapter/in/docs/AuthApi.java
@@ -84,6 +84,7 @@ public interface AuthApi {
     @ApiResponse(responseCode = "204", description = "로그아웃 성공")
     ResponseEntity<Void> logout(HttpServletResponse response);
 
+    @ApiExceptionExamples(WithdrawExceptionDocs.class)
     @Operation(summary = "회원 탈퇴", description = "회원 탈퇴합니다.")
     @ApiResponse(responseCode = "204", description = "회원 탈퇴 성공")
     ResponseEntity<Void> withdraw();

--- a/src/main/java/com/jnulocker/auth/adapter/in/docs/AuthApi.java
+++ b/src/main/java/com/jnulocker/auth/adapter/in/docs/AuthApi.java
@@ -83,4 +83,8 @@ public interface AuthApi {
     @Operation(summary = "로그아웃", description = "로그아웃합니다.")
     @ApiResponse(responseCode = "204", description = "로그아웃 성공")
     ResponseEntity<Void> logout(HttpServletResponse response);
+
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴합니다.")
+    @ApiResponse(responseCode = "204", description = "회원 탈퇴 성공")
+    ResponseEntity<Void> withdraw();
 }

--- a/src/main/java/com/jnulocker/auth/adapter/in/docs/WithdrawExceptionDocs.java
+++ b/src/main/java/com/jnulocker/auth/adapter/in/docs/WithdrawExceptionDocs.java
@@ -1,0 +1,17 @@
+package com.jnulocker.auth.adapter.in.docs;
+
+import com.jnulocker.common.exception.BusinessException;
+import com.jnulocker.common.swagger.ExceptionDoc;
+import com.jnulocker.common.swagger.ExplainError;
+import com.jnulocker.common.swagger.SwaggerExceptionDoc;
+import com.jnulocker.member.exception.MemberNotFoundException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@ExceptionDoc
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class WithdrawExceptionDocs implements SwaggerExceptionDoc {
+
+    @ExplainError("회원 정보를 조회할 수 없을 때 발생하는 예외입니다.")
+    public static final BusinessException 회원_정보를_조회할_수_없을_때 = MemberNotFoundException.EXCEPTION;
+}

--- a/src/main/java/com/jnulocker/auth/application/port/in/WithdrawCommand.java
+++ b/src/main/java/com/jnulocker/auth/application/port/in/WithdrawCommand.java
@@ -1,0 +1,6 @@
+package com.jnulocker.auth.application.port.in;
+
+public interface WithdrawCommand {
+
+    void withdraw();
+}

--- a/src/main/java/com/jnulocker/auth/application/service/AuthCommandService.java
+++ b/src/main/java/com/jnulocker/auth/application/service/AuthCommandService.java
@@ -6,6 +6,7 @@ import com.jnulocker.auth.application.port.in.LogoutCommand;
 import com.jnulocker.auth.application.port.in.ManagerSignupCommand;
 import com.jnulocker.auth.application.port.in.ReissueCommand;
 import com.jnulocker.auth.application.port.in.UserSignupCommand;
+import com.jnulocker.auth.application.port.in.WithdrawCommand;
 import com.jnulocker.auth.application.port.in.request.LoginRequest;
 import com.jnulocker.auth.application.port.in.request.ManagerApproveRequest;
 import com.jnulocker.auth.application.port.in.request.ManagerRejectRequest;
@@ -22,6 +23,7 @@ import com.jnulocker.member.application.port.in.MemberQuery;
 import com.jnulocker.member.domain.Member;
 import com.jnulocker.organization.application.port.in.DepartmentQuery;
 import com.jnulocker.organization.domain.Department;
+import com.jnulocker.registration.application.port.out.RegistrationRecordPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -37,7 +39,8 @@ public class AuthCommandService
                 ManagerSignupCommand,
                 LoginCommand,
                 ReissueCommand,
-                LogoutCommand {
+                LogoutCommand,
+                WithdrawCommand {
     private final AuthenticationManager authenticationManager;
     private final PasswordEncoder passwordEncoder;
     private final MemberQuery memberQuery;
@@ -46,6 +49,7 @@ public class AuthCommandService
     private final TokenProvider tokenProvider;
     private final RedisUtil redisUtil;
     private final TokenRepository tokenRepository;
+    private final RegistrationRecordPort registrationRecordPort;
 
     @Override
     @Transactional
@@ -119,11 +123,7 @@ public class AuthCommandService
 
         approver.validateManagerApproval(rejectee.getDepartment());
 
-        // refreshToken 삭제
-        tokenProvider.deleteRefreshTokenById(rejectee.getId());
-
-        // reject는 가입 거부이므로 회원 삭제
-        memberCommand.delete(rejectee);
+        deleteMember(rejectee);
     }
 
     @Override
@@ -166,5 +166,24 @@ public class AuthCommandService
         if (memberQuery.existsByEmail(email)) {
             throw UserAlreadyExistException.EXCEPTION;
         }
+    }
+
+    @Override
+    @Transactional
+    public void withdraw() {
+        Long memberId = SecurityUtils.getCurrentMemberId();
+        Member member = memberQuery.findByIdOrThrow(memberId);
+        deleteMember(member);
+    }
+
+    private void deleteMember(Member member) {
+        // RefreshToken 삭제
+        tokenProvider.deleteRefreshTokenById(member.getId());
+
+        // 신청 기록 삭제: 사물함 available 상태로 변경
+        registrationRecordPort.deleteAllByMember(member);
+
+        // 회원 삭제
+        memberCommand.delete(member);
     }
 }

--- a/src/main/java/com/jnulocker/auth/application/service/AuthCommandService.java
+++ b/src/main/java/com/jnulocker/auth/application/service/AuthCommandService.java
@@ -23,7 +23,7 @@ import com.jnulocker.member.application.port.in.MemberQuery;
 import com.jnulocker.member.domain.Member;
 import com.jnulocker.organization.application.port.in.DepartmentQuery;
 import com.jnulocker.organization.domain.Department;
-import com.jnulocker.registration.application.port.out.RegistrationRecordPort;
+import com.jnulocker.registration.application.port.in.RegistrationCommand;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -49,7 +49,7 @@ public class AuthCommandService
     private final TokenProvider tokenProvider;
     private final RedisUtil redisUtil;
     private final TokenRepository tokenRepository;
-    private final RegistrationRecordPort registrationRecordPort;
+    private final RegistrationCommand registrationCommand;
 
     @Override
     @Transactional
@@ -181,7 +181,7 @@ public class AuthCommandService
         tokenProvider.deleteRefreshTokenById(member.getId());
 
         // 신청 기록 삭제: 사물함 available 상태로 변경
-        registrationRecordPort.deleteAllByMember(member);
+        registrationCommand.deleteAllByMember(member);
 
         // 회원 삭제
         memberCommand.delete(member);

--- a/src/main/java/com/jnulocker/registration/adapter/out/RegistrationPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/registration/adapter/out/RegistrationPersistenceAdapter.java
@@ -1,9 +1,11 @@
 package com.jnulocker.registration.adapter.out;
 
 import com.jnulocker.common.annotation.PersistenceAdapter;
+import com.jnulocker.member.domain.Member;
 import com.jnulocker.registration.application.port.out.RegistrationLoadPort;
 import com.jnulocker.registration.application.port.out.RegistrationRecordPort;
 import com.jnulocker.registration.domain.Registration;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -40,5 +42,17 @@ public class RegistrationPersistenceAdapter
     @Override
     public Optional<Registration> getRegistrationByMemberIdAndEventId(Long memberId, UUID eventId) {
         return registrationRepository.findByMemberIdAndLocker_Floor_EventId(memberId, eventId);
+    }
+
+    @Override
+    public void deleteAllByMember(Member member) {
+        List<Registration> registrations = registrationRepository.findAllByMember(member);
+        for (Registration registration : registrations) {
+            // Locker를 다시 사용가능 상태로 변경
+            registration.getLocker().markAsAvailable();
+        }
+
+        // Registration 삭제
+        registrationRepository.deleteAllByMember(member);
     }
 }

--- a/src/main/java/com/jnulocker/registration/adapter/out/RegistrationPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/registration/adapter/out/RegistrationPersistenceAdapter.java
@@ -45,14 +45,12 @@ public class RegistrationPersistenceAdapter
     }
 
     @Override
-    public void deleteAllByMember(Member member) {
-        List<Registration> registrations = registrationRepository.findAllByMember(member);
-        for (Registration registration : registrations) {
-            // Locker를 다시 사용가능 상태로 변경
-            registration.getLocker().markAsAvailable();
-        }
+    public List<Registration> getAllByMember(Member member) {
+        return registrationRepository.findAllByMember(member);
+    }
 
-        // Registration 삭제
+    @Override
+    public void deleteAllByMember(Member member) {
         registrationRepository.deleteAllByMember(member);
     }
 }

--- a/src/main/java/com/jnulocker/registration/adapter/out/RegistrationRepository.java
+++ b/src/main/java/com/jnulocker/registration/adapter/out/RegistrationRepository.java
@@ -1,7 +1,9 @@
 package com.jnulocker.registration.adapter.out;
 
 import com.jnulocker.events.domain.Event;
+import com.jnulocker.member.domain.Member;
 import com.jnulocker.registration.domain.Registration;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -26,4 +28,9 @@ public interface RegistrationRepository extends JpaRepository<Registration, Long
     Optional<Registration> findByMemberIdAndLocker_Floor_EventId(Long memberId, UUID eventId);
 
     void deleteAllByLocker_Floor_Event(Event event);
+
+    @EntityGraph(attributePaths = {"locker"})
+    List<Registration> findAllByMember(Member member);
+
+    void deleteAllByMember(Member member);
 }

--- a/src/main/java/com/jnulocker/registration/application/port/in/RegistrationCommand.java
+++ b/src/main/java/com/jnulocker/registration/application/port/in/RegistrationCommand.java
@@ -1,5 +1,6 @@
 package com.jnulocker.registration.application.port.in;
 
+import com.jnulocker.member.domain.Member;
 import com.jnulocker.registration.application.port.in.request.RegisterForEventRequest;
 import java.util.UUID;
 
@@ -7,4 +8,6 @@ public interface RegistrationCommand {
     void registerForEvent(UUID eventId, RegisterForEventRequest request);
 
     void cancelMyRegistration(UUID eventId);
+
+    void deleteAllByMember(Member member);
 }

--- a/src/main/java/com/jnulocker/registration/application/port/out/RegistrationLoadPort.java
+++ b/src/main/java/com/jnulocker/registration/application/port/out/RegistrationLoadPort.java
@@ -1,6 +1,8 @@
 package com.jnulocker.registration.application.port.out;
 
+import com.jnulocker.member.domain.Member;
 import com.jnulocker.registration.domain.Registration;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -13,4 +15,6 @@ public interface RegistrationLoadPort {
     Page<Registration> getRegistrationsByEventId(UUID eventId, Pageable pageable);
 
     Optional<Registration> getRegistrationByMemberIdAndEventId(Long memberId, UUID eventId);
+
+    List<Registration> getAllByMember(Member member);
 }

--- a/src/main/java/com/jnulocker/registration/application/port/out/RegistrationRecordPort.java
+++ b/src/main/java/com/jnulocker/registration/application/port/out/RegistrationRecordPort.java
@@ -1,5 +1,6 @@
 package com.jnulocker.registration.application.port.out;
 
+import com.jnulocker.member.domain.Member;
 import com.jnulocker.registration.domain.Registration;
 
 public interface RegistrationRecordPort {
@@ -7,4 +8,6 @@ public interface RegistrationRecordPort {
     void save(Registration registration);
 
     void delete(Registration registration);
+
+    void deleteAllByMember(Member member);
 }

--- a/src/main/java/com/jnulocker/registration/application/service/RegistrationCommandService.java
+++ b/src/main/java/com/jnulocker/registration/application/service/RegistrationCommandService.java
@@ -14,6 +14,7 @@ import com.jnulocker.registration.application.port.out.RegistrationRecordPort;
 import com.jnulocker.registration.domain.Registration;
 import com.jnulocker.registration.exception.RegistrationAlreadyExistsException;
 import com.jnulocker.registration.exception.RegistrationNotFoundException;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -64,5 +65,19 @@ public class RegistrationCommandService implements RegistrationCommand {
         locker.markAsAvailable();
 
         registrationRecordPort.delete(registration);
+    }
+
+    @Override
+    @Transactional
+    public void deleteAllByMember(Member member) {
+        // 해당 회원의 모든 등록 정보 삭제
+        List<Registration> registrations = registrationLoadPort.getAllByMember(member);
+
+        for (Registration registration : registrations) {
+            Locker locker = registration.getLocker();
+            locker.markAsAvailable(); // 사물함을 사용 가능 상태로 변경
+        }
+
+        registrationRecordPort.deleteAllByMember(member);
     }
 }

--- a/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
@@ -898,7 +898,6 @@ class AuthControllerIntegrationTest {
     }
 
     @Test
-    @DisplayName("여러 사물함 신청 후 회원탈퇴하면 모든 Registration이 삭제되고 Locker들이 사용가능 상태가 된다")
     void 여러_사물함_신청_후_회원탈퇴하면_모든_Registration이_삭제되고_Locker들이_사용가능_상태가_된다() {
         // given
         List<Integer> lockersPerFloor = Arrays.asList(5, 5);
@@ -955,7 +954,6 @@ class AuthControllerIntegrationTest {
     }
 
     @Test
-    @DisplayName("인증되지 않은 사용자는 회원탈퇴할 수 없다")
     void 인증되지_않은_사용자는_회원탈퇴할_수_없다() {
         // given
         String invalidToken = "invalid.token.value";

--- a/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
@@ -4,6 +4,9 @@ import static auth.application.port.in.request.ManagerSignupRequestTestDataBuild
 import static auth.application.port.in.request.SendEmailRequestTestDataBuilder.sendEmailRequestBuilder;
 import static auth.application.port.in.request.UserSignupRequestTestDataBuilder.userSignupRequestBuilder;
 import static auth.application.port.in.request.VerifyCodeRequestTestDataBuilder.verifyCodeRequestBuilder;
+import static com.jnulocker.events.adapter.in.EventControllerIntegrationTest.getEventLockers;
+import static com.jnulocker.registration.adapter.in.RegistrationControllerIntegrationTest.createRequestForAvailableLocker;
+import static com.jnulocker.registration.adapter.in.RegistrationControllerIntegrationTest.registerForEvent;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThatList;
@@ -23,6 +26,12 @@ import com.jnulocker.auth.jwt.exception.JwtErrorCode;
 import com.jnulocker.auth.utils.AuthTestUtil;
 import com.jnulocker.common.exception.ErrorResponse;
 import com.jnulocker.common.util.RedisUtil;
+import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
+import com.jnulocker.events.domain.Event;
+import com.jnulocker.events.domain.EventStatus;
+import com.jnulocker.events.domain.Locker;
+import com.jnulocker.events.utils.EventTestUtil;
+import com.jnulocker.events.utils.LockerEventContext;
 import com.jnulocker.member.adapter.out.MemberRepository;
 import com.jnulocker.member.domain.Member;
 import com.jnulocker.member.domain.Role;
@@ -31,6 +40,10 @@ import com.jnulocker.member.utils.MemberTestUtil;
 import com.jnulocker.organization.domain.Department;
 import com.jnulocker.organization.exception.DepartmentErrorCode;
 import com.jnulocker.organization.utils.OrganizationTestUtil;
+import com.jnulocker.registration.adapter.out.RegistrationRepository;
+import com.jnulocker.registration.application.port.in.request.RegisterForEventRequest;
+import com.jnulocker.registration.domain.Registration;
+import com.jnulocker.registration.utils.RegistrationTestUtil;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import io.restassured.RestAssured;
@@ -39,7 +52,10 @@ import io.restassured.http.Cookies;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -70,9 +86,15 @@ class AuthControllerIntegrationTest {
 
     @Autowired private TokenRepository tokenRepository;
 
+    @Autowired private RegistrationRepository registrationRepository;
+
     @Autowired private MemberTestUtil memberTestUtil;
 
     @Autowired private OrganizationTestUtil organizationTestUtil;
+
+    @Autowired private EventTestUtil eventTestUtil;
+
+    @Autowired private RegistrationTestUtil registrationTestUtil;
 
     @Autowired private RedisUtil redisUtil;
 
@@ -91,8 +113,10 @@ class AuthControllerIntegrationTest {
 
     @AfterEach
     void tearDown() {
-        memberRepository.deleteAll();
         tokenRepository.deleteAll();
+        registrationTestUtil.deleteAll();
+        memberRepository.deleteAll(); // Member를 먼저 삭제 (Department 참조)
+        eventTestUtil.deleteAll(); // Event, Department, Organization 삭제
         redisUtil.deleteAll();
     }
 
@@ -761,6 +785,188 @@ class AuthControllerIntegrationTest {
         assertThat(refreshTokenResponse).isBlank();
     }
 
+    @Test
+    void USER는_회원탈퇴할_수_있다() {
+        // given
+        Department department = organizationTestUtil.createCouncilDepartment();
+        UserSignupRequest signupRequest =
+                userSignupRequestBuilder().withDepartmentId(department.getId()).build();
+        signupUser(signupRequest).statusCode(HttpStatus.CREATED.value());
+
+        LoginRequest loginRequest =
+                new LoginRequest(signupRequest.email(), signupRequest.password());
+        ExtractableResponse<Response> loginResponse =
+                login(loginRequest).statusCode(HttpStatus.OK.value()).extract();
+        String accessToken = getCookieValue(loginResponse.detailedCookies(), ACCESS_TOKEN);
+
+        // 회원 존재 확인
+        boolean memberExistsBefore = memberRepository.existsByEmail(signupRequest.email());
+        assertThat(memberExistsBefore).isTrue();
+
+        // when
+        withdraw(accessToken).statusCode(HttpStatus.NO_CONTENT.value());
+
+        // then
+        boolean memberExistsAfter = memberRepository.existsByEmail(signupRequest.email());
+        assertThat(memberExistsAfter).isFalse();
+    }
+
+    @Test
+    void MANAGER는_회원탈퇴할_수_있다() {
+        // given
+        Department department = organizationTestUtil.createCouncilDepartment();
+        ManagerSignupRequest signupRequest =
+                managerSignupRequestBuilder().withDepartmentId(department.getId()).build();
+        signupManager(signupRequest).statusCode(HttpStatus.CREATED.value());
+
+        Member member = memberTestUtil.findMemberByEmail(signupRequest.email());
+        String approverToken =
+                authTestUtil.generateAccessTokenWithDepartment(Role.MANAGER, department);
+
+        // 관리자 승인
+        ManagerApproveRequest approveRequest = new ManagerApproveRequest(member.getId());
+        approveManagerSignup(approverToken, approveRequest)
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        // 로그인 후 탈퇴
+        LoginRequest loginRequest =
+                new LoginRequest(signupRequest.email(), signupRequest.password());
+        ExtractableResponse<Response> loginResponse =
+                login(loginRequest).statusCode(HttpStatus.OK.value()).extract();
+        String accessToken = getCookieValue(loginResponse.detailedCookies(), ACCESS_TOKEN);
+
+        // 회원 존재 확인
+        boolean memberExistsBefore = memberRepository.existsByEmail(signupRequest.email());
+        assertThat(memberExistsBefore).isTrue();
+
+        // when
+        withdraw(accessToken).statusCode(HttpStatus.NO_CONTENT.value());
+
+        // then
+        boolean memberExistsAfter = memberRepository.existsByEmail(signupRequest.email());
+        assertThat(memberExistsAfter).isFalse();
+    }
+
+    @Test
+    void 사물함_신청_후_회원탈퇴하면_Registration이_삭제되고_Locker가_사용가능_상태가_된다() {
+        // given
+        List<Integer> lockersPerFloor = Arrays.asList(5, 5);
+        LockerEventContext context =
+                eventTestUtil.setUpLockerEventForRegistration(
+                        lockersPerFloor, Role.USER, EventStatus.OPEN, true);
+
+        Event event = context.event();
+        Member member = context.member();
+        String accessToken = context.accessToken();
+
+        // 사물함 조회
+        List<FloorWithLockersResponse> floors =
+                getEventLockers(event.getId(), accessToken)
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .jsonPath()
+                        .getList(".", FloorWithLockersResponse.class);
+        Long lockerId = floors.getFirst().lockers().get(1).lockerId();
+
+        // 사물함 신청
+        RegisterForEventRequest registerRequest = new RegisterForEventRequest(lockerId);
+        registerForEvent(event.getId(), registerRequest, accessToken)
+                .statusCode(HttpStatus.CREATED.value());
+
+        // 신청된 Registration과 Locker 상태 확인
+        Optional<Registration> registrationBefore =
+                registrationRepository.findByMemberIdAndLocker_Floor_EventId(
+                        member.getId(), event.getId());
+        assertThat(registrationBefore).isPresent();
+
+        Locker lockerBefore = registrationBefore.get().getLocker();
+        assertThat(lockerBefore.getAvailable()).isFalse(); // 신청으로 인해 사용불가 상태
+
+        // when
+        withdraw(accessToken).statusCode(HttpStatus.NO_CONTENT.value());
+
+        // then
+        // 회원 삭제 확인
+        boolean memberExists = memberRepository.existsById(member.getId());
+        assertThat(memberExists).isFalse();
+
+        // Registration 삭제 확인
+        Optional<Registration> registrationAfter =
+                registrationRepository.findByMemberIdAndLocker_Floor_EventId(
+                        member.getId(), event.getId());
+        assertThat(registrationAfter).isNotPresent();
+    }
+
+    @Test
+    @DisplayName("여러 사물함 신청 후 회원탈퇴하면 모든 Registration이 삭제되고 Locker들이 사용가능 상태가 된다")
+    void 여러_사물함_신청_후_회원탈퇴하면_모든_Registration이_삭제되고_Locker들이_사용가능_상태가_된다() {
+        // given
+        List<Integer> lockersPerFloor = Arrays.asList(5, 5);
+
+        // 첫 번째 이벤트 생성
+        LockerEventContext context =
+                eventTestUtil.setUpLockerEventForRegistration(
+                        lockersPerFloor, Role.USER, EventStatus.OPEN, true);
+
+        Event event1 = context.event();
+        Department department = context.department();
+        Member member = context.member();
+        String accessToken = context.accessToken();
+
+        // 두 번째 이벤트 생성 (같은 멤버)
+        Event event2 =
+                eventTestUtil.createEventWithParticipationDepartment(
+                        lockersPerFloor, department, EventStatus.OPEN, true);
+
+        RegisterForEventRequest registerRequest1 =
+                createRequestForAvailableLocker(event1, accessToken);
+        RegisterForEventRequest registerRequest2 =
+                createRequestForAvailableLocker(event2, accessToken);
+
+        // 첫 번째 이벤트에 사물함 신청
+        registerForEvent(event1.getId(), registerRequest1, accessToken)
+                .statusCode(HttpStatus.CREATED.value());
+
+        // 두 번째 이벤트에 사물함 신청
+        registerForEvent(event2.getId(), registerRequest2, accessToken)
+                .statusCode(HttpStatus.CREATED.value());
+
+        // 신청 확인
+        List<Registration> registrationsBefore =
+                registrationRepository.findAll().stream()
+                        .filter(r -> r.getMember().getId().equals(member.getId()))
+                        .toList();
+        assertThatList(registrationsBefore).hasSize(2);
+
+        // when
+        withdraw(accessToken).statusCode(HttpStatus.NO_CONTENT.value());
+
+        // then
+        // 모든 Registration 삭제 확인
+        List<Registration> registrationsAfter =
+                registrationRepository.findAll().stream()
+                        .filter(r -> r.getMember().getId().equals(member.getId()))
+                        .toList();
+        assertThatList(registrationsAfter).isEmpty();
+
+        // 회원 삭제 확인
+        boolean memberExists = memberRepository.existsById(member.getId());
+        assertThat(memberExists).isFalse();
+    }
+
+    @Test
+    @DisplayName("인증되지 않은 사용자는 회원탈퇴할 수 없다")
+    void 인증되지_않은_사용자는_회원탈퇴할_수_없다() {
+        // given
+        String invalidToken = "invalid.token.value";
+
+        // when
+        ValidatableResponse response = withdraw(invalidToken);
+
+        // then
+        response.statusCode(HttpStatus.UNAUTHORIZED.value());
+    }
+
     private ValidatableResponse rejectManagerSignup(
             String accessToken, ManagerRejectRequest request) {
         return given().contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -892,5 +1098,15 @@ class AuthControllerIntegrationTest {
                 .then()
                 .log()
                 .all();
+    }
+
+    public static ValidatableResponse withdraw(String accessToken) {
+        return given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
+                .when()
+                .delete(AUTH_URL + "/withdraw")
+                .then()
+                .log()
+                .ifError();
     }
 }

--- a/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
@@ -48,7 +48,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers
 @ActiveProfiles("test")
 @DisplayName("이벤트 신청 컨트롤러 통합 테스트")
-class RegistrationControllerIntegrationTest {
+public class RegistrationControllerIntegrationTest {
 
     private static final String REGISTRATION_URL = "/v1/events/{event-id}/registrations";
     private static final String ACCESS_TOKEN = "access_token";
@@ -87,10 +87,11 @@ class RegistrationControllerIntegrationTest {
         accessToken = context.accessToken();
 
         Event event = context.event();
-        RegisterForEventRequest request = createRequestForAvailableLocker(event);
+        RegisterForEventRequest request = createRequestForAvailableLocker(event, accessToken);
 
         // when, then
-        registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
+        registerForEvent(event.getId(), request, accessToken)
+                .statusCode(HttpStatus.CREATED.value());
     }
 
     @Test
@@ -103,9 +104,10 @@ class RegistrationControllerIntegrationTest {
         accessToken = context.accessToken();
 
         Event event = context.event();
-        RegisterForEventRequest request = createRequestForAvailableLocker(event);
+        RegisterForEventRequest request = createRequestForAvailableLocker(event, accessToken);
 
-        registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
+        registerForEvent(event.getId(), request, accessToken)
+                .statusCode(HttpStatus.CREATED.value());
 
         accessToken = authTestUtil.generateAccessToken(Role.MANAGER);
 
@@ -141,9 +143,10 @@ class RegistrationControllerIntegrationTest {
         accessToken = context.accessToken();
 
         Event event = context.event();
-        RegisterForEventRequest request = createRequestForAvailableLocker(event);
+        RegisterForEventRequest request = createRequestForAvailableLocker(event, accessToken);
 
-        registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
+        registerForEvent(event.getId(), request, accessToken)
+                .statusCode(HttpStatus.CREATED.value());
 
         RegistrationResponse registrationResponse =
                 getMyRegistration(event.getId())
@@ -191,12 +194,12 @@ class RegistrationControllerIntegrationTest {
         accessToken = context.accessToken();
 
         Event event = context.event();
-        RegisterForEventRequest request = createRequestForAvailableLocker(event);
+        RegisterForEventRequest request = createRequestForAvailableLocker(event, accessToken);
 
         // when
         accessToken = null;
         ErrorResponse errorResponse =
-                registerForEvent(event.getId(), request)
+                registerForEvent(event.getId(), request, accessToken)
                         .statusCode(JwtErrorCode.INVALID_ACCESS_TOKEN.getHttpStatus().value())
                         .extract()
                         .as(ErrorResponse.class);
@@ -217,11 +220,11 @@ class RegistrationControllerIntegrationTest {
 
         Event event = context.event();
 
-        RegisterForEventRequest request = createRequestForUnavailableLocker(event);
+        RegisterForEventRequest request = createRequestForUnavailableLocker(event, accessToken);
 
         // when
         ErrorResponse errorResponse =
-                registerForEvent(event.getId(), request)
+                registerForEvent(event.getId(), request, accessToken)
                         .statusCode(EventErrorCode.LOCKER_UNAVAILABLE.getHttpStatus().value())
                         .extract()
                         .as(ErrorResponse.class);
@@ -241,14 +244,15 @@ class RegistrationControllerIntegrationTest {
         accessToken = context.accessToken();
 
         Event event = context.event();
-        RegisterForEventRequest request = createRequestForAvailableLocker(event);
+        RegisterForEventRequest request = createRequestForAvailableLocker(event, accessToken);
 
         // when
-        registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
+        registerForEvent(event.getId(), request, accessToken)
+                .statusCode(HttpStatus.CREATED.value());
 
         // then
         ErrorResponse errorResponse =
-                registerForEvent(event.getId(), request)
+                registerForEvent(event.getId(), request, accessToken)
                         .statusCode(
                                 RegistrationErrorCode.REGISTRATION_ALREADY_EXISTS
                                         .getHttpStatus()
@@ -275,7 +279,10 @@ class RegistrationControllerIntegrationTest {
 
         // when
         ErrorResponse errorResponse =
-                registerForEvent(nonExistentEventId, createRequestForAvailableLocker(event))
+                registerForEvent(
+                                nonExistentEventId,
+                                createRequestForAvailableLocker(event, accessToken),
+                                accessToken)
                         .statusCode(EventErrorCode.EVENT_NOT_FOUND.getHttpStatus().value())
                         .extract()
                         .as(ErrorResponse.class);
@@ -296,11 +303,12 @@ class RegistrationControllerIntegrationTest {
         Event event = context.event();
 
         Event anotherEvent = createEventWithLockers(EventStatus.OPEN, true);
-        RegisterForEventRequest request = createRequestForAvailableLocker(anotherEvent);
+        RegisterForEventRequest request =
+                createRequestForAvailableLocker(anotherEvent, accessToken);
 
         // when
         ErrorResponse errorResponse =
-                registerForEvent(event.getId(), request)
+                registerForEvent(event.getId(), request, accessToken)
                         .statusCode(EventErrorCode.INVALID_LOCKER_FOR_EVENT.getHttpStatus().value())
                         .extract()
                         .as(ErrorResponse.class);
@@ -320,11 +328,11 @@ class RegistrationControllerIntegrationTest {
         accessToken = context.accessToken();
 
         Event event = context.event();
-        RegisterForEventRequest request = createRequestForAvailableLocker(event);
+        RegisterForEventRequest request = createRequestForAvailableLocker(event, accessToken);
 
         // when
         ErrorResponse errorResponse =
-                registerForEvent(event.getId(), request)
+                registerForEvent(event.getId(), request, accessToken)
                         .statusCode(EventErrorCode.EVENT_NOT_OPEN.getHttpStatus().value())
                         .extract()
                         .as(ErrorResponse.class);
@@ -343,11 +351,11 @@ class RegistrationControllerIntegrationTest {
         accessToken = context.accessToken();
 
         Event event = context.event();
-        RegisterForEventRequest request = createRequestForAvailableLocker(event);
+        RegisterForEventRequest request = createRequestForAvailableLocker(event, accessToken);
 
         // when
         ErrorResponse errorResponse =
-                registerForEvent(event.getId(), request)
+                registerForEvent(event.getId(), request, accessToken)
                         .statusCode(EventErrorCode.EVENT_NOT_OPEN.getHttpStatus().value())
                         .extract()
                         .as(ErrorResponse.class);
@@ -366,11 +374,11 @@ class RegistrationControllerIntegrationTest {
         accessToken = context.accessToken();
 
         Event event = context.event();
-        RegisterForEventRequest request = createRequestForAvailableLocker(event);
+        RegisterForEventRequest request = createRequestForAvailableLocker(event, accessToken);
 
         // when
         ErrorResponse errorResponse =
-                registerForEvent(event.getId(), request)
+                registerForEvent(event.getId(), request, accessToken)
                         .statusCode(EventErrorCode.EVENT_NOT_OPEN.getHttpStatus().value())
                         .extract()
                         .as(ErrorResponse.class);
@@ -389,11 +397,11 @@ class RegistrationControllerIntegrationTest {
         accessToken = context.accessToken();
 
         Event event = context.event();
-        RegisterForEventRequest request = createRequestForAvailableLocker(event);
+        RegisterForEventRequest request = createRequestForAvailableLocker(event, accessToken);
 
         // when
         ErrorResponse errorResponse =
-                registerForEvent(event.getId(), request)
+                registerForEvent(event.getId(), request, accessToken)
                         .statusCode(
                                 EventErrorCode.ONLY_PARTICIPATION_DEPARTMENT_CAN_REGISTER
                                         .getHttpStatus()
@@ -416,9 +424,10 @@ class RegistrationControllerIntegrationTest {
         accessToken = context.accessToken();
 
         Event event = context.event();
-        RegisterForEventRequest request = createRequestForAvailableLocker(event);
+        RegisterForEventRequest request = createRequestForAvailableLocker(event, accessToken);
 
-        registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
+        registerForEvent(event.getId(), request, accessToken)
+                .statusCode(HttpStatus.CREATED.value());
 
         // when, then
         cancelMyRegistration(event.getId()).statusCode(HttpStatus.NO_CONTENT.value());
@@ -447,13 +456,15 @@ class RegistrationControllerIntegrationTest {
         accessToken = context.accessToken();
 
         Event event = context.event();
-        RegisterForEventRequest request = createRequestForAvailableLocker(event);
+        RegisterForEventRequest request = createRequestForAvailableLocker(event, accessToken);
 
-        registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
+        registerForEvent(event.getId(), request, accessToken)
+                .statusCode(HttpStatus.CREATED.value());
         cancelMyRegistration(event.getId()).statusCode(HttpStatus.NO_CONTENT.value());
 
         // when, then
-        registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
+        registerForEvent(event.getId(), request, accessToken)
+                .statusCode(HttpStatus.CREATED.value());
     }
 
     @Test
@@ -466,9 +477,10 @@ class RegistrationControllerIntegrationTest {
         accessToken = context.accessToken();
 
         Event event = context.event();
-        RegisterForEventRequest request = createRequestForAvailableLocker(event);
+        RegisterForEventRequest request = createRequestForAvailableLocker(event, accessToken);
 
-        registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
+        registerForEvent(event.getId(), request, accessToken)
+                .statusCode(HttpStatus.CREATED.value());
 
         UUID nonExistentEventId = UUID.randomUUID();
 
@@ -492,7 +504,7 @@ class RegistrationControllerIntegrationTest {
         accessToken = context.accessToken();
 
         Event event = context.event();
-        RegisterForEventRequest request = createRequestForAvailableLocker(event);
+        RegisterForEventRequest request = createRequestForAvailableLocker(event, accessToken);
 
         // 신청 전 조회
         EventPageable eventPageable = new EventPageable(0, 10, "DESC", "createdAt");
@@ -506,7 +518,8 @@ class RegistrationControllerIntegrationTest {
                 myEventsBeforeRegistration.content().getFirst().availableLockerCount();
 
         // 신청
-        registerForEvent(event.getId(), request).statusCode(HttpStatus.CREATED.value());
+        registerForEvent(event.getId(), request, accessToken)
+                .statusCode(HttpStatus.CREATED.value());
 
         // when
         MyEventCustomPage myEventsAfterRegistration =
@@ -541,7 +554,8 @@ class RegistrationControllerIntegrationTest {
                 .ifError();
     }
 
-    private ValidatableResponse registerForEvent(UUID eventId, RegisterForEventRequest request) {
+    public static ValidatableResponse registerForEvent(
+            UUID eventId, RegisterForEventRequest request, String accessToken) {
         return given().contentType(MediaType.APPLICATION_JSON_VALUE)
                 .cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
                 .body(request)
@@ -565,21 +579,23 @@ class RegistrationControllerIntegrationTest {
         return eventTestUtil.createEventWithFloorAndLockers(List.of(5, 10), status, publish);
     }
 
-    private RegisterForEventRequest createRequestForAvailableLocker(Event event) {
-        List<FloorWithLockersResponse> floors = getFloors(event);
+    public static RegisterForEventRequest createRequestForAvailableLocker(
+            Event event, String accessToken) {
+        List<FloorWithLockersResponse> floors = getFloors(event, accessToken);
         // 짝수 번째 인덱스의 사물함은 테스트에서 사용 가능한 상태 (eventTestUtil 참고)
         Long lockerId = floors.getFirst().lockers().get(1).lockerId(); // 짝수 번째 사용 가능
         return new RegisterForEventRequest(lockerId);
     }
 
-    private RegisterForEventRequest createRequestForUnavailableLocker(Event event) {
-        List<FloorWithLockersResponse> floors = getFloors(event);
+    private RegisterForEventRequest createRequestForUnavailableLocker(
+            Event event, String accessToken) {
+        List<FloorWithLockersResponse> floors = getFloors(event, accessToken);
         // 홀수 번째 인덱스의 사물함은 테스트에서 사용 불가능한 상태 (eventTestUtil 참고)
         Long lockerId = floors.getLast().lockers().getFirst().lockerId(); // 홀수 번째 사용 불가
         return new RegisterForEventRequest(lockerId);
     }
 
-    private List<FloorWithLockersResponse> getFloors(Event event) {
+    private static List<FloorWithLockersResponse> getFloors(Event event, String accessToken) {
         return getEventLockers(event.getId(), accessToken)
                 .statusCode(HttpStatus.OK.value())
                 .extract()


### PR DESCRIPTION
### 개요
close #121 

### 작업사항
- 회원탈퇴 API 구현

### 변경로직
- 회원 삭제 시 연관관계 삭제 로직 구현
- 탈퇴 비즈니스 로직 구현
- 테스트코드 작성 및 문서화

### 테스트 결과
<img width="378" alt="image" src="https://github.com/user-attachments/assets/0b73a83f-04f5-4118-9af7-3abf3d8822a4" />

#### 추가된 테스트케이스
<img width="481" alt="image" src="https://github.com/user-attachments/assets/afa66609-2a1b-4de6-bcf6-ae6bb6642a7a" />
<img width="481" alt="image" src="https://github.com/user-attachments/assets/6dc18f0a-8321-4143-b91a-f46690f3cafd" />
<img width="481" alt="image" src="https://github.com/user-attachments/assets/aa962c02-4e8d-4029-ba90-125de951636b" />
<img width="481" alt="image" src="https://github.com/user-attachments/assets/f1c5ed4c-ac51-41c3-b734-78ed08f464e7" />
<img width="481" alt="image" src="https://github.com/user-attachments/assets/1932b20b-69ac-4d41-95d9-587913d48144" />


### reference

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 회원 탈퇴(계정 삭제) 기능이 추가되었습니다. 사용자는 새로운 API 엔드포인트를 통해 계정을 삭제할 수 있습니다.

- **버그 수정**
    - 회원 탈퇴 시, 해당 회원의 모든 사물함 등록 내역이 삭제되며, 사물함이 다시 사용 가능 상태로 변경됩니다.

- **테스트**
    - 회원 탈퇴 기능에 대한 통합 테스트가 추가되어, 다양한 시나리오(일반 회원, 관리자, 등록된 사물함 등)에 대해 정상 동작을 검증합니다.
    - 테스트 코드에서 액세스 토큰 전달 방식이 명시적으로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->