### PR TITLE
[FIX] 테스트용 이벤트 생성 객체에서 이벤트 관련 시각 수정

### DIFF
--- a/src/testFixtures/java/events/application/port/in/request/CreateEventRequestTestDataBuilder.java
+++ b/src/testFixtures/java/events/application/port/in/request/CreateEventRequestTestDataBuilder.java
@@ -7,8 +7,8 @@ import java.util.List;
 
 public class CreateEventRequestTestDataBuilder {
     private String title = "전자컴퓨터공학부 2025-2 사물함 신청";
-    private LocalDateTime startAt = LocalDateTime.of(2025, 8, 1, 15, 0);
-    private LocalDateTime endAt = LocalDateTime.of(2025, 8, 1, 16, 0);
+    private LocalDateTime startAt = LocalDateTime.now().plusHours(1);
+    private LocalDateTime endAt = LocalDateTime.now().plusHours(2);
     private List<Long> participationDepartmentIds = List.of(1L, 2L, 3L);
     private List<FloorInfo> floors = List.of(FloorInfoTestDataBuilder.floorInfoBuilder().build());
 


### PR DESCRIPTION
### 개요
close #152

### 작업사항

- 테스트용 이벤트 생성 객체에서 이벤트 관련 시각을 수정하였습니다.

### 변경로직

- 테스트코드를 실행할 때를 기준으로 이벤트 생성 시 1시간 뒤를 시작시간, 2시간 뒤를 마감시간으로 설정됩니다. 

### 테스트 결과

<img width="300" height="516" alt="image" src="https://github.com/user-attachments/assets/a3dd006e-df65-4536-a9cc-fcadcd06df40" />


### reference
- 이벤트 삭제 시 이벤트의 상태는 `OPEN`이 아니어야 합니다.
- 이벤트 수정 시 이벤트 상태는 `READY`여야만 합니다.

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 테스트
  - 이벤트 생성 시나리오용 테스트 데이터의 기본 시작/종료 시간이 고정 값에서 현재 시각 기준(+1시간/+2시간)으로 동적으로 설정되도록 변경했습니다.
  - 실행 시점이나 시간대에 따른 테스트 불안정성을 줄여 신뢰성과 일관성을 강화했습니다.
  - 사용자 기능이나 동작에는 변화가 없으며, 테스트 유지보수성과 예측 가능성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->