### PR TITLE
[REFACTOR] 발행 이벤트와 도메인 이벤트 구분

### DIFF
--- a/src/main/java/com/jnulocker/auth/event/ManagerApprovedEventHandler.java
+++ b/src/main/java/com/jnulocker/auth/event/ManagerApprovedEventHandler.java
@@ -15,7 +15,8 @@ public class ManagerApprovedEventHandler {
     @TransactionalEventListener(
             classes = ManagerApprovedEvent.class,
             phase = TransactionPhase.AFTER_COMMIT)
-    public void handle(ManagerApprovedEvent event) {
-        managerEmailSender.sendManagerApprovedEmail(event.getEmail(), event.getDepartment());
+    public void handle(ManagerApprovedEvent managerApprovedEvent) {
+        managerEmailSender.sendManagerApprovedEmail(
+                managerApprovedEvent.getEmail(), managerApprovedEvent.getDepartment());
     }
 }

--- a/src/main/java/com/jnulocker/auth/event/ManagerRejectedEventHandler.java
+++ b/src/main/java/com/jnulocker/auth/event/ManagerRejectedEventHandler.java
@@ -15,7 +15,8 @@ public class ManagerRejectedEventHandler {
     @TransactionalEventListener(
             classes = ManagerRejectedEvent.class,
             phase = TransactionPhase.AFTER_COMMIT)
-    public void handle(ManagerRejectedEvent event) {
-        managerEmailSender.sendManagerRejectedEmail(event.getEmail(), event.getDepartment());
+    public void handle(ManagerRejectedEvent managerRejectedEvent) {
+        managerEmailSender.sendManagerRejectedEmail(
+                managerRejectedEvent.getEmail(), managerRejectedEvent.getDepartment());
     }
 }

--- a/src/main/java/com/jnulocker/events/event/LockerEventCreatedEventHandler.java
+++ b/src/main/java/com/jnulocker/events/event/LockerEventCreatedEventHandler.java
@@ -16,8 +16,9 @@ public class LockerEventCreatedEventHandler {
     @TransactionalEventListener(
             classes = LockerEventCreatedEvent.class,
             phase = TransactionPhase.AFTER_COMMIT)
-    public void handle(LockerEventCreatedEvent event) {
-        UUID eventId = event.getEventId();
-        quartzSchedulerUtil.scheduleEventJobs(eventId, event.getStartAt(), event.getEndAt());
+    public void handle(LockerEventCreatedEvent lockerEventCreatedEvent) {
+        UUID eventId = lockerEventCreatedEvent.getEventId();
+        quartzSchedulerUtil.scheduleEventJobs(
+                eventId, lockerEventCreatedEvent.getStartAt(), lockerEventCreatedEvent.getEndAt());
     }
 }

--- a/src/main/java/com/jnulocker/events/event/LockerEventDeletedEventHandler.java
+++ b/src/main/java/com/jnulocker/events/event/LockerEventDeletedEventHandler.java
@@ -17,8 +17,8 @@ public class LockerEventDeletedEventHandler {
     @TransactionalEventListener(
             classes = LockerEventDeletedEvent.class,
             phase = TransactionPhase.AFTER_COMMIT)
-    public void handle(LockerEventDeletedEvent event) throws SchedulerException {
-        UUID eventId = event.getEventId();
+    public void handle(LockerEventDeletedEvent lockerEventDeletedEvent) throws SchedulerException {
+        UUID eventId = lockerEventDeletedEvent.getEventId();
         quartzSchedulerUtil.deleteEventJobs(eventId);
     }
 }

--- a/src/main/java/com/jnulocker/events/event/LockerEventUpdatedEventHandler.java
+++ b/src/main/java/com/jnulocker/events/event/LockerEventUpdatedEventHandler.java
@@ -17,13 +17,14 @@ public class LockerEventUpdatedEventHandler {
     @TransactionalEventListener(
             classes = LockerEventUpdatedEvent.class,
             phase = TransactionPhase.AFTER_COMMIT)
-    public void handle(LockerEventUpdatedEvent event) throws SchedulerException {
-        UUID eventId = event.getEventId();
+    public void handle(LockerEventUpdatedEvent lockerEventUpdatedEvent) throws SchedulerException {
+        UUID eventId = lockerEventUpdatedEvent.getEventId();
 
         // 기존 스케줄링 작업 삭제
         quartzSchedulerUtil.deleteEventJobs(eventId);
 
         // 새로운 스케줄링 작업 생성
-        quartzSchedulerUtil.scheduleEventJobs(eventId, event.getStartAt(), event.getEndAt());
+        quartzSchedulerUtil.scheduleEventJobs(
+                eventId, lockerEventUpdatedEvent.getStartAt(), lockerEventUpdatedEvent.getEndAt());
     }
 }


### PR DESCRIPTION
### 개요
close #135 

### 작업사항
- EventHandler에서 받는 인자를 `event`로 하지 않고 어떤 이벤트를 다루는지 상세하게 명시함으로써 발행 이벤트와 도메인 이벤트를 구분하고자 하였습니다.

### 테스트 결과
<img width="300" alt="image" src="https://github.com/user-attachments/assets/ab395e27-fdef-40a2-8a70-5502dd734493" />

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 여러 이벤트 처리기에서 메서드 파라미터 이름이 보다 명확하게 변경되었습니다.
  - 코드 가독성을 위해 일부 함수 호출이 여러 줄로 정렬되었습니다.

- **Style**
  - 내부 코드 스타일이 개선되어 가독성이 향상되었습니다.

(기능 및 동작에는 변화가 없습니다.)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->