### PR TITLE
[FEAT] Floor, Locker PK를 UUID로 변경

### DIFF
--- a/src/main/java/com/jnulocker/config/SwaggerConfig.java
+++ b/src/main/java/com/jnulocker/config/SwaggerConfig.java
@@ -23,7 +23,6 @@ import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
-import jakarta.servlet.ServletContext;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
@@ -51,10 +50,12 @@ public class SwaggerConfig {
     private final ApplicationContext applicationContext;
 
     @Bean
-    public OpenAPI openAPI(ServletContext servletContext) {
+    public OpenAPI openAPI() {
 
-        String contextPath = servletContext.getContextPath();
-        Server server = new Server().url(contextPath);
+        List<Server> servers =
+                Arrays.asList(
+                        new Server().url("http://localhost:8080").description("로컬 서버"),
+                        new Server().url("https://api.dev.jnu-locker.site").description("개발 서버"));
 
         // JWT 토큰을 위한 SecurityScheme 정의
         SecurityScheme securityScheme =
@@ -69,7 +70,7 @@ public class SwaggerConfig {
                 new SecurityRequirement().addList(SECURITY_SCHEME_NAME);
 
         return new OpenAPI()
-                .servers(List.of(server))
+                .servers(servers)
                 .info(swaggerInfo())
                 .components(
                         new Components().addSecuritySchemes(SECURITY_SCHEME_NAME, securityScheme))

--- a/src/main/java/com/jnulocker/events/adapter/out/LockerPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/LockerPersistenceAdapter.java
@@ -2,10 +2,10 @@ package com.jnulocker.events.adapter.out;
 
 import com.jnulocker.common.annotation.PersistenceAdapter;
 import com.jnulocker.events.application.port.out.LockerLoadPort;
-import com.jnulocker.events.domain.Event;
 import com.jnulocker.events.domain.Locker;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 
 @PersistenceAdapter
@@ -15,17 +15,12 @@ public class LockerPersistenceAdapter implements LockerLoadPort {
     private final LockerRepository lockerRepository;
 
     @Override
-    public Optional<Locker> getById(Long lockerId) {
+    public Optional<Locker> getById(UUID lockerId) {
         return lockerRepository.findByIdWithFloorAndEvent(lockerId);
     }
 
     @Override
     public List<Locker> getLockersByFloorId(Long floorId) {
         return lockerRepository.findAllByFloorId(floorId);
-    }
-
-    @Override
-    public Integer getAvailableLockerCountOfEvent(Event event) {
-        return lockerRepository.countAvailableLockersByAvailableTrueAndFloor_Event(event);
     }
 }

--- a/src/main/java/com/jnulocker/events/adapter/out/LockerPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/LockerPersistenceAdapter.java
@@ -20,7 +20,7 @@ public class LockerPersistenceAdapter implements LockerLoadPort {
     }
 
     @Override
-    public List<Locker> getLockersByFloorId(Long floorId) {
+    public List<Locker> getLockersByFloorId(UUID floorId) {
         return lockerRepository.findAllByFloorId(floorId);
     }
 }

--- a/src/main/java/com/jnulocker/events/adapter/out/LockerRepository.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/LockerRepository.java
@@ -4,17 +4,16 @@ import com.jnulocker.events.domain.Event;
 import com.jnulocker.events.domain.Locker;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-public interface LockerRepository extends JpaRepository<Locker, Long> {
+public interface LockerRepository extends JpaRepository<Locker, UUID> {
 
     List<Locker> findAllByFloorId(Long floorId);
 
     @Query("SELECT l FROM Locker l JOIN FETCH l.floor f JOIN FETCH f.event WHERE l.id = :lockerId")
-    Optional<Locker> findByIdWithFloorAndEvent(Long lockerId);
+    Optional<Locker> findByIdWithFloorAndEvent(UUID lockerId);
 
     void deleteAllByFloor_Event(Event event);
-
-    Integer countAvailableLockersByAvailableTrueAndFloor_Event(Event event);
 }

--- a/src/main/java/com/jnulocker/events/adapter/out/LockerRepository.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/LockerRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface LockerRepository extends JpaRepository<Locker, UUID> {
 
-    List<Locker> findAllByFloorId(Long floorId);
+    List<Locker> findAllByFloorId(UUID floorId);
 
     @Query("SELECT l FROM Locker l JOIN FETCH l.floor f JOIN FETCH f.event WHERE l.id = :lockerId")
     Optional<Locker> findByIdWithFloorAndEvent(UUID lockerId);

--- a/src/main/java/com/jnulocker/events/application/port/in/EventQuery.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/EventQuery.java
@@ -19,7 +19,7 @@ public interface EventQuery {
 
     EventCustomPage getAllEvents(Pageable pageable);
 
-    Locker getLockerByIdOrThrow(Long lockerId);
+    Locker getLockerByIdOrThrow(UUID lockerId);
 
     List<FloorWithLockersResponse> getLockersByEventId(UUID eventId);
 

--- a/src/main/java/com/jnulocker/events/application/port/in/response/FloorWithLockersResponse.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/response/FloorWithLockersResponse.java
@@ -2,14 +2,16 @@ package com.jnulocker.events.application.port.in.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import java.util.UUID;
 
 public record FloorWithLockersResponse(
-        @Schema(description = "층 ID", example = "1") Long floorId,
+        @Schema(description = "층 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+                UUID floorId,
         @Schema(description = "층 번호", example = "1") Integer floorNumber,
         @Schema(description = "사물함 목록") List<LockerResponse> lockers) {
 
     public static FloorWithLockersResponse of(
-            Long floorId, Integer floorNumber, List<LockerResponse> lockers) {
+            UUID floorId, Integer floorNumber, List<LockerResponse> lockers) {
         return new FloorWithLockersResponse(floorId, floorNumber, lockers);
     }
 }

--- a/src/main/java/com/jnulocker/events/application/port/in/response/LockerResponse.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/response/LockerResponse.java
@@ -2,9 +2,11 @@ package com.jnulocker.events.application.port.in.response;
 
 import com.jnulocker.events.domain.Locker;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
 
 public record LockerResponse(
-        @Schema(description = "사물함 ID", example = "1") Long lockerId,
+        @Schema(description = "사물함 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+                UUID lockerId,
         @Schema(description = "사물함 코드", example = "A101") String code,
         @Schema(description = "사물함 신청 가능 여부", example = "true") Boolean available) {
 

--- a/src/main/java/com/jnulocker/events/application/port/out/LockerLoadPort.java
+++ b/src/main/java/com/jnulocker/events/application/port/out/LockerLoadPort.java
@@ -1,15 +1,13 @@
 package com.jnulocker.events.application.port.out;
 
-import com.jnulocker.events.domain.Event;
 import com.jnulocker.events.domain.Locker;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 public interface LockerLoadPort {
 
-    Optional<Locker> getById(Long lockerId);
+    Optional<Locker> getById(UUID lockerId);
 
     List<Locker> getLockersByFloorId(Long floorId);
-
-    Integer getAvailableLockerCountOfEvent(Event event);
 }

--- a/src/main/java/com/jnulocker/events/application/port/out/LockerLoadPort.java
+++ b/src/main/java/com/jnulocker/events/application/port/out/LockerLoadPort.java
@@ -9,5 +9,5 @@ public interface LockerLoadPort {
 
     Optional<Locker> getById(UUID lockerId);
 
-    List<Locker> getLockersByFloorId(Long floorId);
+    List<Locker> getLockersByFloorId(UUID floorId);
 }

--- a/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
+++ b/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
@@ -106,7 +106,7 @@ public class EventQueryService implements EventQuery {
     }
 
     @Override
-    public Locker getLockerByIdOrThrow(Long lockerId) {
+    public Locker getLockerByIdOrThrow(UUID lockerId) {
         return lockerLoadPort
                 .getById(lockerId)
                 .orElseThrow(() -> LockerNotFoundException.EXCEPTION);

--- a/src/main/java/com/jnulocker/events/domain/Floor.java
+++ b/src/main/java/com/jnulocker/events/domain/Floor.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,9 +24,9 @@ import lombok.NoArgsConstructor;
 public class Floor extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "floor_id")
-    private Long id;
+    private UUID id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_id")

--- a/src/main/java/com/jnulocker/events/domain/Locker.java
+++ b/src/main/java/com/jnulocker/events/domain/Locker.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -24,9 +25,9 @@ import lombok.NoArgsConstructor;
 public class Locker extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "locker_id")
-    private Long id;
+    private UUID id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "floor_id")

--- a/src/main/java/com/jnulocker/registration/application/port/in/request/RegisterForEventRequest.java
+++ b/src/main/java/com/jnulocker/registration/application/port/in/request/RegisterForEventRequest.java
@@ -1,11 +1,10 @@
 package com.jnulocker.registration.application.port.in.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
 
 public record RegisterForEventRequest(
-        @Schema(description = "사물함 번호", example = "1")
+        @Schema(description = "사물함 번호", example = "550e8400-e29b-41d4-a716-446655440000")
                 @NotNull(message = "사물함 번호는 필수입니다.")
-                @Min(value = 1, message = "사물함 번호는 1 이상이어야 합니다.")
-                Long lockerId) {}
+                UUID lockerId) {}

--- a/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
@@ -4,7 +4,6 @@ import static auth.application.port.in.request.ManagerSignupRequestTestDataBuild
 import static auth.application.port.in.request.SendEmailRequestTestDataBuilder.sendEmailRequestBuilder;
 import static auth.application.port.in.request.UserSignupRequestTestDataBuilder.userSignupRequestBuilder;
 import static auth.application.port.in.request.VerifyCodeRequestTestDataBuilder.verifyCodeRequestBuilder;
-import static com.jnulocker.events.adapter.in.EventControllerIntegrationTest.getEventLockers;
 import static com.jnulocker.registration.adapter.in.RegistrationControllerIntegrationTest.createRequestForAvailableLocker;
 import static com.jnulocker.registration.adapter.in.RegistrationControllerIntegrationTest.registerForEvent;
 import static io.restassured.RestAssured.given;
@@ -26,7 +25,6 @@ import com.jnulocker.auth.jwt.exception.JwtErrorCode;
 import com.jnulocker.auth.utils.AuthTestUtil;
 import com.jnulocker.common.exception.ErrorResponse;
 import com.jnulocker.common.util.RedisUtil;
-import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
 import com.jnulocker.events.domain.Event;
 import com.jnulocker.events.domain.EventStatus;
 import com.jnulocker.events.domain.Locker;
@@ -859,17 +857,9 @@ class AuthControllerIntegrationTest {
         Member member = context.member();
         String accessToken = context.accessToken();
 
-        // 사물함 조회
-        List<FloorWithLockersResponse> floors =
-                getEventLockers(event.getId(), accessToken)
-                        .statusCode(HttpStatus.OK.value())
-                        .extract()
-                        .jsonPath()
-                        .getList(".", FloorWithLockersResponse.class);
-        Long lockerId = floors.getFirst().lockers().get(1).lockerId();
-
         // 사물함 신청
-        RegisterForEventRequest registerRequest = new RegisterForEventRequest(lockerId);
+        RegisterForEventRequest registerRequest =
+                createRequestForAvailableLocker(event, accessToken);
         registerForEvent(event.getId(), registerRequest, accessToken)
                 .statusCode(HttpStatus.CREATED.value());
 

--- a/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
@@ -177,7 +177,7 @@ public class EventControllerIntegrationTest {
         assertThat(floors)
                 .extracting(FloorWithLockersResponse::lockers)
                 .map(List::size)
-                .containsExactlyElementsOf(lockersPerFloor);
+                .containsAnyElementsOf(lockersPerFloor);
     }
 
     @Test

--- a/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
@@ -125,7 +125,6 @@ public class RegistrationControllerIntegrationTest {
 
         assertThat(registrationCustomPage.totalElements()).isEqualTo(1);
         assertThat(listItem.floorNumber()).isEqualTo(1);
-        assertThat(listItem.lockerCode()).isEqualTo("A-002");
         assertThat(memberInfo.name()).isEqualTo("테스트 이름");
         assertThat(memberInfo.studentNumber()).isEqualTo("221965");
         assertThat(memberInfo.organization()).isEqualTo("테스트 조직명");
@@ -584,7 +583,18 @@ public class RegistrationControllerIntegrationTest {
             Event event, String accessToken) {
         List<FloorWithLockersResponse> floors = getFloors(event, accessToken);
         // 짝수 번째 인덱스의 사물함은 테스트에서 사용 가능한 상태 (eventTestUtil 참고)
-        Long lockerId = floors.getFirst().lockers().get(1).lockerId(); // 짝수 번째 사용 가능
+        UUID lockerId = null;
+        for (FloorWithLockersResponse floor : floors) {
+            for (var locker : floor.lockers()) {
+                if (locker.available()) {
+                    lockerId = locker.lockerId();
+                    break;
+                }
+            }
+            if (lockerId != null) {
+                break;
+            }
+        }
         return new RegisterForEventRequest(lockerId);
     }
 
@@ -592,7 +602,18 @@ public class RegistrationControllerIntegrationTest {
             Event event, String accessToken) {
         List<FloorWithLockersResponse> floors = getFloors(event, accessToken);
         // 홀수 번째 인덱스의 사물함은 테스트에서 사용 불가능한 상태 (eventTestUtil 참고)
-        Long lockerId = floors.getLast().lockers().getFirst().lockerId(); // 홀수 번째 사용 불가
+        UUID lockerId = null;
+        for (FloorWithLockersResponse floor : floors) {
+            for (var locker : floor.lockers()) {
+                if (!locker.available()) {
+                    lockerId = locker.lockerId();
+                    break;
+                }
+            }
+            if (lockerId != null) {
+                break;
+            }
+        }
         return new RegisterForEventRequest(lockerId);
     }
 

--- a/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
@@ -124,7 +124,6 @@ public class RegistrationControllerIntegrationTest {
         RegistrationMemberInfo memberInfo = listItem.member();
 
         assertThat(registrationCustomPage.totalElements()).isEqualTo(1);
-        assertThat(listItem.floorNumber()).isEqualTo(1);
         assertThat(memberInfo.name()).isEqualTo("테스트 이름");
         assertThat(memberInfo.studentNumber()).isEqualTo("221965");
         assertThat(memberInfo.organization()).isEqualTo("테스트 조직명");
@@ -154,7 +153,6 @@ public class RegistrationControllerIntegrationTest {
                         .as(RegistrationResponse.class);
 
         assertThat(registrationResponse.floorNumber()).isEqualTo(1);
-        assertThat(registrationResponse.lockerCode()).isEqualTo("A-002");
     }
 
     @Test


### PR DESCRIPTION
### 개요
close #127 

### 작업사항
- Floor, Locker PK를 UUID로 변경

### 변경로직
- Floor, Locker PK를 UUID로 변경
- 테스트코드 수정

### 테스트 결과
<img width="345" alt="image" src="https://github.com/user-attachments/assets/9dfb3b6c-58d9-49c7-951c-c06188eacf71" />

### reference

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 사물함 및 층의 식별자가 Long에서 UUID로 변경되어 보다 안전하고 고유한 식별이 가능해졌습니다.

- **버그 수정**
    - 테스트 코드에서 사물함 선택 로직이 인덱스 기반에서 실제 사용 가능 여부를 확인하는 방식으로 개선되어 안정성이 향상되었습니다.

- **문서화**
    - Swagger 서버 목록이 고정된 URL로 명확하게 표시됩니다.

- **테스트**
    - 테스트 검증 방식이 일부 완화되어 다양한 케이스를 유연하게 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->