### PR TITLE
[CHORE] 배포된 FE 서버 CORS 허용

### DIFF
--- a/src/main/java/com/jnulocker/config/WebConfig.java
+++ b/src/main/java/com/jnulocker/config/WebConfig.java
@@ -14,11 +14,13 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedOriginPatterns(
                         "http://localhost:3000",
                         "https://localhost:3000",
+                        "https://localhost:3001",
                         "http://localhost:8080",
                         "https://localhost:8080",
                         "https://jnu-locker.vercel.app",
                         "https://api.dev.jnu-locker.site",
-                        "https://www.jnu-locker.site")
+                        "https://www.jnu-locker.site",
+                        "https://jnu-locker-manager.vercel.app")
                 .allowedMethods(
                         HttpMethod.GET.name(),
                         HttpMethod.POST.name(),


### PR DESCRIPTION
### 개요
close #151 

### 작업사항

배포된 FE 서버 CORS 허용

- `https://jnu-locker-manager.vercel.app`
- `https://localhost:3001`

### 변경로직

### 테스트 결과

<img width="300" height="516" alt="image" src="https://github.com/user-attachments/assets/1fed99c1-85c3-42cc-9157-83ebc9487000" />


### reference

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **구성 업데이트**
  * CORS 설정 확장: 새로운 오리진(https://localhost:3001 및 https://jnu-locker-manager.vercel.app) 추가
  * 기존 크로스 오리진 구성 유지

<!-- end of auto-generated comment: release notes by coderabbit.ai -->