### PR TITLE
[FIX] 사물함 번호 숫자 순서로 정렬

### DIFF
--- a/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
+++ b/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
@@ -136,10 +136,8 @@ public class EventQueryService implements EventQuery {
 
     private FloorWithLockersResponse convertToFloorResponse(
             Floor floor, Map<UUID, List<Locker>> lockersByFloorId) {
-        List<Locker> lockersForFloor = lockersByFloorId.getOrDefault(floor.getId(), List.of())
-                .stream()
-                .sorted()
-                .toList();
+        List<Locker> lockersForFloor =
+                lockersByFloorId.getOrDefault(floor.getId(), List.of()).stream().sorted().toList();
         return FloorWithLockersResponse.of(floor, lockersForFloor);
     }
 }

--- a/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
+++ b/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
@@ -136,7 +136,10 @@ public class EventQueryService implements EventQuery {
 
     private FloorWithLockersResponse convertToFloorResponse(
             Floor floor, Map<UUID, List<Locker>> lockersByFloorId) {
-        List<Locker> lockersForFloor = lockersByFloorId.getOrDefault(floor.getId(), List.of());
+        List<Locker> lockersForFloor = lockersByFloorId.getOrDefault(floor.getId(), List.of())
+                .stream()
+                .sorted()
+                .toList();
         return FloorWithLockersResponse.of(floor, lockersForFloor);
     }
 }

--- a/src/main/java/com/jnulocker/events/domain/Locker.java
+++ b/src/main/java/com/jnulocker/events/domain/Locker.java
@@ -22,7 +22,7 @@ import lombok.NoArgsConstructor;
 @Builder(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Locker extends BaseEntity {
+public class Locker extends BaseEntity implements Comparable<Locker> {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -57,6 +57,40 @@ public class Locker extends BaseEntity {
     private void checkAvailability() {
         if (Boolean.FALSE.equals(available)) {
             throw LockerUnavailableException.EXCEPTION;
+        }
+    }
+
+    @Override
+    public int compareTo(Locker other) {
+        String[] thisCodeParts = parseCode(this.code);
+        String[] otherCodeParts = parseCode(other.code);
+
+        String thisPrefix = thisCodeParts[0];
+        String otherPrefix = otherCodeParts[0];
+        int thisNumber = Integer.parseInt(thisCodeParts[1]);
+        int otherNumber = Integer.parseInt(otherCodeParts[1]);
+
+        // 1. 접두사 비교 (null인 경우 빈 문자열로 처리)
+        String safeThisPrefix = thisPrefix != null ? thisPrefix : "";
+        String safeOtherPrefix = otherPrefix != null ? otherPrefix : "";
+        int prefixComparison = safeThisPrefix.compareTo(safeOtherPrefix);
+
+        if (prefixComparison != 0) {
+            return prefixComparison;
+        }
+
+        // 2. 번호 비교 (숫자로 비교)
+        return Integer.compare(thisNumber, otherNumber);
+    }
+
+    private String[] parseCode(String code) {
+        if (code.contains("-")) {
+            // 접두사가 있는 경우: "A-001" -> ["A", "001"]
+            String[] parts = code.split("-", 2);
+            return new String[]{parts[0], parts[1]};
+        } else {
+            // 접두사가 없는 경우: "001" -> [null, "001"]
+            return new String[]{null, code};
         }
     }
 }

--- a/src/main/java/com/jnulocker/events/domain/Locker.java
+++ b/src/main/java/com/jnulocker/events/domain/Locker.java
@@ -83,7 +83,7 @@ public class Locker extends BaseEntity implements Comparable<Locker> {
         return Integer.compare(thisNumber, otherNumber);
     }
 
-    private String[] parseCode(String code) {
+    private static String[] parseCode(String code) {
         if (code.contains("-")) {
             // 접두사가 있는 경우: "A-001" -> ["A", "001"]
             String[] parts = code.split("-", 2);

--- a/src/main/java/com/jnulocker/events/domain/Locker.java
+++ b/src/main/java/com/jnulocker/events/domain/Locker.java
@@ -87,10 +87,10 @@ public class Locker extends BaseEntity implements Comparable<Locker> {
         if (code.contains("-")) {
             // 접두사가 있는 경우: "A-001" -> ["A", "001"]
             String[] parts = code.split("-", 2);
-            return new String[]{parts[0], parts[1]};
+            return new String[] {parts[0], parts[1]};
         } else {
             // 접두사가 없는 경우: "001" -> [null, "001"]
-            return new String[]{null, code};
+            return new String[] {null, code};
         }
     }
 }

--- a/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
@@ -4,6 +4,7 @@ import static events.application.port.in.request.CreateEventRequestTestDataBuild
 import static events.application.port.in.request.UpdateEventRequestTestDataBuilder.updateEventRequestBuilder;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatList;
 
 import com.jnulocker.auth.utils.AuthTestUtil;
 import com.jnulocker.common.exception.ErrorResponse;
@@ -20,6 +21,7 @@ import com.jnulocker.events.application.port.in.response.EventListItem;
 import com.jnulocker.events.application.port.in.response.EventPageable;
 import com.jnulocker.events.application.port.in.response.EventResponse;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
+import com.jnulocker.events.application.port.in.response.LockerResponse;
 import com.jnulocker.events.application.port.in.response.MyEventCustomPage;
 import com.jnulocker.events.application.port.in.response.MyEventResponse;
 import com.jnulocker.events.domain.Event;
@@ -37,6 +39,7 @@ import io.restassured.response.ValidatableResponse;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -917,6 +920,168 @@ public class EventControllerIntegrationTest extends RedisTest {
         }
 
         return covered >= end; // 마지막 범위까지 확인 후 결과
+    }
+
+    @Test
+    void 접두사_없는_사물함들이_번호순으로_정렬된다() {
+        List<String> lockerCodes = List.of("010", "001", "1000", "101", "100");
+        Map<Integer, List<String>> floorToLockerCodes = Map.of(1, lockerCodes);
+
+        Event event =
+                eventTestUtil
+                        .setUpLockerEventWithCustomCodes(
+                                floorToLockerCodes, Role.MANAGER, EventStatus.OPEN, true)
+                        .event();
+
+        List<FloorWithLockersResponse> floors =
+                getEventLockers(event.getId(), accessToken)
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .jsonPath()
+                        .getList(".", FloorWithLockersResponse.class);
+
+        List<LockerResponse> lockers = floors.getFirst().lockers();
+        assertThat(lockers).hasSize(lockerCodes.size());
+
+        assertThatList(lockers)
+                .extracting(LockerResponse::code)
+                .containsExactly("001", "010", "100", "101", "1000");
+    }
+
+    @Test
+    void 같은_접두사_내에서_사물함이_번호순으로_정렬된다() {
+        List<String> lockerCodes = List.of("A-1000", "A-001", "A-101", "A-010", "A-100");
+        Map<Integer, List<String>> floorToLockerCodes = Map.of(1, lockerCodes);
+
+        Event event =
+                eventTestUtil
+                        .setUpLockerEventWithCustomCodes(
+                                floorToLockerCodes, Role.MANAGER, EventStatus.OPEN, true)
+                        .event();
+
+        List<FloorWithLockersResponse> floors =
+                getEventLockers(event.getId(), accessToken)
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .jsonPath()
+                        .getList(".", FloorWithLockersResponse.class);
+
+        List<LockerResponse> lockers = floors.getFirst().lockers();
+        assertThat(lockers).hasSize(lockerCodes.size());
+
+        assertThatList(lockers)
+                .extracting(LockerResponse::code)
+                .containsExactly("A-001", "A-010", "A-100", "A-101", "A-1000");
+    }
+
+    @Test
+    void 혼합_패턴에서_올바른_순서로_정렬된다() {
+        List<String> lockerCodes =
+                List.of("010", "A-100", "001", "A-101", "B-010", "A-1000", "B-001");
+        Map<Integer, List<String>> floorToLockerCodes = Map.of(1, lockerCodes);
+
+        Event event =
+                eventTestUtil
+                        .setUpLockerEventWithMixedPattern(
+                                floorToLockerCodes, Role.MANAGER, EventStatus.OPEN, true)
+                        .event();
+
+        List<FloorWithLockersResponse> floors =
+                getEventLockers(event.getId(), accessToken)
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .jsonPath()
+                        .getList(".", FloorWithLockersResponse.class);
+
+        List<LockerResponse> lockers = floors.getFirst().lockers();
+        assertThat(lockers).hasSize(lockerCodes.size());
+
+        assertThatList(lockers)
+                .extracting(LockerResponse::code)
+                .containsExactly("001", "010", "A-100", "A-101", "A-1000", "B-001", "B-010");
+    }
+
+    @Test
+    void 문자열_정렬과_숫자_정렬이_다른_경우를_올바르게_처리한다() {
+        // 문자열 정렬: 010, 100, 2 순서 (잘못된 순서)
+        // 숫자 정렬: 2, 010, 100 순서 (올바른 순서)
+        List<String> lockerCodes = List.of("010", "100", "2");
+        Map<Integer, List<String>> floorToLockerCodes = Map.of(1, lockerCodes);
+
+        Event event =
+                eventTestUtil
+                        .setUpLockerEventWithCustomCodes(
+                                floorToLockerCodes, Role.MANAGER, EventStatus.OPEN, true)
+                        .event();
+
+        List<FloorWithLockersResponse> floors =
+                getEventLockers(event.getId(), accessToken)
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .jsonPath()
+                        .getList(".", FloorWithLockersResponse.class);
+
+        List<LockerResponse> lockers = floors.getFirst().lockers();
+        assertThat(lockers).hasSize(lockerCodes.size());
+        // 숫자 정렬 순서로 검증 (2 < 010 < 100)
+        assertThatList(lockers).extracting(LockerResponse::code).containsExactly("2", "010", "100");
+    }
+
+    @Test
+    void 접두사가_있는_경우에도_숫자_정렬이_올바르게_동작한다() {
+        // 문자열 정렬: A-010, A-100, A-2 순서 (잘못된 순서)
+        // 숫자 정렬: A-2, A-010, A-100 순서 (올바른 순서)
+        List<String> lockerCodes = List.of("A-010", "A-100", "A-2");
+        Map<Integer, List<String>> floorToLockerCodes = Map.of(1, lockerCodes);
+
+        Event event =
+                eventTestUtil
+                        .setUpLockerEventWithCustomCodes(
+                                floorToLockerCodes, Role.MANAGER, EventStatus.OPEN, true)
+                        .event();
+
+        List<FloorWithLockersResponse> floors =
+                getEventLockers(event.getId(), accessToken)
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .jsonPath()
+                        .getList(".", FloorWithLockersResponse.class);
+
+        List<LockerResponse> lockers = floors.getFirst().lockers();
+        assertThat(lockers).hasSize(lockerCodes.size());
+        // 숫자 정렬 순서로 검증 (A-2 < A-010 < A-100)
+        assertThatList(lockers)
+                .extracting(LockerResponse::code)
+                .containsExactly("A-2", "A-010", "A-100");
+    }
+
+    @Test
+    void 접두사가_다른_경우_접두사_우선_정렬_후_숫자_정렬이_동작한다() {
+        // 접두사 우선: B < A는 잘못된 순서, A < B가 올바른 순서
+        // 그리고 같은 접두사 내에서 숫자 정렬
+        List<String> lockerCodes = List.of("B-5", "A-100", "A-2", "B-10");
+        Map<Integer, List<String>> floorToLockerCodes = Map.of(1, lockerCodes);
+
+        Event event =
+                eventTestUtil
+                        .setUpLockerEventWithCustomCodes(
+                                floorToLockerCodes, Role.MANAGER, EventStatus.OPEN, true)
+                        .event();
+
+        List<FloorWithLockersResponse> floors =
+                getEventLockers(event.getId(), accessToken)
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .jsonPath()
+                        .getList(".", FloorWithLockersResponse.class);
+
+        List<LockerResponse> lockers = floors.getFirst().lockers();
+        assertThat(lockers).hasSize(lockerCodes.size());
+        // 올바른 정렬 순서: A-2, A-100, B-5, B-10
+
+        assertThatList(lockers)
+                .extracting(LockerResponse::code)
+                .containsExactly("A-2", "A-100", "B-5", "B-10");
     }
 
     // 다양한 층과 접두사, 범위를 가진 이벤트 생성 요청 준비

--- a/src/test/java/com/jnulocker/events/utils/EventTestUtil.java
+++ b/src/test/java/com/jnulocker/events/utils/EventTestUtil.java
@@ -24,6 +24,7 @@ import com.jnulocker.organization.domain.Organization;
 import com.jnulocker.organization.utils.OrganizationTestUtil;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -179,5 +180,61 @@ public class EventTestUtil {
 
     public Event getEventById(UUID eventId) {
         return eventRepository.findById(eventId).orElseThrow();
+    }
+
+    public LockerEventContext setUpLockerEventWithCustomCodes(
+            Map<Integer, List<String>> floorToLockerCodes,
+            Role role,
+            EventStatus eventStatus,
+            boolean publish) {
+        Department department = organizationTestUtil.createCouncilDepartment();
+        Member member = memberTestUtil.createMemberFromRoleWithDepartment(role, department);
+        String accessToken = authTestUtil.generateAccessTokenWithMember(member);
+
+        Event event =
+                createEventWithCustomCodes(floorToLockerCodes, department, eventStatus, publish);
+
+        return new LockerEventContext(department, member, accessToken, event);
+    }
+
+    public LockerEventContext setUpLockerEventWithMixedPattern(
+            Map<Integer, List<String>> floorToLockerCodes,
+            Role role,
+            EventStatus eventStatus,
+            boolean publish) {
+        return setUpLockerEventWithCustomCodes(floorToLockerCodes, role, eventStatus, publish);
+    }
+
+    private Event createEventWithCustomCodes(
+            Map<Integer, List<String>> floorToLockerCodes,
+            Department department,
+            EventStatus eventStatus,
+            boolean publish) {
+        Event savedEvent = createAndSaveEvent(department, eventStatus, publish);
+        EventParticipation eventParticipation = EventParticipation.create(savedEvent, department);
+        eventParticipationRepository.save(eventParticipation);
+
+        createFloorsWithCustomCodes(floorToLockerCodes, savedEvent);
+        return savedEvent;
+    }
+
+    private void createFloorsWithCustomCodes(
+            Map<Integer, List<String>> floorToLockerCodes, Event savedEvent) {
+        for (Map.Entry<Integer, List<String>> entry : floorToLockerCodes.entrySet()) {
+            int floorNumber = entry.getKey();
+            List<String> lockerCodes = entry.getValue();
+            Floor floor = floorRepository.save(Floor.create(savedEvent, floorNumber));
+            createLockersWithCustomCodes(lockerCodes, floor);
+        }
+    }
+
+    private void createLockersWithCustomCodes(List<String> lockerCodes, Floor floor) {
+        List<Locker> lockers = new ArrayList<>();
+        for (int i = 0; i < lockerCodes.size(); i++) {
+            String code = lockerCodes.get(i);
+            boolean available = (i + 1) % 2 == 0;
+            lockers.add(Locker.create(floor, code, available));
+        }
+        lockerRepository.saveAll(lockers);
     }
 }


### PR DESCRIPTION
### 개요
close #159 

### 작업사항
- 현재 사물함 번호는 `접두사-번호`로 구성되어있어 "문자열 사전순"으로 정렬됨
- 하지만 이렇게 둔다면 `1100` 등 앞자리가 `1`인 경우 `2`, `34` 보다 더 앞에 나옴
- 따라서 "접두사 순으로 정렬 후 번호 순으로 정렬"하도록 로직 수정

- 아래 이미지를 보면 `100` 이후 `101`이 아닌 `1000`이 나오는 모습을 볼 수 있음

  <img width="600" alt="Image" src="https://github.com/user-attachments/assets/3fc33ce1-c039-4ff3-be52-55cd2468bc10" />

### 변경로직
- 사물함 응답시 정렬 방식을 `1) 접두사`, `2) 번호` 순으로 정렬하도록 수정

### 테스트 결과

<img width="384" height="386" alt="image" src="https://github.com/user-attachments/assets/56a4be26-52f7-4906-ae4c-385bd3b05d7e" />

#### 추가된 테스트케이스
<img width="328" height="18" alt="image" src="https://github.com/user-attachments/assets/3ce70c5d-89c3-4ff7-bfc3-eca68f98ce10" />
<img width="328" height="18" alt="image" src="https://github.com/user-attachments/assets/b0f34149-175d-46d9-b580-d7116877b16b" />
<img width="328" height="18" alt="image" src="https://github.com/user-attachments/assets/7cda3ba1-a374-4015-a736-5c45933dae9f" />
<img width="328" height="18" alt="image" src="https://github.com/user-attachments/assets/94353de0-beca-4210-9103-d4f29c3c46f0" />
<img width="328" height="18" alt="image" src="https://github.com/user-attachments/assets/e51e6a60-2a91-4ada-8595-431833c81b6b" />
<img width="328" height="18" alt="image" src="https://github.com/user-attachments/assets/f3d6e3ae-d14d-43be-9044-41f3da10320b" />

### reference

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 버그 수정
  * 이벤트 조회 시 층별 사물함 목록이 접두어와 번호 기준으로 일관되게 정렬되어 반환됩니다. 숫자만, 접두어 포함(A-, B- 등), 혼합 형식 모두에서 올바른 순서를 보장해 가독성과 예측 가능성을 개선했습니다.
* 테스트
  * 다양한 코드 형식과 혼합 패턴을 검증하는 통합 테스트를 추가했습니다.
  * 테스트 유틸리티를 확장해 사용자 정의 코드 시나리오 구성 및 검증을 지원합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->