### PR TITLE
[FEAT] 이벤트 생성, 수정 요청 본문 검증 로직 추가 및 사물함 정보 조회 로직 개선

### DIFF
--- a/src/main/java/com/jnulocker/events/application/port/in/request/CreateEventRequest.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/request/CreateEventRequest.java
@@ -30,6 +30,17 @@ public record CreateEventRequest(
 
     @AssertTrue(message = "이벤트 종료 시간은 시작 시간 이후여야 합니다.")
     private boolean isEndAtAfterStartAt() {
-        return startAt == null || endAt == null || !endAt.isBefore(startAt);
+        return !endAt.isBefore(startAt);
+    }
+
+    @AssertTrue(message = "전체 사물함 개수는 2000개를 초과할 수 없습니다.")
+    private boolean isTotalLockersWithinLimit() {
+        int lockerCount =
+                floors.stream()
+                        .flatMap(floor -> floor.prefixes().stream())
+                        .flatMap(prefix -> prefix.ranges().stream())
+                        .mapToInt(range -> range.lockerEndNumber() - range.lockerStartNumber() + 1)
+                        .sum();
+        return lockerCount <= 2000;
     }
 }

--- a/src/main/java/com/jnulocker/events/application/port/in/request/CreateEventRequest.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/request/CreateEventRequest.java
@@ -35,17 +35,6 @@ public record CreateEventRequest(
 
     @AssertTrue(message = "전체 사물함 개수는 2000개를 초과할 수 없습니다.")
     private boolean isTotalLockersWithinLimit() {
-        // null 여부는 @NotNull에 의해 처리되므로, null이면 검증 스킵
-        int lockerCount =
-                floors.stream()
-                        .flatMap(floor -> floor.prefixes().stream())
-                        .flatMap(prefix -> prefix.ranges().stream())
-                        .filter(
-                                range ->
-                                        range.lockerStartNumber() != null
-                                                && range.lockerEndNumber() != null)
-                        .mapToInt(range -> range.lockerEndNumber() - range.lockerStartNumber() + 1)
-                        .sum();
-        return lockerCount <= 2000;
+        return LockerValidationUtils.isTotalLockersWithinLimit(floors);
     }
 }

--- a/src/main/java/com/jnulocker/events/application/port/in/request/CreateEventRequest.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/request/CreateEventRequest.java
@@ -35,6 +35,7 @@ public record CreateEventRequest(
 
     @AssertTrue(message = "전체 사물함 개수는 2000개를 초과할 수 없습니다.")
     private boolean isTotalLockersWithinLimit() {
+        // null 여부는 @NotNull에 의해 처리되므로, null이면 검증 스킵
         int lockerCount =
                 floors.stream()
                         .flatMap(floor -> floor.prefixes().stream())

--- a/src/main/java/com/jnulocker/events/application/port/in/request/CreateEventRequest.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/request/CreateEventRequest.java
@@ -30,7 +30,7 @@ public record CreateEventRequest(
 
     @AssertTrue(message = "이벤트 종료 시간은 시작 시간 이후여야 합니다.")
     private boolean isEndAtAfterStartAt() {
-        return !endAt.isBefore(startAt);
+        return startAt == null || endAt == null || !endAt.isBefore(startAt);
     }
 
     @AssertTrue(message = "전체 사물함 개수는 2000개를 초과할 수 없습니다.")
@@ -39,6 +39,10 @@ public record CreateEventRequest(
                 floors.stream()
                         .flatMap(floor -> floor.prefixes().stream())
                         .flatMap(prefix -> prefix.ranges().stream())
+                        .filter(
+                                range ->
+                                        range.lockerStartNumber() != null
+                                                && range.lockerEndNumber() != null)
                         .mapToInt(range -> range.lockerEndNumber() - range.lockerStartNumber() + 1)
                         .sum();
         return lockerCount <= 2000;

--- a/src/main/java/com/jnulocker/events/application/port/in/request/LockerRange.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/request/LockerRange.java
@@ -3,11 +3,16 @@ package com.jnulocker.events.application.port.in.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 
 public record LockerRange(
-        @Schema(description = "사물함 시작 번호", example = "1") @NotNull(message = "사물함 시작 번호는 필수입니다.")
+        @Schema(description = "사물함 시작 번호", example = "1")
+                @NotNull(message = "사물함 시작 번호는 필수입니다.")
+                @PositiveOrZero(message = "사물함 시작 번호는 0 이상이어야 합니다.")
                 Integer lockerStartNumber,
-        @Schema(description = "사물함 종료 번호", example = "20") @NotNull(message = "사물함 종료 번호는 필수입니다.")
+        @Schema(description = "사물함 종료 번호", example = "20")
+                @NotNull(message = "사물함 종료 번호는 필수입니다.")
+                @PositiveOrZero(message = "사물함 종료 번호는 0 이상이어야 합니다.")
                 Integer lockerEndNumber) {
 
     @AssertTrue(message = "사물함 종료 번호는 시작 번호보다 크거나 같아야 합니다.")

--- a/src/main/java/com/jnulocker/events/application/port/in/request/LockerValidationUtils.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/request/LockerValidationUtils.java
@@ -1,0 +1,24 @@
+package com.jnulocker.events.application.port.in.request;
+
+import java.util.List;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class LockerValidationUtils {
+
+    public static final int MAX_LOCKER_COUNT = 2000;
+
+    public static boolean isTotalLockersWithinLimit(List<FloorInfo> floors) {
+        int lockerCount =
+                floors.stream()
+                        .flatMap(floor -> floor.prefixes().stream())
+                        .flatMap(prefix -> prefix.ranges().stream())
+                        .filter(
+                                range ->
+                                        range.lockerStartNumber() != null
+                                                && range.lockerEndNumber() != null)
+                        .mapToInt(range -> range.lockerEndNumber() - range.lockerStartNumber() + 1)
+                        .sum();
+        return lockerCount <= MAX_LOCKER_COUNT;
+    }
+}

--- a/src/main/java/com/jnulocker/events/application/port/in/request/PrefixInfo.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/request/PrefixInfo.java
@@ -3,10 +3,14 @@ package com.jnulocker.events.application.port.in.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
 import java.util.List;
 
 public record PrefixInfo(
         @Schema(description = "사물함 접두사 (선택사항, 기본값: 빈 문자열)", example = "A", nullable = true)
+                @Pattern(
+                        regexp = "^[A-Za-zㄱ-ㅣ가-힣0-9]*$",
+                        message = "사물함 접두사는 영어, 한글, 숫자만 포함할 수 있습니다.")
                 String lockerPrefix,
         @Schema(description = "사물함 번호 범위 목록")
                 @NotEmpty(message = "사물함 번호 범위는 최소 1개 이상이어야 합니다.")

--- a/src/main/java/com/jnulocker/events/application/port/in/request/UpdateEventRequest.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/request/UpdateEventRequest.java
@@ -30,15 +30,20 @@ public record UpdateEventRequest(
 
     @AssertTrue(message = "이벤트 종료 시간은 시작 시간 이후여야 합니다.")
     private boolean isEndAtAfterStartAt() {
-        return !endAt.isBefore(startAt);
+        return startAt == null || endAt == null || !endAt.isBefore(startAt);
     }
 
     @AssertTrue(message = "전체 사물함 개수는 2000개를 초과할 수 없습니다.")
     private boolean isTotalLockersWithinLimit() {
+        // 시작 번호, 종료 번호는 검증하지 않는다
         int lockerCount =
                 floors.stream()
                         .flatMap(floor -> floor.prefixes().stream())
                         .flatMap(prefix -> prefix.ranges().stream())
+                        .filter(
+                                range ->
+                                        range.lockerStartNumber() != null
+                                                && range.lockerEndNumber() != null)
                         .mapToInt(range -> range.lockerEndNumber() - range.lockerStartNumber() + 1)
                         .sum();
         return lockerCount <= 2000;

--- a/src/main/java/com/jnulocker/events/application/port/in/request/UpdateEventRequest.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/request/UpdateEventRequest.java
@@ -35,17 +35,6 @@ public record UpdateEventRequest(
 
     @AssertTrue(message = "전체 사물함 개수는 2000개를 초과할 수 없습니다.")
     private boolean isTotalLockersWithinLimit() {
-        // null 여부는 @NotNull에 의해 처리되므로, null이면 검증 스킵
-        int lockerCount =
-                floors.stream()
-                        .flatMap(floor -> floor.prefixes().stream())
-                        .flatMap(prefix -> prefix.ranges().stream())
-                        .filter(
-                                range ->
-                                        range.lockerStartNumber() != null
-                                                && range.lockerEndNumber() != null)
-                        .mapToInt(range -> range.lockerEndNumber() - range.lockerStartNumber() + 1)
-                        .sum();
-        return lockerCount <= 2000;
+        return LockerValidationUtils.isTotalLockersWithinLimit(floors);
     }
 }

--- a/src/main/java/com/jnulocker/events/application/port/in/request/UpdateEventRequest.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/request/UpdateEventRequest.java
@@ -30,6 +30,17 @@ public record UpdateEventRequest(
 
     @AssertTrue(message = "이벤트 종료 시간은 시작 시간 이후여야 합니다.")
     private boolean isEndAtAfterStartAt() {
-        return startAt == null || endAt == null || !endAt.isBefore(startAt);
+        return !endAt.isBefore(startAt);
+    }
+
+    @AssertTrue(message = "전체 사물함 개수는 2000개를 초과할 수 없습니다.")
+    private boolean isTotalLockersWithinLimit() {
+        int lockerCount =
+                floors.stream()
+                        .flatMap(floor -> floor.prefixes().stream())
+                        .flatMap(prefix -> prefix.ranges().stream())
+                        .mapToInt(range -> range.lockerEndNumber() - range.lockerStartNumber() + 1)
+                        .sum();
+        return lockerCount <= 2000;
     }
 }

--- a/src/main/java/com/jnulocker/events/application/port/in/request/UpdateEventRequest.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/request/UpdateEventRequest.java
@@ -35,7 +35,7 @@ public record UpdateEventRequest(
 
     @AssertTrue(message = "전체 사물함 개수는 2000개를 초과할 수 없습니다.")
     private boolean isTotalLockersWithinLimit() {
-        // 시작 번호, 종료 번호는 검증하지 않는다
+        // null 여부는 @NotNull에 의해 처리되므로, null이면 검증 스킵
         int lockerCount =
                 floors.stream()
                         .flatMap(floor -> floor.prefixes().stream())

--- a/src/main/java/com/jnulocker/events/infrastructure/mapper/LockerMapper.java
+++ b/src/main/java/com/jnulocker/events/infrastructure/mapper/LockerMapper.java
@@ -6,129 +6,77 @@ import com.jnulocker.events.application.port.in.request.PrefixInfo;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
 import com.jnulocker.events.application.port.in.response.LockerResponse;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 
-/** 사물함 정보를 다양한 형태로 변환하는 매퍼 클래스입니다. 주로 사물함 데이터를 API 요청/응답 형식으로 변환하는 기능을 담당합니다. */
 @Slf4j
 @UtilityClass
 public class LockerMapper {
 
-    /**
-     * 사물함 코드 패턴: prefix-number 또는 number 예: "A-123", "123", "B-456", "789" </br> 정규표현식 설명 -
-     * (?:([A-Za-zㄱ-ㅣ가-힣0-9]+)-)? : 선택적 접두사 (영문자, 한글, 숫자)와 하이픈 </br> - ([A-Za-zㄱ-ㅣ가-힣0-9]+) : 접두사
-     * (영문자, 한글, 숫자) </br> - - : 하이픈 </br> - ?:(...): 캡쳐하지 않고 그룹화 </br> - ...?: 0회 또는 1회 반복 </br> -
-     * 위 내용 해석: 문자와 하이픈을 포함한 접두사가 있거나 없을 수 있고, 있다면 하이픈을 포함하지 않고 문자만 캡쳐 </br> - (\\d+) : 필수 숫자 부분
-     */
-    private static final Pattern LOCKER_CODE_PATTERN =
-            Pattern.compile("^(?:([A-Za-zㄱ-ㅣ가-힣0-9]+)-)?(\\d+)$");
-
-    /**
-     * FloorWithLockersResponse 목록을 FloorInfo 목록으로 변환합니다. 이 메소드는 사물함 코드를 분석하여 prefix, 숫자 범위를 추출하고
-     * 그룹화합니다.
-     */
     public static List<FloorInfo> toFloorInfos(List<FloorWithLockersResponse> floorWithLockers) {
         return floorWithLockers.stream().map(LockerMapper::toFloorInfo).toList();
     }
 
-    /** 단일 FloorWithLockersResponse를 FloorInfo로 변환합니다. */
     private static FloorInfo toFloorInfo(FloorWithLockersResponse floorWithLockers) {
-        // 같은 prefix를 가진 사물함을 그룹화
-        Map<String, List<LockerResponse>> lockersByPrefix =
-                groupLockersByPrefix(floorWithLockers.lockers());
+        // 사물함 코드에서 접두사와 번호를 추출하여 접두사별로 번호를 그룹화
+        Map<String, List<Integer>> numbersByPrefix = new HashMap<>();
+        for (LockerResponse locker : floorWithLockers.lockers()) {
+            LockerCodeInfo codeInfo = extractLockerCodeInfo(locker.code());
+            numbersByPrefix
+                    .computeIfAbsent(codeInfo.prefix(), k -> new ArrayList<>())
+                    .add(codeInfo.number());
+        }
 
-        // 각 prefix 그룹을 PrefixInfo로 변환
-        List<PrefixInfo> prefixes =
-                lockersByPrefix.entrySet().stream()
-                        .map(entry -> toPrefixInfo(entry.getKey(), entry.getValue()))
-                        .toList();
+        // 접두사별로 번호를 정렬하고 범위로 변환
+        List<PrefixInfo> prefixes = new ArrayList<>();
+        for (Map.Entry<String, List<Integer>> entry : numbersByPrefix.entrySet()) {
+            Collections.sort(entry.getValue());
+            List<LockerRange> ranges = toLockerRanges(entry.getValue());
+            prefixes.add(new PrefixInfo(entry.getKey(), ranges));
+        }
 
         return new FloorInfo(floorWithLockers.floorNumber(), prefixes);
     }
 
-    /** 사물함 목록을 prefix별로 그룹화합니다. */
-    private static Map<String, List<LockerResponse>> groupLockersByPrefix(
-            List<LockerResponse> lockers) {
-        Map<String, List<LockerResponse>> result = new HashMap<>();
-
-        for (LockerResponse locker : lockers) {
-            // 사물함 코드에서 prefix와 number 추출
-            LockerCodeInfo codeInfo = extractLockerCodeInfo(locker.code());
-
-            // prefix별로 그룹화
-            String prefix = codeInfo.prefix() != null ? codeInfo.prefix() : "";
-            result.computeIfAbsent(prefix, k -> new ArrayList<>()).add(locker);
-        }
-
-        return result;
-    }
-
-    /** prefix와 사물함 목록을 PrefixInfo로 변환합니다. */
-    private static PrefixInfo toPrefixInfo(String prefix, List<LockerResponse> lockers) {
-        // 각 사물함 코드의 숫자 부분 추출
-        List<Integer> numbers =
-                lockers.stream()
-                        .map(locker -> extractLockerCodeInfo(locker.code()).number())
-                        .sorted()
-                        .toList();
-
-        // 연속된 숫자 범위를 LockerRange로 변환
-        List<LockerRange> ranges = toLockerRanges(numbers);
-
-        // prefix가 빈 문자열이면 null로 설정 (사물함 코드가 숫자만 있는 경우)
-        String actualPrefix = prefix.isEmpty() ? null : prefix;
-
-        return new PrefixInfo(actualPrefix, ranges);
-    }
-
-    /** 정렬된 숫자 목록을 연속된 범위로 그룹화하여 LockerRange 목록으로 변환합니다. */
-    private static List<LockerRange> toLockerRanges(List<Integer> sortedNumbers) {
-        if (sortedNumbers.isEmpty()) {
+    private static List<LockerRange> toLockerRanges(List<Integer> numbers) {
+        if (numbers.isEmpty()) {
             return List.of();
         }
 
         List<LockerRange> ranges = new ArrayList<>();
-        int start = sortedNumbers.getFirst();
+        int start = numbers.getFirst();
         int prev = start;
-
-        for (int i = 1; i < sortedNumbers.size(); i++) {
-            int current = sortedNumbers.get(i);
-
-            // 연속되지 않은 숫자를 만나면 새로운 범위 시작
-            if (current > prev + 1) {
+        for (int i = 1; i <= numbers.size(); i++) {
+            if (i == numbers.size() || numbers.get(i) > prev + 1) {
                 ranges.add(new LockerRange(start, prev));
-                start = current;
+                if (i < numbers.size()) {
+                    start = numbers.get(i);
+                    prev = start;
+                }
+            } else {
+                prev = numbers.get(i);
             }
-
-            prev = current;
         }
-
-        // 마지막 범위 추가
-        ranges.add(new LockerRange(start, prev));
-
         return ranges;
     }
 
-    /** 사물함 코드에서 prefix와 숫자 부분을 추출합니다. */
     private static LockerCodeInfo extractLockerCodeInfo(String code) {
-        Matcher matcher = LOCKER_CODE_PATTERN.matcher(code);
-
-        if (matcher.matches()) {
-            String prefix = matcher.group(1); // prefix (optional)
-            int number = Integer.parseInt(matcher.group(2)); // number
-            return new LockerCodeInfo(prefix, number);
+        int hyphenIndex = code.lastIndexOf('-');
+        String prefix = null;
+        String numberPart = code;
+        if (hyphenIndex >= 0) {
+            prefix = code.substring(0, hyphenIndex);
+            numberPart = code.substring(hyphenIndex + 1);
         }
 
-        // 패턴이 일치하지 않으면 코드 전체를 숫자로 파싱 시도
         try {
-            return new LockerCodeInfo(null, Integer.parseInt(code));
+            int number = Integer.parseInt(numberPart);
+            return new LockerCodeInfo(prefix, number);
         } catch (NumberFormatException e) {
-            // 숫자로 파싱할 수 없으면 prefix가 있는 것으로 간주하고 처리
             log.warn("유효하지 않은 사물함 코드 형식: {}", code);
             return new LockerCodeInfo(code, 0);
         }


### PR DESCRIPTION
### 개요
close #143 

### 작업사항
- 이벤트 생성, 수정 요청 본문 검증 로직 추가
- 사물함 정보 조회 로직 개선

### 변경로직
- 이벤트 생성, 수정 검증 로직 적용
  - 이벤트당 사물함은 최대 2000개 생성 가능
  - 사물함 접두사는 영어, 한글, 숫자만 가능

- 사물함 조회 로직 개선
  - 과한 메모리 사용을 줄이기 위해 중간 객체 제거

### 테스트 결과
<img width="344" alt="image" src="https://github.com/user-attachments/assets/8396119b-8c15-4a62-85fa-d6161e1b0211" />

### reference

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 이벤트 생성 및 수정 시 전체 사물함 개수가 2000개를 초과하지 않도록 검증이 추가되었습니다.
- **버그 수정**
    - 사물함 범위의 시작 및 끝 번호에 0 이상의 값만 입력할 수 있도록 제한되었습니다.
    - 사물함 접두사에 영어, 한글, 숫자만 사용할 수 있도록 입력값 검증이 강화되었습니다.
- **리팩토링**
    - 사물함 코드 그룹화 및 범위 계산 로직이 간소화되어 성능과 안정성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->