### PR TITLE
[FEAT] Node exporter, cAdvisor 모니터링 추가

### DIFF
--- a/config/prometheus.yml.tmpl
+++ b/config/prometheus.yml.tmpl
@@ -2,7 +2,16 @@ global:
   scrape_interval: ${SCRAPE_INTERVAL}
   evaluation_interval: ${EVALUATION_INTERVAL}
 scrape_configs:
-  - job_name: 'prometheus'
+  - job_name: 'spring-boot-app'
     metrics_path: '${MANAGEMENT_BASE_PATH}/prometheus'
     static_configs:
       - targets: ['${WAS_TARGET}:8080']
+
+  - job_name: 'node-exporter'
+    metrics_path: '/metrics'
+    static_configs:
+      - targets: ['node-exporter:9100']
+
+  - job_name: 'docker-containers'
+    static_configs:
+      - targets: ["cadvisor:8090"]

--- a/config/prometheus.yml.tmpl
+++ b/config/prometheus.yml.tmpl
@@ -13,5 +13,6 @@ scrape_configs:
       - targets: ['node-exporter:9100']
 
   - job_name: 'docker-containers'
+    metrics_path: '/metrics'
     static_configs:
       - targets: ["cadvisor:8090"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     image: mysql:8.0
     ports:
       - "3306:3306"
+    restart: unless-stopped
     environment:
       TZ: Asia/Seoul
       LC_ALL: C.UTF-8
@@ -28,6 +29,7 @@ services:
     image: redis:alpine
     ports:
       - "6379:6379"
+    restart: unless-stopped
     command: /bin/sh -c "redis-server --requirepass $REDIS_PASSWORD"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
@@ -44,11 +46,12 @@ services:
     image: ${DOCKER_USERNAME}/${DOCKER_REPO}:${IMAGE_TAG}
     ports:
       - "8080:8080"
+    restart: unless-stopped
     env_file:
       - .env
     healthcheck:
       test: [ "CMD-SHELL", "wget -q --spider http://localhost:8080$MANAGEMENT_BASE_PATH/health || exit 1" ]
-      start_period: 36s
+      start_period: 50s
       start_interval: 5s
       interval: 10s
       timeout: 5s
@@ -63,12 +66,52 @@ services:
     networks:
       - jnu-locker-network
 
+  node-exporter:
+    image: prom/node-exporter:latest
+    container_name: node-exporter-jnu-locker
+    restart: unless-stopped
+    ports:
+      - "9100:9100"
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.rootfs=/rootfs'
+      - '--path.sysfs=/host/sys'
+      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
+    networks:
+      - jnu-locker-network
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:latest
+    container_name: cadvisor-jnu-locker
+    restart: unless-stopped
+    ports:
+      - "8090:8080"
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:rw
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/healthz"]
+      start_period: 15s
+      start_interval: 3s
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    networks:
+      - jnu-locker-network
+
   prometheus:
     # user: root # 최초 실행시에만 하기 (컨테이너 접속 후 /data 경로 nobody 권한 주는 용도)
     container_name: prometheus-jnu-locker
     image: prom/prometheus:latest
     ports:
       - "9090:9090"
+    restart: unless-stopped
     volumes:
       - ./config/prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus-data:/data
@@ -94,6 +137,7 @@ services:
     image: grafana/grafana:latest
     ports:
       - "3000:3000"
+    restart: unless-stopped
     volumes:
       - grafana-data:/var/lib/grafana
     environment:
@@ -118,6 +162,7 @@ services:
     ports:
       - "80:80"
       - "443:443"
+    restart: unless-stopped
     volumes:
       - ./nginx/conf.d/default.conf:/etc/nginx/conf.d/default.conf
       - ./nginx/log:/home/jnu-locker/log


### PR DESCRIPTION
### 개요
close #145 

### 작업사항
- Node exporter, cAdvisor 모니터링 추가

### 변경로직
- docker-compose.yml node exporter, cadvisor 서비스 추가
- prometheus 설정에 job 등록

### 테스트 결과
- Spring Boot 모니터링
    
  <img width="1470" alt="image" src="https://github.com/user-attachments/assets/5d71b67c-10b8-49c4-b0d9-b93c41335dd8" />

- Node Exporter 모니터링: EC2 인스턴스

  <img width="1470" alt="image" src="https://github.com/user-attachments/assets/be39fa36-2cf4-4942-8e95-8c83e281c6cd" />


- cAdvisor 모니터링: 도커 컨테이너

  <img width="1470" alt="image" src="https://github.com/user-attachments/assets/0514c086-286f-4428-b459-a322e8362aac" />


### reference
- 추후 모니터링을 위한 EC2 등의 서버를 분리하고 Grafana 접속을 위한 도메인을 적용할 예정입니다.

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 시스템 및 도커 컨테이너 모니터링을 위한 node-exporter와 cadvisor 서비스를 추가하였습니다.

- **버그 수정**
  - 모든 서비스 컨테이너에 자동 재시작 정책(restart: unless-stopped)을 적용하여 안정성을 개선하였습니다.

- **기타 변경**
  - was 서비스의 healthcheck 시작 대기 시간이 36초에서 50초로 조정되었습니다.
  - Prometheus 모니터링 설정이 업데이트되어 새로운 모니터링 대상이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->