### PR TITLE
[CHORE] Redis Test Container 설정

### DIFF
--- a/src/main/java/com/jnulocker/config/RedisConfig.java
+++ b/src/main/java/com/jnulocker/config/RedisConfig.java
@@ -6,10 +6,12 @@ import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.core.RedisKeyValueAdapter.EnableKeyspaceEvents;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.RedisSerializer;
 
+@Profile({"local", "dev", "prod"})
 @Configuration
 @EnableRedisRepositories(enableKeyspaceEvents = EnableKeyspaceEvents.ON_STARTUP)
 public class RedisConfig {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,15 +20,6 @@ spring:
         order_inserts: true # Action Queue 내부 insert 문을 정렬하여 실행
         order_updates: true # Action Queue 내부 update 문을 정렬하여 실행
     defer-datasource-initialization: true
-  sql:
-    init:
-      mode: never
-
-  data:
-    redis:
-      host: ${REDIS_HOST}
-      password: ${REDIS_PASSWORD}
-      port: ${REDIS_PORT}
 
   mail:
     host: ${MAIL_HOST}
@@ -85,13 +76,13 @@ decorator:
 
 custom:
   email-verification:
-    fixed: ${EMAIL_VERIFICATION_FIXED:false}
-    code: ${EMAIL_VERIFICATION_CODE:123456}
+    fixed: ${EMAIL_VERIFICATION_FIXED}
+    code: ${EMAIL_VERIFICATION_CODE}
   jwt:
-    access-secret-key: ${JWT_ACCESS_SECRET_KEY:dGVzdC1zZWNyZXQta2V5LXRlc3Qtc2VjcmV0LWtleS10ZXN0LXNlY3JldC1rZXktdGVzdC1zZWNyZXQta2V5}
-    refresh-secret-key: ${JWT_REFRESH_SECRET_KEY:dGVzdC1yZWZyZXNoLXNlY3JldC1rZXktdGVzdC1yZWZyZXNoLXNlY3JldC1rZXktdGVzdC1yZWZyZXNoLXNlY3JldC1rZXktdGVzdC1yZWZyZXNo}
-    access-token-expire-time: ${JWT_ACCESS_TOKEN_EXPIRE_TIME:3600}
-    refresh-token-expire-time: ${JWT_REFRESH_TOKEN_EXPIRE_TIME:86400}
+    access-secret-key: ${JWT_ACCESS_SECRET_KEY}
+    refresh-secret-key: ${JWT_REFRESH_SECRET_KEY}
+    access-token-expire-time: ${JWT_ACCESS_TOKEN_EXPIRE_TIME}
+    refresh-token-expire-time: ${JWT_REFRESH_TOKEN_EXPIRE_TIME}
   lock:
     watchdog:
       timeout: ${LOCK_WATCHDOG_TIMEOUT:30000} # Watchdog 타임아웃 (밀리초, 기본: 30초)
@@ -103,7 +94,32 @@ email:
 spring:
   config:
     activate:
+      on-profile: local
+
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      password: ${REDIS_PASSWORD}
+      port: ${REDIS_PORT}
+
+  sql:
+    init:
+      mode: never
+  jpa:
+    hibernate:
+      ddl-auto: update
+
+---
+spring:
+  config:
+    activate:
       on-profile: dev
+
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      password: ${REDIS_PASSWORD}
+      port: ${REDIS_PORT}
 
   sql:
     init:
@@ -118,6 +134,12 @@ spring:
     activate:
       on-profile: prod
 
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      password: ${REDIS_PASSWORD}
+      port: ${REDIS_PORT}
+
   sql:
     init:
       mode: never
@@ -127,23 +149,3 @@ decorator:
   datasource:
     p6spy:
       enable-logging: false
-
----
-spring:
-  config:
-    activate:
-      on-profile: test
-
-  datasource:
-    url: jdbc:tc:mysql:8.0:///test-database
-    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
-
-  sql:
-    init:
-      mode: never
-
-logging:
-  level:
-    p6spy: info
-    org.springframework:
-      transaction.interceptor: trace

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -127,7 +127,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-      
+
 ---
 spring:
   config:

--- a/src/test/java/com/jnulocker/JnuLockerApplicationTests.java
+++ b/src/test/java/com/jnulocker/JnuLockerApplicationTests.java
@@ -1,10 +1,11 @@
 package com.jnulocker;
 
+import com.jnulocker.config.RedisTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class JnuLockerApplicationTests {
+class JnuLockerApplicationTests extends RedisTest {
 
     @Test
     void contextLoads() {}

--- a/src/test/java/com/jnulocker/announce/adapter/in/AnnounceControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/announce/adapter/in/AnnounceControllerIntegrationTest.java
@@ -16,6 +16,7 @@ import com.jnulocker.announce.exception.AnnounceErrorCode;
 import com.jnulocker.announce.utils.AnnounceTestUtil;
 import com.jnulocker.auth.utils.AuthTestUtil;
 import com.jnulocker.common.exception.ErrorResponse;
+import com.jnulocker.config.RedisTest;
 import com.jnulocker.member.domain.Member;
 import com.jnulocker.member.domain.Role;
 import com.jnulocker.member.utils.MemberTestUtil;
@@ -37,14 +38,10 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-@Testcontainers
-@ActiveProfiles("test")
 @DisplayName("공지사항 컨트롤러 통합 테스트")
-public class AnnounceControllerIntegrationTest {
+public class AnnounceControllerIntegrationTest extends RedisTest {
 
     private static final String ANNOUNCE_URL = "/v1/announces";
     private static final String ACCESS_TOKEN = "access_token";

--- a/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/auth/adapter/in/AuthControllerIntegrationTest.java
@@ -25,6 +25,7 @@ import com.jnulocker.auth.jwt.exception.JwtErrorCode;
 import com.jnulocker.auth.utils.AuthTestUtil;
 import com.jnulocker.common.exception.ErrorResponse;
 import com.jnulocker.common.util.RedisUtil;
+import com.jnulocker.config.RedisTest;
 import com.jnulocker.events.domain.Event;
 import com.jnulocker.events.domain.EventStatus;
 import com.jnulocker.events.domain.Locker;
@@ -65,14 +66,10 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-@Testcontainers
-@ActiveProfiles("test")
 @DisplayName("인증 통합 테스트")
-class AuthControllerIntegrationTest {
+class AuthControllerIntegrationTest extends RedisTest {
 
     private static final String AUTH_URL = "/v1/auth";
     private static final String ACCESS_TOKEN = "access_token";

--- a/src/test/java/com/jnulocker/auth/adapter/out/TokenRepositoryTest.java
+++ b/src/test/java/com/jnulocker/auth/adapter/out/TokenRepositoryTest.java
@@ -6,17 +6,13 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 import com.jnulocker.auth.jwt.RefreshToken;
-import com.jnulocker.config.RedisConfig;
+import com.jnulocker.config.RedisTest;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
-import org.springframework.context.annotation.Import;
 
-@DataRedisTest
-@Import(RedisConfig.class) // keyspace events를 구독하기 위해 RedisConfig를 import
-class TokenRepositoryTest {
+class TokenRepositoryTest extends RedisTest {
 
     @Autowired TokenRepository tokenRepository;
 

--- a/src/test/java/com/jnulocker/config/RedisTest.java
+++ b/src/test/java/com/jnulocker/config/RedisTest.java
@@ -1,0 +1,10 @@
+package com.jnulocker.config;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Import(RedisTestConfig.class)
+public abstract class RedisTest extends RedisTestContainer {}

--- a/src/test/java/com/jnulocker/config/RedisTestConfig.java
+++ b/src/test/java/com/jnulocker/config/RedisTestConfig.java
@@ -1,0 +1,17 @@
+package com.jnulocker.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.core.RedisKeyValueAdapter.EnableKeyspaceEvents;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.RedisSerializer;
+
+@TestConfiguration
+@EnableRedisRepositories(enableKeyspaceEvents = EnableKeyspaceEvents.ON_STARTUP)
+public class RedisTestConfig {
+
+    @Bean
+    public RedisSerializer<Object> springSessionDefaultRedisSerializer() {
+        return RedisSerializer.json(); // 기본값은 JdkSerializationRedisSerializer
+    }
+}

--- a/src/test/java/com/jnulocker/config/RedisTestContainer.java
+++ b/src/test/java/com/jnulocker/config/RedisTestContainer.java
@@ -1,0 +1,29 @@
+package com.jnulocker.config;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+public abstract class RedisTestContainer {
+
+    private static final int REDIS_PORT = 6379;
+    private static final String REDIS_IMAGE = "redis:alpine";
+    private static final GenericContainer<?> REDIS_CONTAINER;
+
+    static {
+        REDIS_CONTAINER =
+                new GenericContainer<>(DockerImageName.parse(REDIS_IMAGE))
+                        .withExposedPorts(REDIS_PORT)
+                        .withReuse(true);
+        REDIS_CONTAINER.start();
+    }
+
+    @DynamicPropertySource
+    private static void registerRedisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", REDIS_CONTAINER::getHost);
+        registry.add("spring.data.redis.port", () -> REDIS_CONTAINER.getMappedPort(REDIS_PORT));
+    }
+}

--- a/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.jnulocker.auth.utils.AuthTestUtil;
 import com.jnulocker.common.exception.ErrorResponse;
+import com.jnulocker.config.RedisTest;
 import com.jnulocker.events.application.port.in.request.CreateEventRequest;
 import com.jnulocker.events.application.port.in.request.FloorInfo;
 import com.jnulocker.events.application.port.in.request.LockerRange;
@@ -54,14 +55,10 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-@Testcontainers
-@ActiveProfiles("test")
 @DisplayName("이벤트 컨트롤러 통합 테스트")
-public class EventControllerIntegrationTest {
+public class EventControllerIntegrationTest extends RedisTest {
 
     private static final String EVENT_URL = "/v1/events";
     private static final String ACCESS_TOKEN = "access_token";

--- a/src/test/java/com/jnulocker/member/adapter/in/MemberControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/member/adapter/in/MemberControllerIntegrationTest.java
@@ -4,6 +4,7 @@ import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.jnulocker.auth.utils.AuthTestUtil;
+import com.jnulocker.config.RedisTest;
 import com.jnulocker.member.application.port.in.response.MemberInfoResponse;
 import com.jnulocker.member.domain.Member;
 import com.jnulocker.member.domain.Role;
@@ -23,14 +24,10 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-@Testcontainers
-@ActiveProfiles("test")
 @DisplayName("회원 통합 테스트")
-public class MemberControllerIntegrationTest {
+public class MemberControllerIntegrationTest extends RedisTest {
 
     private static final String MEMBER_URL = "/v1/members";
     private static final String ACCESS_TOKEN = "access_token";

--- a/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
@@ -44,12 +44,8 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-@Testcontainers
-@ActiveProfiles("test")
 @DisplayName("이벤트 신청 컨트롤러 통합 테스트")
 public class RegistrationControllerIntegrationTest extends RedisTest {
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,27 @@
+spring:
+  application:
+    name: jnu-locker
+
+  datasource:
+    url: jdbc:tc:mysql:8.0:///test-database
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+
+  sql:
+    init:
+      mode: never
+
+custom:
+  jwt:
+    access-secret-key: dGVzdC1zZWNyZXQta2V5LXRlc3Qtc2VjcmV0LWtleS10ZXN0LXNlY3JldC1rZXktdGVzdC1zZWNyZXQta2V5
+    refresh-secret-key: dGVzdC1yZWZyZXNoLXNlY3JldC1rZXktdGVzdC1yZWZyZXNoLXNlY3JldC1rZXktdGVzdC1yZWZyZXNoLXNlY3JldC1rZXktdGVzdC1yZWZyZXNo
+    access-token-expire-time: 3600
+    refresh-token-expire-time: 86400
+  lock:
+    watchdog:
+      timeout: 30000 # Watchdog 타임아웃 (밀리초, 기본: 30초)
+
+logging:
+  level:
+    p6spy: info
+    org.springframework:
+      transaction.interceptor: trace


### PR DESCRIPTION
### 개요
close #149 

### 작업사항
- Redis Test Container 설정
- 로컬에서 Redis가 실행되지 않은 상황에서도 MySQL 처럼 테스트 컨테이너로 Redis 를 띄워 테스트가 동작합니다.

### 변경로직

- 테스트용 RedisConfig 작성
- Redis Test Container 추상클래스 작성 및 상속
- application.yml 에서 profile에 따른 설정 분리

### 테스트 결과
<img width="387" alt="image" src="https://github.com/user-attachments/assets/3dc08c59-fb08-4a5e-8389-a79c713cc463" />

#### 기존 컨테이너가 종료된 상태에서도 테스트 컨테이너가 실행되며 테스트가 돌아갑니다.
<img width="1196" alt="image" src="https://github.com/user-attachments/assets/075a9570-3e10-49b3-ac24-afa0bf79f326" />


### reference

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **환경설정**
  * Redis 및 데이터베이스 환경설정이 프로필별로 분리되어 관리됩니다.
  * 테스트 환경용 별도 설정 파일이 추가되었습니다.
  * 일부 환경변수의 기본값이 제거되어, 환경변수 설정이 필수로 변경되었습니다.

* **테스트**
  * Redis 연동 통합 테스트 환경이 개선되어, 테스트 코드에서 일관된 Redis 컨테이너 환경을 사용합니다.
  * 테스트 클래스들이 공통 Redis 테스트 베이스 클래스를 상속하도록 변경되어 중복 설정이 제거되고 유지보수가 용이해졌습니다.
  * 여러 통합 테스트에서 프로필 및 컨테이너 관련 어노테이션이 제거되고 베이스 클래스로 통합되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->