### PR TITLE
[REFACTOR] 사물함 목록 조회 및 신청 정보 조회 쿼리 개선

### DIFF
--- a/src/main/java/com/jnulocker/events/adapter/out/LockerPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/LockerPersistenceAdapter.java
@@ -2,6 +2,7 @@ package com.jnulocker.events.adapter.out;
 
 import com.jnulocker.common.annotation.PersistenceAdapter;
 import com.jnulocker.events.application.port.out.LockerLoadPort;
+import com.jnulocker.events.domain.Floor;
 import com.jnulocker.events.domain.Locker;
 import java.util.List;
 import java.util.Optional;
@@ -20,7 +21,7 @@ public class LockerPersistenceAdapter implements LockerLoadPort {
     }
 
     @Override
-    public List<Locker> getLockersByFloorId(UUID floorId) {
-        return lockerRepository.findAllByFloorIdOrderByCode(floorId);
+    public List<Locker> getLockersByFloorIds(List<Floor> floors) {
+        return lockerRepository.findAllByFloorInOrderByCode(floors);
     }
 }

--- a/src/main/java/com/jnulocker/events/adapter/out/LockerRepository.java
+++ b/src/main/java/com/jnulocker/events/adapter/out/LockerRepository.java
@@ -1,6 +1,7 @@
 package com.jnulocker.events.adapter.out;
 
 import com.jnulocker.events.domain.Event;
+import com.jnulocker.events.domain.Floor;
 import com.jnulocker.events.domain.Locker;
 import java.util.List;
 import java.util.Optional;
@@ -10,10 +11,10 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface LockerRepository extends JpaRepository<Locker, UUID> {
 
-    List<Locker> findAllByFloorIdOrderByCode(UUID floorId);
-
     @Query("SELECT l FROM Locker l JOIN FETCH l.floor f JOIN FETCH f.event WHERE l.id = :lockerId")
     Optional<Locker> findByIdWithFloorAndEvent(UUID lockerId);
+
+    List<Locker> findAllByFloorInOrderByCode(List<Floor> floors);
 
     void deleteAllByFloor_Event(Event event);
 }

--- a/src/main/java/com/jnulocker/events/application/port/in/response/FloorWithLockersResponse.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/response/FloorWithLockersResponse.java
@@ -1,5 +1,7 @@
 package com.jnulocker.events.application.port.in.response;
 
+import com.jnulocker.events.domain.Floor;
+import com.jnulocker.events.domain.Locker;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import java.util.UUID;
@@ -10,8 +12,9 @@ public record FloorWithLockersResponse(
         @Schema(description = "층 번호", example = "1") Integer floorNumber,
         @Schema(description = "사물함 목록") List<LockerResponse> lockers) {
 
-    public static FloorWithLockersResponse of(
-            UUID floorId, Integer floorNumber, List<LockerResponse> lockers) {
-        return new FloorWithLockersResponse(floorId, floorNumber, lockers);
+    public static FloorWithLockersResponse of(Floor floor, List<Locker> lockers) {
+        List<LockerResponse> lockerResponses = lockers.stream().map(LockerResponse::from).toList();
+
+        return new FloorWithLockersResponse(floor.getId(), floor.getFloorNumber(), lockerResponses);
     }
 }

--- a/src/main/java/com/jnulocker/events/application/port/out/LockerLoadPort.java
+++ b/src/main/java/com/jnulocker/events/application/port/out/LockerLoadPort.java
@@ -1,5 +1,6 @@
 package com.jnulocker.events.application.port.out;
 
+import com.jnulocker.events.domain.Floor;
 import com.jnulocker.events.domain.Locker;
 import java.util.List;
 import java.util.Optional;
@@ -9,5 +10,5 @@ public interface LockerLoadPort {
 
     Optional<Locker> getById(UUID lockerId);
 
-    List<Locker> getLockersByFloorId(UUID floorId);
+    List<Locker> getLockersByFloorIds(List<Floor> floors);
 }

--- a/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
+++ b/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
@@ -8,7 +8,6 @@ import com.jnulocker.events.application.port.in.request.FloorInfo;
 import com.jnulocker.events.application.port.in.response.EventCustomPage;
 import com.jnulocker.events.application.port.in.response.EventResponse;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
-import com.jnulocker.events.application.port.in.response.LockerResponse;
 import com.jnulocker.events.application.port.in.response.MyEventCustomPage;
 import com.jnulocker.events.application.port.in.response.MyEventResponse;
 import com.jnulocker.events.application.port.out.EventLoadPort;
@@ -24,7 +23,9 @@ import com.jnulocker.events.exception.OnlyParticipationDepartmentCanSeeEventExce
 import com.jnulocker.member.application.port.in.MemberQuery;
 import com.jnulocker.member.domain.Member;
 import java.util.*;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -33,6 +34,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class EventQueryService implements EventQuery {
 
     private final EventLoadPort eventLoadPort;
@@ -119,20 +121,24 @@ public class EventQueryService implements EventQuery {
         }
 
         List<Floor> floors = floorLoadPort.getFloorsByEventId(eventId);
+        if (floors.isEmpty()) {
+            return List.of();
+        }
+
+        // 모든 사물함을 가져와서 층별로 그룹화
+        List<Locker> allLockers = lockerLoadPort.getLockersByFloorIds(floors);
+        Map<UUID, List<Locker>> lockersByFloorId =
+                allLockers.stream()
+                        .collect(Collectors.groupingBy(locker -> locker.getFloor().getId()));
 
         return floors.stream()
-                .map(
-                        floor ->
-                                FloorWithLockersResponse.of(
-                                        floor.getId(),
-                                        floor.getFloorNumber(),
-                                        getLockerResponsesByFloor(floor)))
+                .map(floor -> convertToFloorResponse(floor, lockersByFloorId))
                 .toList();
     }
 
-    private List<LockerResponse> getLockerResponsesByFloor(Floor floor) {
-        return lockerLoadPort.getLockersByFloorId(floor.getId()).stream()
-                .map(LockerResponse::from)
-                .toList();
+    private FloorWithLockersResponse convertToFloorResponse(
+            Floor floor, Map<UUID, List<Locker>> lockersByFloorId) {
+        List<Locker> lockersForFloor = lockersByFloorId.getOrDefault(floor.getId(), List.of());
+        return FloorWithLockersResponse.of(floor, lockersForFloor);
     }
 }

--- a/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
+++ b/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
@@ -25,7 +25,6 @@ import com.jnulocker.member.domain.Member;
 import java.util.*;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -34,7 +33,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-@Slf4j
 public class EventQueryService implements EventQuery {
 
     private final EventLoadPort eventLoadPort;

--- a/src/main/java/com/jnulocker/registration/adapter/out/RegistrationPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/registration/adapter/out/RegistrationPersistenceAdapter.java
@@ -36,12 +36,12 @@ public class RegistrationPersistenceAdapter
 
     @Override
     public Page<Registration> getRegistrationsByEventId(UUID eventId, Pageable pageable) {
-        return registrationRepository.findAllByLocker_Floor_EventId(eventId, pageable);
+        return registrationRepository.findAllByEventIdOptimized(eventId, pageable);
     }
 
     @Override
     public Optional<Registration> getRegistrationByMemberIdAndEventId(Long memberId, UUID eventId) {
-        return registrationRepository.findByMemberIdAndLocker_Floor_EventId(memberId, eventId);
+        return registrationRepository.findByMemberIdAndEventId(memberId, eventId);
     }
 
     @Override

--- a/src/main/java/com/jnulocker/registration/adapter/out/RegistrationPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/registration/adapter/out/RegistrationPersistenceAdapter.java
@@ -36,7 +36,7 @@ public class RegistrationPersistenceAdapter
 
     @Override
     public Page<Registration> getRegistrationsByEventId(UUID eventId, Pageable pageable) {
-        return registrationRepository.findAllByEventIdOptimized(eventId, pageable);
+        return registrationRepository.findAllByEventId(eventId, pageable);
     }
 
     @Override

--- a/src/main/java/com/jnulocker/registration/adapter/out/RegistrationRepository.java
+++ b/src/main/java/com/jnulocker/registration/adapter/out/RegistrationRepository.java
@@ -17,23 +17,22 @@ public interface RegistrationRepository extends JpaRepository<Registration, Long
 
     @Query(
             """
-        SELECT r FROM Registration r
-        JOIN FETCH r.member m
-        JOIN FETCH m.department d
-        JOIN FETCH r.locker l
-        JOIN FETCH l.floor f
-        WHERE f.event.id = :eventId
-        ORDER BY r.createdAt
-        """)
-    Page<Registration> findAllByEventIdOptimized(UUID eventId, Pageable pageable);
+                    SELECT r FROM Registration r
+                    JOIN FETCH r.member m
+                    JOIN FETCH m.department d
+                    JOIN FETCH r.locker l
+                    JOIN FETCH l.floor f
+                    WHERE f.event.id = :eventId
+                    """)
+    Page<Registration> findAllByEventId(UUID eventId, Pageable pageable);
 
     @Query(
             """
-        SELECT r FROM Registration r
-        JOIN FETCH r.locker l
-        JOIN FETCH l.floor f
-        WHERE r.member.id = :memberId AND f.event.id = :eventId
-        """)
+                    SELECT r FROM Registration r
+                    JOIN FETCH r.locker l
+                    JOIN FETCH l.floor f
+                    WHERE r.member.id = :memberId AND f.event.id = :eventId
+                    """)
     Optional<Registration> findByMemberIdAndEventId(Long memberId, UUID eventId);
 
     void deleteAllByLocker_Floor_Event(Event event);

--- a/src/main/java/com/jnulocker/registration/adapter/out/RegistrationRepository.java
+++ b/src/main/java/com/jnulocker/registration/adapter/out/RegistrationRepository.java
@@ -10,22 +10,31 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface RegistrationRepository extends JpaRepository<Registration, Long> {
     boolean existsByMemberIdAndLocker_Floor_EventId(Long memberId, UUID eventId);
 
-    @EntityGraph(
-            attributePaths = {
-                "member",
-                "member.department",
-                "member.department.organization",
-                "locker",
-                "locker.floor"
-            })
-    Page<Registration> findAllByLocker_Floor_EventId(UUID eventId, Pageable pageable);
+    @Query(
+            """
+        SELECT r FROM Registration r
+        JOIN FETCH r.member m
+        JOIN FETCH m.department d
+        JOIN FETCH r.locker l
+        JOIN FETCH l.floor f
+        WHERE f.event.id = :eventId
+        ORDER BY r.createdAt
+        """)
+    Page<Registration> findAllByEventIdOptimized(UUID eventId, Pageable pageable);
 
-    @EntityGraph(attributePaths = {"member", "member.department", "locker", "locker.floor"})
-    Optional<Registration> findByMemberIdAndLocker_Floor_EventId(Long memberId, UUID eventId);
+    @Query(
+            """
+        SELECT r FROM Registration r
+        JOIN FETCH r.locker l
+        JOIN FETCH l.floor f
+        WHERE r.member.id = :memberId AND f.event.id = :eventId
+        """)
+    Optional<Registration> findByMemberIdAndEventId(Long memberId, UUID eventId);
 
     void deleteAllByLocker_Floor_Event(Event event);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     name: jnu-locker
 
   datasource:
-    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}
+    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}?rewriteBatchedStatements=true
     username: ${MYSQL_USERNAME}
     password: ${MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -15,8 +15,11 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
+        jdbc:
+          batch_size: 50 # 한 번에 50개의 SQL 문을 배치로 실행
+        order_inserts: true # Action Queue 내부 insert 문을 정렬하여 실행
+        order_updates: true # Action Queue 내부 update 문을 정렬하여 실행
     defer-datasource-initialization: true
-
   sql:
     init:
       mode: never

--- a/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
@@ -873,8 +873,7 @@ class AuthControllerIntegrationTest {
 
         // 신청된 Registration과 Locker 상태 확인
         Optional<Registration> registrationBefore =
-                registrationRepository.findByMemberIdAndLocker_Floor_EventId(
-                        member.getId(), event.getId());
+                registrationRepository.findByMemberIdAndEventId(member.getId(), event.getId());
         assertThat(registrationBefore).isPresent();
 
         Locker lockerBefore = registrationBefore.get().getLocker();
@@ -890,8 +889,7 @@ class AuthControllerIntegrationTest {
 
         // Registration 삭제 확인
         Optional<Registration> registrationAfter =
-                registrationRepository.findByMemberIdAndLocker_Floor_EventId(
-                        member.getId(), event.getId());
+                registrationRepository.findByMemberIdAndEventId(member.getId(), event.getId());
         assertThat(registrationAfter).isNotPresent();
     }
 


### PR DESCRIPTION
### 개요
close #139 

### 작업사항
- 사물함 목록 조회 쿼리: IN 쿼리로 배치 조회하도록 개선
- 신청 정보 조회 쿼리: 목록 조회 및 단일 조회 모두 fetch join으로 불필요하고 중복된 join 절 제거

### 변경로직

- 사물함 목록 조회 쿼리 IN 쿼리 적용
- 신청 정보 조회 fetch join 적용


#### 사물함 조회

- 변경 전
  
  <details>
  <summary>LEFT JOIN으로 조회하는 쿼리가 floor 개수만큼 나감</summary>
  
  <br/>
  
  ```sql
  select
      l1_0.locker_id,
      l1_0.available,
      l1_0.code,
      l1_0.created_at,
      l1_0.floor_id,
      l1_0.updated_at 
  from
      locker l1_0 
  left join 
      floor f1_0 
          on f1_0.floor_id=l1_0.floor_id   -- left join 사용. 이 쿼리가 floor 개수 만큼 실행됨
  where
      f1_0.floor_id='8D71C2BC9AEC40828FE0F3C6B2998206'
  order by
      l1_0.code
  ```
  
  </details>


- 변경 후

    
  <details>
  <summary>IN 쿼리로 한 쿼리로 모든 사물함 불러옴</summary>
  
  <br/>
  
  
    ```sql
    select
        l1_0.locker_id,
        l1_0.available,
        l1_0.code,
        l1_0.created_at,
        l1_0.floor_id,
        l1_0.updated_at 
    from
        locker l1_0 
    where
        l1_0.floor_id in ('8D71C2BC9AEC40828FE0F3C6B2998206')  -- Join 대신 IN 절 사용
    order by
        l1_0.code
    ```    
    
  
  </details>


#### 신청정보 조회

단일 조회, 목록 조회 모두 동일한 효과를 가짐. 불필요한 JOIN 및 중복 JOIN이 제거되었음
아래에는 단일 조회에 대한 예시만 추가함

목록 조회에서는 `locker`, `floor`, `member`에 대한 중복 JOIN과 `event`에 대한 불필요한 JOIN이 존재했음

- 변경 전


  <details>
  <summary>모든 연관관계 엔티티들의 필드를 JOIN과 함께 불러오며 중복되는 JOIN 또한 존재</summary>
  
  <br/>
  
  
    ```sql
    select -- 불필요한 필드 조회
        r1_0.registration_id,
        r1_0.created_at,
        l2_0.locker_id,
        l2_0.available,
        l2_0.code,
        l2_0.created_at,
        f2_0.floor_id,
        f2_0.created_at,
        f2_0.event_id,
        f2_0.floor_number,
        f2_0.updated_at,
        l2_0.updated_at,
        m2_0.id,
        m2_0.created_at,
        m2_0.department_id,
        d1_0.id,
        d1_0.created_at,
        d1_0.email,
        d1_0.name,
        d1_0.nickname,
        d1_0.organization_id,
        d1_0.phone_number,
        d1_0.updated_at,
        m2_0.email,
        m2_0.name,
        m2_0.password,
        m2_0.phone_number,
        m2_0.role,
        m2_0.student_number,
        m2_0.updated_at,
        r1_0.updated_at 
    from
        registration r1_0 
    left join
        member m1_0 
            on m1_0.id=r1_0.member_id  -- 불필요한 JOIN
    left join
        locker l1_0 
            on l1_0.locker_id=r1_0.locker_id 
    left join
        floor f1_0 
            on f1_0.floor_id=l1_0.floor_id 
    left join
        event e1_0 
            on e1_0.event_id=f1_0.event_id  -- 불필요한 JOIN
    left join
        locker l2_0 
            on l2_0.locker_id=r1_0.locker_id  -- 중복 JOIN
    left join
        floor f2_0 
            on f2_0.floor_id=l2_0.floor_id  -- 중복 JOIN
    left join
        member m2_0 
            on m2_0.id=r1_0.member_id  -- 중복 JOIN
    left join
        department d1_0 
            on d1_0.id=m2_0.department_id  -- 불필요한 JOIN
    where
        m1_0.id=1 
        and e1_0.event_id='2A38A88F470C4AFEA17F7D4666C4F619'
    ```    
    
  
  </details>




- 변경 후


  <details>
  <summary>필요한 필드, JOIN만 수행</summary>
  
  <br/>
 
  
    ```sql
    select
        r1_0.registration_id,
        r1_0.created_at,
        l1_0.locker_id,
        l1_0.available,
        l1_0.code,
        l1_0.created_at,
        f1_0.floor_id,
        f1_0.created_at,
        f1_0.event_id,
        f1_0.floor_number,
        f1_0.updated_at,
        l1_0.updated_at,
        r1_0.member_id,
        r1_0.updated_at 
    from
        registration r1_0 
    join
        locker l1_0 
            on l1_0.locker_id=r1_0.locker_id 
    join
        floor f1_0 
            on f1_0.floor_id=l1_0.floor_id 
    where
        r1_0.member_id=1 
        and f1_0.event_id='2A38A88F470C4AFEA17F7D4666C4F619'

    ```    
    
  
  </details>



### 테스트 결과
<img width="344" alt="image" src="https://github.com/user-attachments/assets/ef609ee0-29b4-44bd-9eec-31a3287aaec3" />


### reference

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **기능 개선**
  - 여러 층의 사물함을 한 번에 조회할 수 있도록 사물함 조회 기능이 개선되었습니다.
  - 층 및 사물함 응답 생성 방식이 도메인 객체 기반으로 변경되어 데이터 변환이 간소화되었습니다.

- **성능 최적화**
  - 데이터베이스 배치 처리 및 Hibernate 설정이 추가되어 대량 데이터 처리 성능이 향상되었습니다.

- **버그 수정**
  - 회원 탈퇴 시 사물함 신청 내역 삭제 및 사물함 상태 변경 테스트가 간소화되었습니다.

- **코드 리팩터링**
  - 사물함 및 등록 관련 쿼리 방식이 더 효율적으로 변경되었습니다.
  - 등록 관련 쿼리에서 복잡한 연관관계 대신 명확한 JPQL 쿼리를 사용하도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->