### PR TITLE
[CHORE] Prometheus 데이터 저장 기간 및 용량 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 </details>
 
-[[위원회용] 전남대학교 사물함 신청 서비스](https://jnu-locker-manager.vercel.app/)
+[[위원회용] 전남대학교 사물함 신청 서비스](https://www.manager.jnu-locker.site/)
 
 <details>
 <summary>🧑‍💼 위원회용 테스트 계정</summary>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,9 @@ services:
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/data' # 기본값이 /data
-      - '--storage.tsdb.retention.time=1y' # 데이터 보존 기간 설정 (1년: 1y or 365d)
+      - '--storage.tsdb.retention.time=30d' # 데이터 보존 기간 설정 (1년: 1y or 365d)
+      - '--storage.tsdb.retention.size=3GB' # 데이터 보존 용량 설정
+      - '--web.enable-lifecycle' # reload 기능 활성화
     depends_on:
       was:
         condition: service_healthy


### PR DESCRIPTION
### 개요
close #160 

### 작업사항
- 기존에 1년 데이터 저장은 5초 마다 수집한 데이터를 1년동안 저장해 30GB 저장용량을 초과하게 됨
- 따라서 저장 기간과 용량을 수정함
- README.md 관리자 사이트 주소 최신화

### 변경로직

- 최대 저장 기간 30일 설정
- 최대 저장 용량 3GB 설정
- 런타임 설정 옵션 적용
- 리드미 최신화

### 테스트 결과
<img width="384" height="386" alt="image" src="https://github.com/user-attachments/assets/98fbdbb3-f686-4a10-9f3d-fd30d76fe54a" />

### reference

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 문서
  - README의 위원회 서비스 링크를 최신 도메인(https://www.manager.jnu-locker.site/)으로 업데이트하여 접근 경로의 정확성을 개선했습니다.
- Chores
  - 운영 모니터링 구성 업데이트: Prometheus 데이터 보존 기간을 30일로 조정하고 보존 용량 한도(3GB)를 추가했습니다. 또한 런타임에서 구성 재로드가 가능하도록 활성화하여 모니터링 데이터 관리 효율과 운영 안정성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->