### PR TITLE
[FIX] 이벤트의 사물함 목록 조회 시 층 번호순, Code 순서대로 응답하도록 수정

### DIFF
--- a/src/main/java/com/jnulocker/events/adapter/out/FloorPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/FloorPersistenceAdapter.java
@@ -15,6 +15,6 @@ public class FloorPersistenceAdapter implements FloorLoadPort {
 
     @Override
     public List<Floor> getFloorsByEventId(UUID eventId) {
-        return floorRepository.findAllByEventId(eventId);
+        return floorRepository.findAllByEventIdOrderByFloorNumber(eventId);
     }
 }

--- a/src/main/java/com/jnulocker/events/adapter/out/FloorRepository.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/FloorRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FloorRepository extends JpaRepository<Floor, Long> {
 
-    List<Floor> findAllByEventId(UUID eventId);
+    List<Floor> findAllByEventIdOrderByFloorNumber(UUID eventId);
 
     void deleteAllByEvent(Event event);
 }

--- a/src/main/java/com/jnulocker/events/adapter/out/LockerPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/LockerPersistenceAdapter.java
@@ -21,6 +21,6 @@ public class LockerPersistenceAdapter implements LockerLoadPort {
 
     @Override
     public List<Locker> getLockersByFloorId(UUID floorId) {
-        return lockerRepository.findAllByFloorId(floorId);
+        return lockerRepository.findAllByFloorIdOrderByCode(floorId);
     }
 }

--- a/src/main/java/com/jnulocker/events/adapter/out/LockerRepository.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/LockerRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface LockerRepository extends JpaRepository<Locker, UUID> {
 
-    List<Locker> findAllByFloorId(UUID floorId);
+    List<Locker> findAllByFloorIdOrderByCode(UUID floorId);
 
     @Query("SELECT l FROM Locker l JOIN FETCH l.floor f JOIN FETCH f.event WHERE l.id = :lockerId")
     Optional<Locker> findByIdWithFloorAndEvent(UUID lockerId);

--- a/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
@@ -177,7 +177,7 @@ public class EventControllerIntegrationTest {
         assertThat(floors)
                 .extracting(FloorWithLockersResponse::lockers)
                 .map(List::size)
-                .containsAnyElementsOf(lockersPerFloor);
+                .containsExactlyElementsOf(lockersPerFloor);
     }
 
     @Test


### PR DESCRIPTION
### 개요
close #133 

### 작업사항

- 현재 사물함의 `id` 필드가 `UUID`로 변경되며 `Code` 순서대로 응답하지 않는 문제 발생
- 쿼리에서 `OrderByCode`를 통해 사물함 코드 순서대로 목록이 반환되도록 수정
- 또한 사물함 층 목록도 층번호 순으로 응답하도록 수정

### 변경로직
- 사물함 조회 쿼리 `OrderByCode` 적용
- 층 조회 쿼리 `OrderByFloorNumber` 적용

### 테스트 결과
<img width="342" alt="image" src="https://github.com/user-attachments/assets/2ffb69c6-99a4-4583-8ca2-c674f6a61224" />

### reference
- `PK`가 `UUID`로 변경되며 발생한 상황인 것 같습니다.

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 이벤트별 층 목록과 층별 사물함 목록이 각각 층 번호와 사물함 코드 순으로 정렬되어 제공됩니다.
- **테스트**
	- 사물함 개수 검증 테스트가 정확한 순서와 일치 여부를 확인하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->