### PR TITLE
[FEAT] 단과대학 조회 시 테스트 단과대학은 응답에서 제외

### DIFF
--- a/src/main/java/com/jnulocker/organization/application/service/OrganizationQueryService.java
+++ b/src/main/java/com/jnulocker/organization/application/service/OrganizationQueryService.java
@@ -25,6 +25,7 @@ public class OrganizationQueryService implements OrganizationQuery, DepartmentQu
     @Override
     public List<OrganizationResponse> getOrganizations(OrganizationType organizationType) {
         return organizationLoadPort.getAllByType(organizationType).stream()
+                .filter(org -> !org.getName().contains("테스트"))
                 .map(OrganizationResponse::from)
                 .toList();
     }


### PR DESCRIPTION
### 개요
close #131 

### 작업사항
- 단과대학 조회 시 테스트 계정을 위한 데이터인 `테스트 단과대학`을 응답에서 제외시켰습니다.

### 변경로직
- 테스트 계정을 위해 db에 테스트 학과를 설정하였습니다.

### 테스트 결과
<img width="300" alt="image" src="https://github.com/user-attachments/assets/25155785-d1a9-4730-a164-42cce78cf216" />


### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 이름에 "테스트"가 포함된 조직이 조직 목록에서 제외됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->