### PR TITLE
[CHORE] 수정된 FE 배포 서버 CORS 허용

### DIFF
--- a/src/main/java/com/jnulocker/config/WebConfig.java
+++ b/src/main/java/com/jnulocker/config/WebConfig.java
@@ -20,7 +20,7 @@ public class WebConfig implements WebMvcConfigurer {
                         "https://jnu-locker.vercel.app",
                         "https://api.dev.jnu-locker.site",
                         "https://www.jnu-locker.site",
-                        "https://jnu-locker-manager.vercel.app")
+                        "https://www.manager.jnu-locker.site")
                 .allowedMethods(
                         HttpMethod.GET.name(),
                         HttpMethod.POST.name(),


### PR DESCRIPTION
### 개요
close #157 

### 작업사항

배포된 FE 서버 CORS 허용

- `https://www.manager.jnu-locker.site` 추가
- `https://jnu-locker-manager.vercel.app` 제거

### 변경로직

### 테스트 결과

<img width="300" height="515" alt="image" src="https://github.com/user-attachments/assets/b5c13d7c-9a72-484c-8847-ba74a8bb05d6" />

### reference

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 새 도메인에서 발생하던 브라우저 CORS 오류를 해소하여 정상적으로 서비스에 접속할 수 있습니다.
- 작업(Chores)
  - 서비스 접속 허용 도메인을 최신 도메인으로 업데이트했습니다. 이전 도메인에서는 접속이 제한될 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->