### PR TITLE
[FEAT] 특정 이벤트에 해당하는 모든 사물함 신청 정보 조회 API 구현

### DIFF
--- a/config/prometheus.yml.tmpl
+++ b/config/prometheus.yml.tmpl
@@ -15,4 +15,4 @@ scrape_configs:
   - job_name: 'docker-containers'
     metrics_path: '/metrics'
     static_configs:
-      - targets: ["cadvisor:8090"]
+      - targets: ["cadvisor:8080"]

--- a/src/main/java/com/jnulocker/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/jnulocker/auth/jwt/JwtFilter.java
@@ -59,8 +59,6 @@ public class JwtFilter extends OncePerRequestFilter {
     }
 
     private static final String MEDIA_TYPE = "application/json; charset=UTF-8";
-    private static final String AUTHORIZATION_HEADER = "Authorization";
-    private static final String BEARER_PREFIX = "Bearer ";
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
     @Override

--- a/src/main/java/com/jnulocker/config/SecurityConfig.java
+++ b/src/main/java/com/jnulocker/config/SecurityConfig.java
@@ -86,6 +86,8 @@ public class SecurityConfig {
                                         "/v1/auth/managers/pending",
                                         "/v1/events",
                                         "/v1/events/*",
+                                        "/v1/events/*/registrations",
+                                        "/v1/events/*/registrations/all",
                                         "/v1/announces",
                                         "/v1/announces/*")
                                 .hasAuthority(Role.MANAGER.getRole())

--- a/src/main/java/com/jnulocker/registration/adapter/in/RegistrationController.java
+++ b/src/main/java/com/jnulocker/registration/adapter/in/RegistrationController.java
@@ -5,9 +5,11 @@ import com.jnulocker.registration.application.port.in.RegistrationCommand;
 import com.jnulocker.registration.application.port.in.RegistrationQuery;
 import com.jnulocker.registration.application.port.in.request.RegisterForEventRequest;
 import com.jnulocker.registration.application.port.in.response.RegistrationCustomPage;
+import com.jnulocker.registration.application.port.in.response.RegistrationListItem;
 import com.jnulocker.registration.application.port.in.response.RegistrationPageable;
 import com.jnulocker.registration.application.port.in.response.RegistrationResponse;
 import jakarta.validation.Valid;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
@@ -37,6 +39,13 @@ public class RegistrationController implements RegistrationApi {
             @Valid @ParameterObject RegistrationPageable registrationPageable) {
         Pageable pageable = registrationPageable.toPageable();
         return ResponseEntity.ok(registrationQuery.getRegistrations(eventId, pageable));
+    }
+
+    @Override
+    @GetMapping("/all")
+    public ResponseEntity<List<RegistrationListItem>> getAllRegistrations(
+            @PathVariable("event-id") UUID eventId) {
+        return ResponseEntity.ok(registrationQuery.getAllRegistrations(eventId));
     }
 
     @Override

--- a/src/main/java/com/jnulocker/registration/adapter/in/docs/RegistrationApi.java
+++ b/src/main/java/com/jnulocker/registration/adapter/in/docs/RegistrationApi.java
@@ -3,6 +3,7 @@ package com.jnulocker.registration.adapter.in.docs;
 import com.jnulocker.common.swagger.ApiExceptionExamples;
 import com.jnulocker.registration.application.port.in.request.RegisterForEventRequest;
 import com.jnulocker.registration.application.port.in.response.RegistrationCustomPage;
+import com.jnulocker.registration.application.port.in.response.RegistrationListItem;
 import com.jnulocker.registration.application.port.in.response.RegistrationPageable;
 import com.jnulocker.registration.application.port.in.response.RegistrationResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,6 +12,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import java.util.UUID;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.MediaType;
@@ -33,6 +35,18 @@ public interface RegistrationApi {
     ResponseEntity<RegistrationCustomPage> getRegistrations(
             @PathVariable("event-id") UUID eventId,
             @Valid @ParameterObject RegistrationPageable registrationPageable);
+
+    @ApiExceptionExamples(GetRegistrationsExceptionDocs.class)
+    @Operation(summary = "사물함 신청 목록 전체 조회", description = "이벤트에 대한 신청 목록을 전체 조회합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "사물함 신청 목록 전체 조회 성공",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = RegistrationListItem.class)))
+    ResponseEntity<List<RegistrationListItem>> getAllRegistrations(
+            @PathVariable("event-id") UUID eventId);
 
     @ApiExceptionExamples(GetMyRegistrationExceptionDocs.class)
     @Operation(summary = "자신의 사물함 신청 현황 조회", description = "이벤트에 대한 자신의 신청 현황을 조회합니다")

--- a/src/main/java/com/jnulocker/registration/adapter/out/RegistrationPersistenceAdapter.java
+++ b/src/main/java/com/jnulocker/registration/adapter/out/RegistrationPersistenceAdapter.java
@@ -40,6 +40,11 @@ public class RegistrationPersistenceAdapter
     }
 
     @Override
+    public List<Registration> getAllRegistrationsByEventId(UUID eventId) {
+        return registrationRepository.findAllByEventId(eventId);
+    }
+
+    @Override
     public Optional<Registration> getRegistrationByMemberIdAndEventId(Long memberId, UUID eventId) {
         return registrationRepository.findByMemberIdAndEventId(memberId, eventId);
     }

--- a/src/main/java/com/jnulocker/registration/adapter/out/RegistrationRepository.java
+++ b/src/main/java/com/jnulocker/registration/adapter/out/RegistrationRepository.java
@@ -12,7 +12,8 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-public interface RegistrationRepository extends JpaRepository<Registration, Long> {
+public interface RegistrationRepository
+        extends JpaRepository<Registration, Long>, RegistrationRepositoryCustom {
     boolean existsByMemberIdAndLocker_Floor_EventId(Long memberId, UUID eventId);
 
     @Query(

--- a/src/main/java/com/jnulocker/registration/adapter/out/RegistrationRepositoryCustom.java
+++ b/src/main/java/com/jnulocker/registration/adapter/out/RegistrationRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.jnulocker.registration.adapter.out;
+
+import com.jnulocker.registration.domain.Registration;
+import java.util.List;
+import java.util.UUID;
+
+public interface RegistrationRepositoryCustom {
+
+    List<Registration> findAllByEventId(UUID eventId);
+}

--- a/src/main/java/com/jnulocker/registration/adapter/out/RegistrationRepositoryCustomImpl.java
+++ b/src/main/java/com/jnulocker/registration/adapter/out/RegistrationRepositoryCustomImpl.java
@@ -1,0 +1,28 @@
+package com.jnulocker.registration.adapter.out;
+
+import static com.jnulocker.events.domain.QFloor.floor;
+import static com.jnulocker.events.domain.QLocker.locker;
+import static com.jnulocker.registration.domain.QRegistration.*;
+
+import com.jnulocker.registration.domain.Registration;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class RegistrationRepositoryCustomImpl implements RegistrationRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Registration> findAllByEventId(UUID eventId) {
+        return queryFactory
+                .selectFrom(registration)
+                .where(floor.event.id.eq(eventId))
+                .join(locker.floor)
+                // 층 번호 오름차순, 사물함 코드 오름차순
+                .orderBy(floor.floorNumber.asc(), locker.code.asc())
+                .fetch();
+    }
+}

--- a/src/main/java/com/jnulocker/registration/application/port/in/RegistrationQuery.java
+++ b/src/main/java/com/jnulocker/registration/application/port/in/RegistrationQuery.java
@@ -1,12 +1,16 @@
 package com.jnulocker.registration.application.port.in;
 
 import com.jnulocker.registration.application.port.in.response.RegistrationCustomPage;
+import com.jnulocker.registration.application.port.in.response.RegistrationListItem;
 import com.jnulocker.registration.application.port.in.response.RegistrationResponse;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 
 public interface RegistrationQuery {
     RegistrationCustomPage getRegistrations(UUID eventId, Pageable pageable);
+
+    List<RegistrationListItem> getAllRegistrations(UUID eventId);
 
     RegistrationResponse getMyRegistration(UUID eventId);
 }

--- a/src/main/java/com/jnulocker/registration/application/port/out/RegistrationLoadPort.java
+++ b/src/main/java/com/jnulocker/registration/application/port/out/RegistrationLoadPort.java
@@ -14,6 +14,8 @@ public interface RegistrationLoadPort {
 
     Page<Registration> getRegistrationsByEventId(UUID eventId, Pageable pageable);
 
+    List<Registration> getAllRegistrationsByEventId(UUID eventId);
+
     Optional<Registration> getRegistrationByMemberIdAndEventId(Long memberId, UUID eventId);
 
     List<Registration> getAllByMember(Member member);

--- a/src/main/java/com/jnulocker/registration/application/service/RegistrationQueryService.java
+++ b/src/main/java/com/jnulocker/registration/application/service/RegistrationQueryService.java
@@ -5,10 +5,12 @@ import com.jnulocker.events.application.port.in.EventQuery;
 import com.jnulocker.events.domain.Event;
 import com.jnulocker.registration.application.port.in.RegistrationQuery;
 import com.jnulocker.registration.application.port.in.response.RegistrationCustomPage;
+import com.jnulocker.registration.application.port.in.response.RegistrationListItem;
 import com.jnulocker.registration.application.port.in.response.RegistrationResponse;
 import com.jnulocker.registration.application.port.out.RegistrationLoadPort;
 import com.jnulocker.registration.domain.Registration;
 import com.jnulocker.registration.exception.RegistrationNotFoundException;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -30,6 +32,14 @@ public class RegistrationQueryService implements RegistrationQuery {
         Page<Registration> registrations =
                 registrationLoadPort.getRegistrationsByEventId(event.getId(), pageable);
         return RegistrationCustomPage.from(registrations);
+    }
+
+    @Override
+    public List<RegistrationListItem> getAllRegistrations(UUID eventId) {
+        Event event = eventQuery.getByIdOrThrow(eventId);
+        List<Registration> registrations =
+                registrationLoadPort.getAllRegistrationsByEventId(event.getId());
+        return registrations.stream().map(RegistrationListItem::from).toList();
     }
 
     @Override

--- a/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
@@ -183,7 +183,7 @@ public class RegistrationControllerIntegrationTest extends RedisTest {
         RegistrationListItem firstItem = registrations.get(0);
         RegistrationListItem secondItem = registrations.get(1);
 
-        // 첫 번째 항목 (1층 2번 사물함, 사용자 1)
+        // 첫 번째 항목 (1층 사물함, 사용자 1)
         assertThat(firstItem.floorNumber()).isEqualTo(1);
         assertThat(firstItem.lockerCode()).isEqualTo(user1Locker);
         assertThat(firstItem.member().name()).isEqualTo(user1.getName());
@@ -193,7 +193,7 @@ public class RegistrationControllerIntegrationTest extends RedisTest {
         assertThat(firstItem.member().department()).isEqualTo(user1.getDepartment().getName());
         assertThat(firstItem.member().email()).isEqualTo(user1.getEmail());
 
-        // 두 번째 항목 (2층 3번 사물함, 사용자 2)
+        // 두 번째 항목 (2층 사물함, 사용자 2)
         assertThat(secondItem.floorNumber()).isEqualTo(2);
         assertThat(secondItem.lockerCode()).isEqualTo(user2Locker);
         assertThat(secondItem.member().name()).isEqualTo(user2.getName());

--- a/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
@@ -8,8 +8,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.jnulocker.auth.jwt.exception.JwtErrorCode;
 import com.jnulocker.auth.utils.AuthTestUtil;
 import com.jnulocker.common.exception.ErrorResponse;
+import com.jnulocker.config.RedisTest;
 import com.jnulocker.events.application.port.in.response.EventPageable;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
+import com.jnulocker.events.application.port.in.response.LockerResponse;
 import com.jnulocker.events.application.port.in.response.MyEventCustomPage;
 import com.jnulocker.events.application.port.in.response.MyEventListItem;
 import com.jnulocker.events.domain.Event;
@@ -17,6 +19,7 @@ import com.jnulocker.events.domain.EventStatus;
 import com.jnulocker.events.exception.EventErrorCode;
 import com.jnulocker.events.utils.EventTestUtil;
 import com.jnulocker.events.utils.LockerEventContext;
+import com.jnulocker.member.domain.Member;
 import com.jnulocker.member.domain.Role;
 import com.jnulocker.member.utils.MemberTestUtil;
 import com.jnulocker.registration.application.port.in.request.RegisterForEventRequest;
@@ -48,7 +51,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers
 @ActiveProfiles("test")
 @DisplayName("이벤트 신청 컨트롤러 통합 테스트")
-public class RegistrationControllerIntegrationTest {
+public class RegistrationControllerIntegrationTest extends RedisTest {
 
     private static final String REGISTRATION_URL = "/v1/events/{event-id}/registrations";
     private static final String ACCESS_TOKEN = "access_token";
@@ -129,6 +132,76 @@ public class RegistrationControllerIntegrationTest {
         assertThat(memberInfo.organization()).isEqualTo("테스트 조직명");
         assertThat(memberInfo.department()).isEqualTo("테스트 학과명");
         assertThat(memberInfo.email()).isEqualTo("test@email.com");
+    }
+
+    @Test
+    @DisplayName("신청된 사물함 목록 전체 조회 시, 층과 사물함번호 순으로 정렬된다")
+    void 신청된_사물함_목록_전체_조회_시_층과_사물함번호_순으로_정렬된다() {
+        // given
+        LockerEventContext context =
+                eventTestUtil.setUpLockerEventForRegistration(
+                        List.of(10, 5), Role.USER, EventStatus.OPEN, true);
+        Event event = context.event();
+        Member eventParticipant = context.member();
+
+        // 사용자 2가 2층 사물함을 먼저 신청
+        Member user2 =
+                memberTestUtil.createMemberFromRoleWithDepartment(
+                        Role.USER, eventParticipant.getDepartment());
+        String user2Token = authTestUtil.generateAccessTokenWithMember(user2);
+        String user2Locker = "B-002";
+        RegisterForEventRequest request2 =
+                createRequestForSpecificLocker(event, user2Token, 2, user2Locker);
+        registerForEvent(event.getId(), request2, user2Token)
+                .statusCode(HttpStatus.CREATED.value());
+
+        // 사용자 1이 1층 사물함을 나중에 신청
+        Member user1 =
+                memberTestUtil.createMemberFromRoleWithDepartment(
+                        Role.USER, eventParticipant.getDepartment());
+        String user1Token = authTestUtil.generateAccessTokenWithMember(user1);
+        String user1Locker = "A-008";
+        RegisterForEventRequest request1 =
+                createRequestForSpecificLocker(event, user1Token, 1, user1Locker);
+        registerForEvent(event.getId(), request1, user1Token)
+                .statusCode(HttpStatus.CREATED.value());
+
+        accessToken = authTestUtil.generateAccessToken(Role.MANAGER);
+
+        // when
+        List<RegistrationListItem> registrations =
+                getAllRegistrations(event.getId())
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .jsonPath()
+                        .getList(".", RegistrationListItem.class);
+
+        // then
+        assertThat(registrations).hasSize(2);
+
+        // 정렬 순서 검증: 층(asc), 사물함 코드(asc)
+        RegistrationListItem firstItem = registrations.get(0);
+        RegistrationListItem secondItem = registrations.get(1);
+
+        // 첫 번째 항목 (1층 2번 사물함, 사용자 1)
+        assertThat(firstItem.floorNumber()).isEqualTo(1);
+        assertThat(firstItem.lockerCode()).isEqualTo(user1Locker);
+        assertThat(firstItem.member().name()).isEqualTo(user1.getName());
+        assertThat(firstItem.member().studentNumber()).isEqualTo(user1.getStudentNumber());
+        assertThat(firstItem.member().organization())
+                .isEqualTo(user1.getDepartment().getOrganization().getName());
+        assertThat(firstItem.member().department()).isEqualTo(user1.getDepartment().getName());
+        assertThat(firstItem.member().email()).isEqualTo(user1.getEmail());
+
+        // 두 번째 항목 (2층 3번 사물함, 사용자 2)
+        assertThat(secondItem.floorNumber()).isEqualTo(2);
+        assertThat(secondItem.lockerCode()).isEqualTo(user2Locker);
+        assertThat(secondItem.member().name()).isEqualTo(user2.getName());
+        assertThat(secondItem.member().studentNumber()).isEqualTo(user2.getStudentNumber());
+        assertThat(secondItem.member().organization())
+                .isEqualTo(user2.getDepartment().getOrganization().getName());
+        assertThat(secondItem.member().department()).isEqualTo(user2.getDepartment().getName());
+        assertThat(secondItem.member().email()).isEqualTo(user2.getEmail());
     }
 
     @Test
@@ -543,6 +616,15 @@ public class RegistrationControllerIntegrationTest {
                 .ifError();
     }
 
+    private ValidatableResponse getAllRegistrations(UUID eventId) {
+        return given().cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
+                .when()
+                .get(REGISTRATION_URL + "/all", eventId)
+                .then()
+                .log()
+                .ifError();
+    }
+
     private ValidatableResponse getMyRegistration(UUID eventId) {
         return given().cookie(new Cookie.Builder(ACCESS_TOKEN, accessToken).build())
                 .when()
@@ -621,5 +703,19 @@ public class RegistrationControllerIntegrationTest {
                 .extract()
                 .jsonPath()
                 .getList(".", FloorWithLockersResponse.class);
+    }
+
+    private RegisterForEventRequest createRequestForSpecificLocker(
+            Event event, String accessToken, int floorNumber, String lockerNumber) {
+        List<FloorWithLockersResponse> floors = getFloors(event, accessToken);
+        UUID lockerId =
+                floors.stream()
+                        .filter(floor -> floor.floorNumber() == floorNumber)
+                        .flatMap(floor -> floor.lockers().stream())
+                        .filter(locker -> locker.code().equals(lockerNumber))
+                        .findFirst()
+                        .map(LockerResponse::lockerId)
+                        .orElseThrow(() -> new AssertionError("Cannot find specified locker"));
+        return new RegisterForEventRequest(lockerId);
     }
 }


### PR DESCRIPTION
### 개요
close #147 

### 작업사항
- 특정 이벤트에 해당하는 모든 사물함 신청 정보 조회 API 구현

### 변경로직
- 특정 이벤트에 대한 사물함 신청 정보 조회 쿼리 구현
- 정렬은 층번호 / 사물함번호 순으로 정렬
- 문서화 및 테스트코드 작성

### 테스트 결과
<img width="350" alt="image" src="https://github.com/user-attachments/assets/7c73b1f2-0685-4823-9d87-085fda8fc139" />

#### 추가된 테스트케이스
<img width="337" alt="image" src="https://github.com/user-attachments/assets/9215804b-fc0e-40d5-9fe0-e46d4f8e0d71" />

### reference

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 이벤트별로 모든 사물함 등록 내역을 한 번에 조회할 수 있는 엔드포인트가 추가되었습니다. 조회 결과는 층 번호와 사물함 번호 오름차순으로 정렬되어 반환됩니다.
  * 해당 조회 기능은 관리자 권한이 필요하도록 접근 제어가 강화되었습니다.

* **버그 수정**
  * Prometheus에서 cadvisor 서비스의 기본 포트가 8090에서 8080으로 변경되었습니다.

* **테스트**
  * 전체 사물함 등록 내역 조회 시 정렬 기준(층, 사물함 번호)에 대한 통합 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->