### PR TITLE
[FEAT] reissue시 JWT 토큰 응답 본문에 담아 전달

### DIFF
--- a/src/main/java/com/jnulocker/auth/adapter/in/AuthController.java
+++ b/src/main/java/com/jnulocker/auth/adapter/in/AuthController.java
@@ -102,11 +102,13 @@ public class AuthController implements AuthApi {
 
     @Override
     @PostMapping("/reissue")
-    public ResponseEntity<Void> reissue(HttpServletRequest request, HttpServletResponse response) {
+    public ResponseEntity<AuthTokenResponse> reissue(
+            HttpServletRequest request, HttpServletResponse response) {
         String refreshToken = getRefreshToken(request);
         AuthToken authToken = reissueCommand.reissue(refreshToken);
         addCookieFromAuthToken(response, authToken);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        return ResponseEntity.ok(
+                AuthTokenResponse.of(authToken.accessToken(), authToken.refreshToken()));
     }
 
     @Override

--- a/src/main/java/com/jnulocker/auth/adapter/in/docs/AuthApi.java
+++ b/src/main/java/com/jnulocker/auth/adapter/in/docs/AuthApi.java
@@ -68,7 +68,8 @@ public interface AuthApi {
     @ApiExceptionExamples(ReissueExceptionDocs.class)
     @Operation(summary = "토큰 재발급", description = "refreshToken을 이용하여 토큰을 재발급합니다.")
     @ApiResponse(responseCode = "204", description = "토큰 재발급 성공")
-    ResponseEntity<Void> reissue(HttpServletRequest request, HttpServletResponse response);
+    ResponseEntity<AuthTokenResponse> reissue(
+            HttpServletRequest request, HttpServletResponse response);
 
     @ApiExceptionExamples(MailSendExceptionDocs.class)
     @Operation(summary = "인증 메일 전송", description = "유효한 이메일인지 확인하기 위해 인증 코드를 전송합니다.")

--- a/src/main/java/com/jnulocker/auth/adapter/in/docs/AuthApi.java
+++ b/src/main/java/com/jnulocker/auth/adapter/in/docs/AuthApi.java
@@ -67,7 +67,7 @@ public interface AuthApi {
 
     @ApiExceptionExamples(ReissueExceptionDocs.class)
     @Operation(summary = "토큰 재발급", description = "refreshToken을 이용하여 토큰을 재발급합니다.")
-    @ApiResponse(responseCode = "204", description = "토큰 재발급 성공")
+    @ApiResponse(responseCode = "200", description = "토큰 재발급 성공")
     ResponseEntity<AuthTokenResponse> reissue(
             HttpServletRequest request, HttpServletResponse response);
 

--- a/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
@@ -364,11 +364,19 @@ class AuthControllerIntegrationTest {
 
         // when
         ExtractableResponse<Response> response =
-                reissueToken(refreshToken).statusCode(HttpStatus.NO_CONTENT.value()).extract();
+                reissueToken(refreshToken).statusCode(HttpStatus.OK.value()).extract();
 
         // then
-        String newAccessToken = getCookieValue(response.detailedCookies(), ACCESS_TOKEN);
-        assertThat(newAccessToken).isNotBlank();
+        Cookies cookies = response.detailedCookies();
+        String accessTokenFromCookie = getCookieValue(cookies, ACCESS_TOKEN);
+        String refreshTokenFromCookie = getCookieValue(cookies, REFRESH_TOKEN);
+        String accessTokenFromBody = response.jsonPath().getString("accessToken");
+        String refreshTokenFromBody = response.jsonPath().getString("refreshToken");
+
+        assertThat(accessTokenFromCookie).isNotBlank();
+        assertThat(refreshTokenFromCookie).isNotBlank();
+        assertThat(accessTokenFromBody).isNotBlank();
+        assertThat(refreshTokenFromBody).isNotBlank();
     }
 
     @Test


### PR DESCRIPTION
### 개요
close #128 

### 작업사항
- reissue API 응답을 토큰을 담도록 수정하고 reissue 테스트코드를 수정하였습니다.

### 변경로직
- reissue 응답 시 JWT 토큰을 응답 본문에 담음

### 테스트 결과
<img width="400" alt="image" src="https://github.com/user-attachments/assets/675a30e7-a103-4891-9638-3444958e0515" />

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 토큰 재발급 시 응답 본문에 새로운 액세스 토큰과 리프레시 토큰 정보가 포함되어 반환됩니다.

- **버그 수정**
  - 토큰 재발급 테스트가 응답 본문과 쿠키 모두에서 토큰 값이 올바르게 반환되는지 검증하도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->