### PR TITLE
[FEAT] Spring AI Tool Calling - 기본 조회 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ java {
 }
 
 configurations {
+    configureEach {
+        exclude group: 'commons-logging', module: 'commons-logging'
+    }
     compileOnly {
         extendsFrom annotationProcessor
     }

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 ext {
-    springAiVersion = "1.0.2"
+    springAiVersion = "1.1.0-M4"
 }
 
 dependencyManagement {

--- a/src/main/java/com/jnulocker/ai/application/service/AiChatCommandService.java
+++ b/src/main/java/com/jnulocker/ai/application/service/AiChatCommandService.java
@@ -15,8 +15,6 @@ public class AiChatCommandService implements AiChatCommand {
 
     @Override
     public AiChatResponse chat(AiChatRequest request) {
-        // ChatClient에 defaultAdvisors로 QuestionAnswerAdvisor가 등록되어 있어
-        // 자동으로 VectorStore에서 관련 문서를 검색하고 context로 전달합니다.
         String message = client.prompt().user(request.message()).call().content();
 
         return AiChatResponse.of(message);

--- a/src/main/java/com/jnulocker/ai/application/tools/AiToolErrorHandlingAspect.java
+++ b/src/main/java/com/jnulocker/ai/application/tools/AiToolErrorHandlingAspect.java
@@ -1,0 +1,67 @@
+package com.jnulocker.ai.application.tools;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+public class AiToolErrorHandlingAspect {
+
+    @Around("@annotation(aiToolMethod)")
+    public Object handleToolErrors(ProceedingJoinPoint joinPoint, AiToolMethod aiToolMethod) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        String methodName = signature.getName();
+        String className = signature.getDeclaringType().getSimpleName();
+        Object[] args = joinPoint.getArgs();
+        String[] paramNames = signature.getParameterNames();
+
+        try {
+            log.info(
+                    "[AI Tool] {}.{}({})",
+                    className,
+                    methodName,
+                    formatParameters(paramNames, args));
+            return joinPoint.proceed();
+
+        } catch (JsonProcessingException e) {
+            log.error("[AI Tool] JSON 직렬화 실패 - {}.{}", className, methodName, e);
+            return formatErrorResponse(methodName, "조회");
+
+        } catch (Exception e) {
+            log.error("[AI Tool] 실행 실패 - {}.{}", className, methodName, e);
+            return formatErrorResponse(methodName, "처리");
+
+        } catch (Throwable t) {
+            log.error("[AI Tool] 예상치 못한 오류 - {}.{}", className, methodName, t);
+            throw new RuntimeException("AI Tool 실행 중 예상치 못한 오류가 발생했습니다.", t);
+        }
+    }
+
+    private String formatParameters(String[] names, Object[] values) {
+        if (names.length == 0) {
+            return "";
+        }
+
+        Map<String, Object> params = new HashMap<>();
+        for (int i = 0; i < names.length; i++) {
+            params.put(names[i], values[i]);
+        }
+
+        return params.entrySet().stream()
+                .map(entry -> entry.getKey() + "=" + entry.getValue())
+                .reduce((a, b) -> a + ", " + b)
+                .orElse("");
+    }
+
+    private String formatErrorResponse(String methodName, String action) {
+        return String.format("%s %s 중 오류가 발생했습니다", methodName, action);
+    }
+}

--- a/src/main/java/com/jnulocker/ai/application/tools/AiToolErrorHandlingAspect.java
+++ b/src/main/java/com/jnulocker/ai/application/tools/AiToolErrorHandlingAspect.java
@@ -1,6 +1,7 @@
 package com.jnulocker.ai.application.tools;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.jnulocker.ai.exception.AiToolExecutionException;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -41,7 +42,7 @@ public class AiToolErrorHandlingAspect {
 
         } catch (Throwable t) {
             log.error("[AI Tool] 예상치 못한 오류 - {}.{}", className, methodName, t);
-            throw new RuntimeException("AI Tool 실행 중 예상치 못한 오류가 발생했습니다.", t);
+            throw AiToolExecutionException.EXCEPTION;
         }
     }
 

--- a/src/main/java/com/jnulocker/ai/application/tools/AiToolMethod.java
+++ b/src/main/java/com/jnulocker/ai/application/tools/AiToolMethod.java
@@ -1,0 +1,10 @@
+package com.jnulocker.ai.application.tools;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AiToolMethod {}

--- a/src/main/java/com/jnulocker/ai/application/tools/AnnounceTools.java
+++ b/src/main/java/com/jnulocker/ai/application/tools/AnnounceTools.java
@@ -30,10 +30,10 @@ public class AnnounceTools {
             return objectMapper.writeValueAsString(result);
         } catch (JsonProcessingException e) {
             log.error("Failed to serialize AnnounceCustomPage", e);
-            return "공지사항 목록 조회 중 오류가 발생했습니다: " + e.getMessage();
+            return "공지사항 목록 조회 중 오류가 발생했습니다: ";
         } catch (Exception e) {
             log.error("Failed to search announcements", e);
-            return "공지사항 검색 중 오류가 발생했습니다: " + e.getMessage();
+            return "공지사항 검색 중 오류가 발생했습니다: ";
         }
     }
 }

--- a/src/main/java/com/jnulocker/ai/application/tools/AnnounceTools.java
+++ b/src/main/java/com/jnulocker/ai/application/tools/AnnounceTools.java
@@ -1,0 +1,39 @@
+package com.jnulocker.ai.application.tools;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jnulocker.announce.application.port.in.AnnounceQuery;
+import com.jnulocker.announce.application.port.in.response.AnnounceCustomPage;
+import com.jnulocker.announce.application.port.in.response.AnnouncePageable;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AnnounceTools {
+
+    private final AnnounceQuery announceQuery;
+    private final ObjectMapper objectMapper;
+
+    @Tool(description = "전체 공지사항 목록을 조회합니다. 최신 공지사항부터 시간 순으로 정렬되어 표시됩니다.")
+    public String searchAnnouncements(
+            @ToolParam(description = "페이지 번호 (0부터 시작, 기본값 0)", required = false) Integer page) {
+        try {
+            log.info("Tool called: searchAnnouncements(page={})", page);
+            Pageable pageable = new AnnouncePageable(page, null, "desc", null).toPageable();
+            AnnounceCustomPage result = announceQuery.getAnnounces(pageable);
+            return objectMapper.writeValueAsString(result);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize AnnounceCustomPage", e);
+            return "공지사항 목록 조회 중 오류가 발생했습니다: " + e.getMessage();
+        } catch (Exception e) {
+            log.error("Failed to search announcements", e);
+            return "공지사항 검색 중 오류가 발생했습니다: " + e.getMessage();
+        }
+    }
+}

--- a/src/main/java/com/jnulocker/ai/application/tools/AnnounceTools.java
+++ b/src/main/java/com/jnulocker/ai/application/tools/AnnounceTools.java
@@ -6,13 +6,11 @@ import com.jnulocker.announce.application.port.in.AnnounceQuery;
 import com.jnulocker.announce.application.port.in.response.AnnounceCustomPage;
 import com.jnulocker.announce.application.port.in.response.AnnouncePageable;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class AnnounceTools {
@@ -21,19 +19,12 @@ public class AnnounceTools {
     private final ObjectMapper objectMapper;
 
     @Tool(description = "전체 공지사항 목록을 조회합니다. 최신 공지사항부터 시간 순으로 정렬되어 표시됩니다.")
+    @AiToolMethod
     public String searchAnnouncements(
-            @ToolParam(description = "페이지 번호 (0부터 시작, 기본값 0)", required = false) Integer page) {
-        try {
-            log.info("Tool called: searchAnnouncements(page={})", page);
-            Pageable pageable = new AnnouncePageable(page, null, "desc", null).toPageable();
-            AnnounceCustomPage result = announceQuery.getAnnounces(pageable);
-            return objectMapper.writeValueAsString(result);
-        } catch (JsonProcessingException e) {
-            log.error("Failed to serialize AnnounceCustomPage", e);
-            return "공지사항 목록 조회 중 오류가 발생했습니다: ";
-        } catch (Exception e) {
-            log.error("Failed to search announcements", e);
-            return "공지사항 검색 중 오류가 발생했습니다: ";
-        }
+            @ToolParam(description = "페이지 번호 (0부터 시작, 기본값 0)", required = false) Integer page)
+            throws JsonProcessingException {
+        Pageable pageable = new AnnouncePageable(page, null, "desc", null).toPageable();
+        AnnounceCustomPage result = announceQuery.getAnnounces(pageable);
+        return objectMapper.writeValueAsString(result);
     }
 }

--- a/src/main/java/com/jnulocker/ai/application/tools/EventTools.java
+++ b/src/main/java/com/jnulocker/ai/application/tools/EventTools.java
@@ -32,10 +32,10 @@ public class EventTools {
             return objectMapper.writeValueAsString(result);
         } catch (JsonProcessingException e) {
             log.error("Failed to serialize EventCustomPage", e);
-            return "이벤트 목록 조회 중 오류가 발생했습니다: " + e.getMessage();
+            return "이벤트 목록 조회 중 오류가 발생했습니다: ";
         } catch (Exception e) {
             log.error("Failed to search events", e);
-            return "이벤트 검색 중 오류가 발생했습니다: " + e.getMessage();
+            return "이벤트 검색 중 오류가 발생했습니다: ";
         }
     }
 

--- a/src/main/java/com/jnulocker/ai/application/tools/EventTools.java
+++ b/src/main/java/com/jnulocker/ai/application/tools/EventTools.java
@@ -7,13 +7,11 @@ import com.jnulocker.events.application.port.in.response.EventCustomPage;
 import com.jnulocker.events.application.port.in.response.EventPageable;
 import com.jnulocker.events.application.port.in.response.MyEventCustomPage;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class EventTools {
@@ -22,39 +20,25 @@ public class EventTools {
     private final ObjectMapper objectMapper;
 
     @Tool(description = "사물함 신청 이벤트 목록을 검색합니다. 진행 중, 예정, 종료된 모든 이벤트를 조회할 수 있습니다.")
+    @AiToolMethod
     public String searchEvents(
             @ToolParam(description = "페이지 번호 (0부터 시작, 기본값 0)", required = false) Integer page,
-            @ToolParam(description = "페이지 크기 (기본값 10)", required = false) Integer size) {
-        try {
-            log.info("Tool called: searchEvents(page={}, size={})", page, size);
-            Pageable pageable = new EventPageable(page, size, null, null).toPageable();
-            EventCustomPage result = eventQuery.getAllEvents(pageable);
-            return objectMapper.writeValueAsString(result);
-        } catch (JsonProcessingException e) {
-            log.error("Failed to serialize EventCustomPage", e);
-            return "이벤트 목록 조회 중 오류가 발생했습니다: ";
-        } catch (Exception e) {
-            log.error("Failed to search events", e);
-            return "이벤트 검색 중 오류가 발생했습니다: ";
-        }
+            @ToolParam(description = "페이지 크기 (기본값 10)", required = false) Integer size)
+            throws JsonProcessingException {
+        Pageable pageable = new EventPageable(page, size, null, null).toPageable();
+        EventCustomPage result = eventQuery.getAllEvents(pageable);
+        return objectMapper.writeValueAsString(result);
     }
 
     @Tool(
             description =
                     "현재 로그인한 사용자가 참여(신청) 가능한 사물함 신청 이벤트 목록을 조회합니다. 사용자의 소속 학과에 해당하는 이벤트만 표시됩니다.")
+    @AiToolMethod
     public String getMyEvents(
-            @ToolParam(description = "페이지 번호 (0부터 시작, 기본값 0)", required = false) Integer page) {
-        try {
-            log.info("Tool called: getMyEvents(page={})", page);
-            Pageable pageable = new EventPageable(page, null, null, null).toPageable();
-            MyEventCustomPage result = eventQuery.getMyEvents(pageable);
-            return objectMapper.writeValueAsString(result);
-        } catch (JsonProcessingException e) {
-            log.error("Failed to serialize MyEventCustomPage", e);
-            return "내 이벤트 목록 조회 중 오류가 발생했습니다: " + e.getMessage();
-        } catch (Exception e) {
-            log.error("Failed to get my events", e);
-            return "내 이벤트 조회 중 오류가 발생했습니다: " + e.getMessage();
-        }
+            @ToolParam(description = "페이지 번호 (0부터 시작, 기본값 0)", required = false) Integer page)
+            throws JsonProcessingException {
+        Pageable pageable = new EventPageable(page, null, null, null).toPageable();
+        MyEventCustomPage result = eventQuery.getMyEvents(pageable);
+        return objectMapper.writeValueAsString(result);
     }
 }

--- a/src/main/java/com/jnulocker/ai/application/tools/EventTools.java
+++ b/src/main/java/com/jnulocker/ai/application/tools/EventTools.java
@@ -1,0 +1,60 @@
+package com.jnulocker.ai.application.tools;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jnulocker.events.application.port.in.EventQuery;
+import com.jnulocker.events.application.port.in.response.EventCustomPage;
+import com.jnulocker.events.application.port.in.response.EventPageable;
+import com.jnulocker.events.application.port.in.response.MyEventCustomPage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EventTools {
+
+    private final EventQuery eventQuery;
+    private final ObjectMapper objectMapper;
+
+    @Tool(description = "사물함 신청 이벤트 목록을 검색합니다. 진행 중, 예정, 종료된 모든 이벤트를 조회할 수 있습니다.")
+    public String searchEvents(
+            @ToolParam(description = "페이지 번호 (0부터 시작, 기본값 0)", required = false) Integer page,
+            @ToolParam(description = "페이지 크기 (기본값 10)", required = false) Integer size) {
+        try {
+            log.info("Tool called: searchEvents(page={}, size={})", page, size);
+            Pageable pageable = new EventPageable(page, size, null, null).toPageable();
+            EventCustomPage result = eventQuery.getAllEvents(pageable);
+            return objectMapper.writeValueAsString(result);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize EventCustomPage", e);
+            return "이벤트 목록 조회 중 오류가 발생했습니다: " + e.getMessage();
+        } catch (Exception e) {
+            log.error("Failed to search events", e);
+            return "이벤트 검색 중 오류가 발생했습니다: " + e.getMessage();
+        }
+    }
+
+    @Tool(
+            description =
+                    "현재 로그인한 사용자가 참여(신청) 가능한 사물함 신청 이벤트 목록을 조회합니다. 사용자의 소속 학과에 해당하는 이벤트만 표시됩니다.")
+    public String getMyEvents(
+            @ToolParam(description = "페이지 번호 (0부터 시작, 기본값 0)", required = false) Integer page) {
+        try {
+            log.info("Tool called: getMyEvents(page={})", page);
+            Pageable pageable = new EventPageable(page, null, null, null).toPageable();
+            MyEventCustomPage result = eventQuery.getMyEvents(pageable);
+            return objectMapper.writeValueAsString(result);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize MyEventCustomPage", e);
+            return "내 이벤트 목록 조회 중 오류가 발생했습니다: " + e.getMessage();
+        } catch (Exception e) {
+            log.error("Failed to get my events", e);
+            return "내 이벤트 조회 중 오류가 발생했습니다: " + e.getMessage();
+        }
+    }
+}

--- a/src/main/java/com/jnulocker/ai/application/tools/MemberTools.java
+++ b/src/main/java/com/jnulocker/ai/application/tools/MemberTools.java
@@ -1,0 +1,34 @@
+package com.jnulocker.ai.application.tools;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jnulocker.member.application.port.in.MemberQuery;
+import com.jnulocker.member.application.port.in.response.MemberInfoResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MemberTools {
+
+    private final MemberQuery memberQuery;
+    private final ObjectMapper objectMapper;
+
+    @Tool(description = "현재 로그인한 사용자의 정보를 조회합니다. 이름, 이메일, 소속 학과, 학번 등을 확인할 수 있습니다.")
+    public String getMyInfo() {
+        try {
+            log.info("Tool called: getMyInfo()");
+            MemberInfoResponse info = memberQuery.getMemberInfo();
+            return objectMapper.writeValueAsString(info);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize MemberInfoResponse", e);
+            return "사용자 정보 조회 중 오류가 발생했습니다: " + e.getMessage();
+        } catch (Exception e) {
+            log.error("Failed to get member info", e);
+            return "사용자 정보 조회 중 오류가 발생했습니다: " + e.getMessage();
+        }
+    }
+}

--- a/src/main/java/com/jnulocker/ai/application/tools/MemberTools.java
+++ b/src/main/java/com/jnulocker/ai/application/tools/MemberTools.java
@@ -5,11 +5,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnulocker.member.application.port.in.MemberQuery;
 import com.jnulocker.member.application.port.in.response.MemberInfoResponse;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.stereotype.Component;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class MemberTools {
@@ -18,17 +16,9 @@ public class MemberTools {
     private final ObjectMapper objectMapper;
 
     @Tool(description = "현재 로그인한 사용자의 정보를 조회합니다. 이름, 이메일, 소속 학과, 학번 등을 확인할 수 있습니다.")
-    public String getMyInfo() {
-        try {
-            log.info("Tool called: getMyInfo()");
-            MemberInfoResponse info = memberQuery.getMemberInfo();
-            return objectMapper.writeValueAsString(info);
-        } catch (JsonProcessingException e) {
-            log.error("Failed to serialize MemberInfoResponse", e);
-            return "사용자 정보 조회 중 오류가 발생했습니다: ";
-        } catch (Exception e) {
-            log.error("Failed to get member info", e);
-            return "사용자 정보 조회 중 오류가 발생했습니다: ";
-        }
+    @AiToolMethod
+    public String getMyInfo() throws JsonProcessingException {
+        MemberInfoResponse info = memberQuery.getMemberInfo();
+        return objectMapper.writeValueAsString(info);
     }
 }

--- a/src/main/java/com/jnulocker/ai/application/tools/MemberTools.java
+++ b/src/main/java/com/jnulocker/ai/application/tools/MemberTools.java
@@ -25,10 +25,10 @@ public class MemberTools {
             return objectMapper.writeValueAsString(info);
         } catch (JsonProcessingException e) {
             log.error("Failed to serialize MemberInfoResponse", e);
-            return "사용자 정보 조회 중 오류가 발생했습니다: " + e.getMessage();
+            return "사용자 정보 조회 중 오류가 발생했습니다: ";
         } catch (Exception e) {
             log.error("Failed to get member info", e);
-            return "사용자 정보 조회 중 오류가 발생했습니다: " + e.getMessage();
+            return "사용자 정보 조회 중 오류가 발생했습니다: ";
         }
     }
 }

--- a/src/main/java/com/jnulocker/ai/exception/AiErrorCode.java
+++ b/src/main/java/com/jnulocker/ai/exception/AiErrorCode.java
@@ -18,7 +18,9 @@ public enum AiErrorCode implements ErrorCode {
     VECTOR_STORE_DELETE_FAILED(
             "AI006", HttpStatus.INTERNAL_SERVER_ERROR, "Vector Store에서 문서를 삭제하는 중 오류가 발생했습니다."),
     EMPTY_FILE("AI007", HttpStatus.BAD_REQUEST, "파일이 비어있습니다."),
-    DOCUMENT_PARSE_FAILED("AI008", HttpStatus.INTERNAL_SERVER_ERROR, "문서 파싱에 실패했습니다.");
+    DOCUMENT_PARSE_FAILED("AI008", HttpStatus.INTERNAL_SERVER_ERROR, "문서 파싱에 실패했습니다."),
+    AI_TOOL_EXECUTION_ERROR(
+            "AI009", HttpStatus.INTERNAL_SERVER_ERROR, "AI 도구 실행 중 예상치 못한 오류가 발생했습니다.");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/jnulocker/ai/exception/AiToolExecutionException.java
+++ b/src/main/java/com/jnulocker/ai/exception/AiToolExecutionException.java
@@ -1,0 +1,12 @@
+package com.jnulocker.ai.exception;
+
+import com.jnulocker.common.exception.BusinessException;
+
+public class AiToolExecutionException extends BusinessException {
+
+    public static final BusinessException EXCEPTION = new AiToolExecutionException();
+
+    private AiToolExecutionException() {
+        super(AiErrorCode.AI_TOOL_EXECUTION_ERROR);
+    }
+}

--- a/src/main/java/com/jnulocker/config/AiConfig.java
+++ b/src/main/java/com/jnulocker/config/AiConfig.java
@@ -31,7 +31,7 @@ public class AiConfig {
                                 .searchRequest(
                                         SearchRequest.builder()
                                                 .topK(5) // 상위 5개 유사 문서 검색
-                                                .similarityThreshold(0.7) // 유사도 임계값 0.7
+                                                .similarityThreshold(0.5)
                                                 .build())
                                 .build())
                 .defaultTools(eventTools, announceTools, memberTools)

--- a/src/main/java/com/jnulocker/config/AiConfig.java
+++ b/src/main/java/com/jnulocker/config/AiConfig.java
@@ -1,5 +1,8 @@
 package com.jnulocker.config;
 
+import com.jnulocker.ai.application.tools.AnnounceTools;
+import com.jnulocker.ai.application.tools.EventTools;
+import com.jnulocker.ai.application.tools.MemberTools;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.vectorstore.QuestionAnswerAdvisor;
 import org.springframework.ai.vectorstore.SearchRequest;
@@ -16,7 +19,12 @@ public class AiConfig {
     private Resource systemTemplate;
 
     @Bean
-    public ChatClient chatClient(ChatClient.Builder builder, VectorStore vectorStore) {
+    public ChatClient chatClient(
+            ChatClient.Builder builder,
+            VectorStore vectorStore,
+            EventTools eventTools,
+            AnnounceTools announceTools,
+            MemberTools memberTools) {
         return builder.defaultSystem(systemTemplate)
                 .defaultAdvisors(
                         QuestionAnswerAdvisor.builder(vectorStore)
@@ -26,6 +34,7 @@ public class AiConfig {
                                                 .similarityThreshold(0.7) // 유사도 임계값 0.7
                                                 .build())
                                 .build())
+                .defaultTools(eventTools, announceTools, memberTools)
                 .build();
     }
 }

--- a/src/test/java/com/jnulocker/announce/utils/AnnounceTestUtil.java
+++ b/src/test/java/com/jnulocker/announce/utils/AnnounceTestUtil.java
@@ -26,7 +26,7 @@ public class AnnounceTestUtil {
 
     @Autowired private DepartmentRepository departmentRepository;
 
-    public Announce createAnnounceWithParticipationDepartment(Department department) {
+    public void createAnnounceWithParticipationDepartment(Department department) {
         // 공지사항 생성 및 저장
         Announce savedAnnounce = createAndSaveAnnounce(department);
 
@@ -34,8 +34,6 @@ public class AnnounceTestUtil {
         AnnounceParticipation announceParticipation =
                 AnnounceParticipation.create(savedAnnounce, department);
         announceParticipationRepository.save(announceParticipation);
-
-        return savedAnnounce;
     }
 
     private Announce createAndSaveAnnounce(Department department) {
@@ -49,7 +47,7 @@ public class AnnounceTestUtil {
         announceParticipationRepository.deleteAll();
     }
 
-    public Announce createAnnounce() {
+    public void createAnnounce() {
         // 조직 생성 및 저장
         Organization organization = organizationBuilder().build();
         Organization savedOrganization = organizationRepository.save(organization);
@@ -59,8 +57,6 @@ public class AnnounceTestUtil {
         Department savedDepartment = departmentRepository.save(department);
 
         // 공지사항 생성 및 저장
-        Announce savedAnnounce = createAndSaveAnnounce(savedDepartment);
-
-        return savedAnnounce;
+        createAndSaveAnnounce(savedDepartment);
     }
 }

--- a/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/events/adapter/in/EventControllerIntegrationTest.java
@@ -982,7 +982,7 @@ public class EventControllerIntegrationTest extends RedisTest {
 
         Event event =
                 eventTestUtil
-                        .setUpLockerEventWithMixedPattern(
+                        .setUpLockerEventWithCustomCodes(
                                 floorToLockerCodes, Role.MANAGER, EventStatus.OPEN, true)
                         .event();
 

--- a/src/test/java/com/jnulocker/events/utils/EventTestUtil.java
+++ b/src/test/java/com/jnulocker/events/utils/EventTestUtil.java
@@ -1,8 +1,8 @@
 package com.jnulocker.events.utils;
 
-import static events.domain.EventTestDataBuilder.*;
-import static organization.domain.DepartmentTestDataBuilder.*;
-import static organization.domain.OrganizationTestDataBuilder.*;
+import static events.domain.EventTestDataBuilder.eventBuilder;
+import static organization.domain.DepartmentTestDataBuilder.departmentBuilder;
+import static organization.domain.OrganizationTestDataBuilder.organizationBuilder;
 
 import com.jnulocker.auth.utils.AuthTestUtil;
 import com.jnulocker.events.adapter.out.EventParticipationRepository;
@@ -52,16 +52,10 @@ public class EventTestUtil {
 
     public LockerEventContext setUpLockerEventForRegistration(
             List<Integer> lockersPerFloor, Role role, EventStatus eventStatus, boolean publish) {
-        // Department 생성
         Department department = organizationTestUtil.createCouncilDepartment();
-
-        // Member 생성
         Member member = memberTestUtil.createMemberFromRoleWithDepartment(role, department);
-
-        // AccessToken 생성
         String accessToken = authTestUtil.generateAccessTokenWithMember(member);
 
-        // Event 생성 및 Department를 EventParticipation에 추가
         Event event =
                 createEventWithParticipationDepartment(
                         lockersPerFloor, department, eventStatus, publish);
@@ -75,29 +69,15 @@ public class EventTestUtil {
             EventStatus eventStatus,
             boolean publish,
             List<Department> participationDepartments) {
-        // Department 생성 (사용자의 Department)
         Department userDepartment = organizationTestUtil.createCouncilDepartment();
-
-        // Member 생성
         Member member = memberTestUtil.createMemberFromRoleWithDepartment(role, userDepartment);
-
-        // AccessToken 생성
         String accessToken = authTestUtil.generateAccessTokenWithMember(member);
 
-        // Event 생성
         Event event = createEventWithFloorAndLockers(lockersPerFloor, eventStatus, publish);
 
-        // 지정된 Department들만 EventParticipation에 추가: 사용자의 Department는 제외
-        for (Department dept : participationDepartments) {
-            addParticipationDepartment(event, dept);
-        }
+        participationDepartments.forEach(dept -> addDepartmentToEvent(event, dept));
 
         return new LockerEventContext(userDepartment, member, accessToken, event);
-    }
-
-    private void addParticipationDepartment(Event event, Department department) {
-        EventParticipation participation = EventParticipation.create(event, department);
-        eventParticipationRepository.save(participation);
     }
 
     public Event createEventWithParticipationDepartment(
@@ -105,36 +85,29 @@ public class EventTestUtil {
             Department department,
             EventStatus eventStatus,
             boolean publish) {
-
-        // 이벤트 생성 및 저장
         Event savedEvent = createAndSaveEvent(department, eventStatus, publish);
 
-        // 이벤트 참여 학과 정보 생성 및 저장
-        EventParticipation eventParticipation = EventParticipation.create(savedEvent, department);
-        eventParticipationRepository.save(eventParticipation);
+        addDepartmentToEvent(savedEvent, department);
 
-        // 층 생성 및 저장
         createFloorsWithEvent(lockersPerFloor, savedEvent);
         return savedEvent;
     }
 
     public Event createEventWithFloorAndLockers(
             List<Integer> lockersPerFloor, EventStatus eventStatus, boolean publish) {
-        // 조직 생성 및 저장
-        Organization organization = organizationBuilder().build();
-        Organization savedOrganization = organizationRepository.save(organization);
-
-        // 학과 생성 및 저장
-        Department department = departmentBuilder().withOrganization(savedOrganization).build();
-        Department savedDepartment = departmentRepository.save(department);
-
-        // 이벤트 생성 및 저장
-        Event savedEvent = createAndSaveEvent(savedDepartment, eventStatus, publish);
-
-        // 층 생성 및 저장
+        Department department = createDepartmentWithOrganization();
+        Event savedEvent = createAndSaveEvent(department, eventStatus, publish);
         createFloorsWithEvent(lockersPerFloor, savedEvent);
 
         return savedEvent;
+    }
+
+    private Department createDepartmentWithOrganization() {
+        Organization organization = organizationBuilder().build();
+        Organization savedOrganization = organizationRepository.save(organization);
+
+        Department department = departmentBuilder().withOrganization(savedOrganization).build();
+        return departmentRepository.save(department);
     }
 
     private Event createAndSaveEvent(
@@ -152,17 +125,15 @@ public class EventTestUtil {
         for (int floorLevel = 0; floorLevel < lockersPerFloor.size(); floorLevel++) {
             int floorNumber = floorLevel + 1;
             Floor floor = floorRepository.save(Floor.create(savedEvent, floorNumber));
-            createLockersWithFloor(lockersPerFloor, floorLevel, floor);
+            createLockersForFloor(lockersPerFloor.get(floorLevel), floorLevel, floor);
         }
     }
 
-    private void createLockersWithFloor(
-            List<Integer> lockersPerFloor, int floorLevel, Floor floor) {
+    private void createLockersForFloor(int lockerCount, int floorLevel, Floor floor) {
         List<Locker> lockers = new ArrayList<>();
-        for (int j = 1; j <= lockersPerFloor.get(floorLevel); j++) {
-            String code =
-                    String.format("%c-%03d", 'A' + floorLevel, j); // A-001, A-002, B-001, B-002 등
-            boolean available = j % 2 == 0; // 짝수 번호 사물함은 사용 가능, 홀수는 사용 불가능으로 설정
+        for (int j = 1; j <= lockerCount; j++) {
+            String code = String.format("%c-%03d", 'A' + floorLevel, j);
+            boolean available = j % 2 == 0;
 
             lockers.add(Locker.create(floor, code, available));
         }
@@ -192,27 +163,19 @@ public class EventTestUtil {
         String accessToken = authTestUtil.generateAccessTokenWithMember(member);
 
         Event event =
-                createEventWithCustomCodes(floorToLockerCodes, department, eventStatus, publish);
+                createEventWithCustomLockerCodes(
+                        floorToLockerCodes, department, eventStatus, publish);
 
         return new LockerEventContext(department, member, accessToken, event);
     }
 
-    public LockerEventContext setUpLockerEventWithMixedPattern(
-            Map<Integer, List<String>> floorToLockerCodes,
-            Role role,
-            EventStatus eventStatus,
-            boolean publish) {
-        return setUpLockerEventWithCustomCodes(floorToLockerCodes, role, eventStatus, publish);
-    }
-
-    private Event createEventWithCustomCodes(
+    private Event createEventWithCustomLockerCodes(
             Map<Integer, List<String>> floorToLockerCodes,
             Department department,
             EventStatus eventStatus,
             boolean publish) {
         Event savedEvent = createAndSaveEvent(department, eventStatus, publish);
-        EventParticipation eventParticipation = EventParticipation.create(savedEvent, department);
-        eventParticipationRepository.save(eventParticipation);
+        addDepartmentToEvent(savedEvent, department);
 
         createFloorsWithCustomCodes(floorToLockerCodes, savedEvent);
         return savedEvent;
@@ -220,21 +183,24 @@ public class EventTestUtil {
 
     private void createFloorsWithCustomCodes(
             Map<Integer, List<String>> floorToLockerCodes, Event savedEvent) {
-        for (Map.Entry<Integer, List<String>> entry : floorToLockerCodes.entrySet()) {
-            int floorNumber = entry.getKey();
-            List<String> lockerCodes = entry.getValue();
-            Floor floor = floorRepository.save(Floor.create(savedEvent, floorNumber));
-            createLockersWithCustomCodes(lockerCodes, floor);
-        }
+        floorToLockerCodes.forEach(
+                (floorNumber, lockerCodes) -> {
+                    Floor floor = floorRepository.save(Floor.create(savedEvent, floorNumber));
+                    createLockersWithCustomCodes(lockerCodes, floor);
+                });
     }
 
     private void createLockersWithCustomCodes(List<String> lockerCodes, Floor floor) {
         List<Locker> lockers = new ArrayList<>();
         for (int i = 0; i < lockerCodes.size(); i++) {
-            String code = lockerCodes.get(i);
             boolean available = (i + 1) % 2 == 0;
-            lockers.add(Locker.create(floor, code, available));
+            lockers.add(Locker.create(floor, lockerCodes.get(i), available));
         }
         lockerRepository.saveAll(lockers);
+    }
+
+    public void addDepartmentToEvent(Event event, Department department) {
+        EventParticipation participation = EventParticipation.create(event, department);
+        eventParticipationRepository.save(participation);
     }
 }


### PR DESCRIPTION
### 개요
close #165 

### 작업사항

[Spring AI의 Tool Calling](https://docs.spring.io/spring-ai/reference/api/tools.html)을 이용해 AI가 사용할 수 있는 Tool들을 정의

- 전체 이벤트 목록 조회
- 내가 참여 가능한 이벤트 조회
- 공지사항 목록 조회
- 내 정보 조회

### 변경로직
- Spring AI 버전 1.0.2 -> 1.1.0-M4 로 업그레이드
- commons-logging 종속성 제거
  - spring은 로깅을 위해 spring-jcl을 사용
  - 이는 [표준 commons-logging을 대체하는데 전이적 의존성에 의해 commons-logging에 대한 의존성이 존재하는 경우 충돌 가능성](https://github.com/spring-projects/spring-framework/issues/21146#issuecomment-453469054) 발생
  - 따라서 exclude를 통해 종속성 제거
- 기본 조회 Tool 구현 (로깅 추가)
- ChatClient에 Tool 등록
- RAG 검색 임계값 0.7 -> 0.5로 수정
- TestUtil 리팩토링

### 테스트 결과
<img width="388" height="406" alt="image" src="https://github.com/user-attachments/assets/f805100f-ed86-4574-ae53-94ade9ff7e13" />

### reference
- [Spring AI Tool Calling](https://docs.spring.io/spring-ai/reference/api/tools.html)
- [spring-jcl](https://docs.spring.io/spring-framework/reference/core/spring-jcl.html)

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 공지사항, 행사, 회원 정보 조회를 위한 AI 도구 추가

* **개선사항**
  * AI 도구의 오류 처리 개선으로 보다 일관된 에러 응답 제공
  * 벡터 스토어 유사도 임계값 조정으로 검색 결과 품질 향상

* **의존성 업데이트**
  * Spring AI 프레임워크 버전 상향 (1.1.0-M4)

* **리팩터**
  * 테스트 유틸 및 이벤트 생성 흐름 정리, 내부 코드 정비
<!-- end of auto-generated comment: release notes by coderabbit.ai -->