### PR TITLE
[REFACTOR] 데이터베이스를 MySQL/Elasticsearch에서 PostgreSQL/PGvector로 통합

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,11 +79,11 @@ dependencies {
     // test containers
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
-    testImplementation 'org.testcontainers:mysql'
+    testImplementation 'org.testcontainers:postgresql'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
-    runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'org.postgresql:postgresql'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
     annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -57,9 +57,8 @@ dependencies {
     // redisson
     implementation "org.redisson:redisson-spring-boot-starter:3.49.0"
 
-    // elasticsearch for vector store
-    implementation 'org.springframework.ai:spring-ai-starter-vector-store-elasticsearch'
-    implementation 'co.elastic.clients:elasticsearch-java:8.19.5' // Elasticsearch Java Client 버전 명시
+    // pgvector for vector store
+    implementation 'org.springframework.ai:spring-ai-starter-vector-store-pgvector'
 
     // pdf document reader
     implementation 'org.springframework.ai:spring-ai-pdf-document-reader'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "5432:5432"
     restart: unless-stopped
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U $POSTGRES_USERNAME" ]
+      test: [ "CMD-SHELL", "pg_isready -U $PGVECTOR_USERNAME" ]
       start_period: 20s
       start_interval: 3s
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,26 +1,25 @@
 services:
-  mysql:
-    container_name: mysql-jnu-locker
-    image: mysql:8.0
-    ports:
-      - "3306:3306"
-    restart: unless-stopped
+  pgvector:
+    image: pgvector/pgvector:pg18
+    container_name: pgvector-jnu-locker
     environment:
       TZ: Asia/Seoul
       LC_ALL: C.UTF-8
-      MYSQL_ROOT_PASSWORD: ${MYSQL_PASSWORD}
-      MYSQL_DATABASE: ${MYSQL_DATABASE}
-      MYSQL_USER: ${MYSQL_USERNAME}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      POSTGRES_USER: ${PGVECTOR_USERNAME}
+      POSTGRES_PASSWORD: ${PGVECTOR_PASSWORD}
+      POSTGRES_DB: ${PGVECTOR_DATABASE}
+    ports:
+      - "5432:5432"
+    restart: unless-stopped
     healthcheck:
-      test: ["CMD", "mysql", "-u", "$MYSQL_USERNAME", "-p$MYSQL_PASSWORD", "-e", "SELECT 1;"]
+      test: [ "CMD-SHELL", "pg_isready -U $POSTGRES_USERNAME" ]
       start_period: 20s
       start_interval: 3s
       interval: 10s
       timeout: 5s
-      retries: 3
+      retries: 5
     volumes:
-      - ${MYSQL_DATA_PATH}:/var/lib/mysql
+      - pgvector-data:/var/lib/postgresql/data
     networks:
       - jnu-locker-network
 
@@ -32,7 +31,7 @@ services:
     restart: unless-stopped
     command: /bin/sh -c "redis-server --requirepass $REDIS_PASSWORD"
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: [ "CMD", "redis-cli", "ping" ]
       start_period: 10s
       start_interval: 3s
       interval: 10s
@@ -51,13 +50,13 @@ services:
       - .env
     healthcheck:
       test: [ "CMD-SHELL", "wget -q --spider http://localhost:8080$MANAGEMENT_BASE_PATH/health || exit 1" ]
-      start_period: 50s
+      start_period: 70s
       start_interval: 5s
       interval: 10s
       timeout: 5s
       retries: 3
     depends_on:
-      mysql:
+      pgvector:
         condition: service_healthy
       redis:
         condition: service_healthy
@@ -96,7 +95,7 @@ services:
       - /sys:/sys:ro
       - /var/lib/docker/:/var/lib/docker:ro
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/healthz"]
+      test: [ "CMD", "wget", "-q", "--spider", "http://localhost:8080/healthz" ]
       start_period: 15s
       start_interval: 3s
       interval: 10s
@@ -125,7 +124,7 @@ services:
       was:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9090/metrics"]
+      test: [ "CMD", "wget", "-q", "--spider", "http://localhost:9090/metrics" ]
       start_period: 20s
       start_interval: 5s
       interval: 10s
@@ -149,7 +148,7 @@ services:
       prometheus:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/api/health"]
+      test: [ "CMD", "wget", "-q", "--spider", "http://localhost:3000/api/health" ]
       start_period: 20s
       start_interval: 5s
       interval: 10s
@@ -178,29 +177,6 @@ services:
       grafana:
         condition: service_healthy
 
-  elasticsearch:
-    image: elasticsearch:8.19.5 # 8.14.0 이상 권장
-    container_name: elasticsearch-jnu-locker
-    environment:
-      - discovery.type=single-node
-      - xpack.security.enabled=false
-      - ES_JAVA_OPTS=-Xms256m -Xmx256m
-      - TZ=Asia/Seoul
-    volumes:
-      - elasticsearch-data:/usr/share/elasticsearch/data
-    ports:
-      - "9200:9200"
-    restart: unless-stopped
-    healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:9200/_cluster/health || exit 1"]
-      start_period: 30s
-      start_interval: 5s
-      interval: 10s
-      timeout: 5s
-      retries: 5
-    networks:
-      - jnu-locker-network
-
 networks:
   jnu-locker-network:
     driver: bridge
@@ -211,4 +187,6 @@ volumes:
   prometheus-data:
     external: true
   elasticsearch-data:
+    external: true
+  pgvector-data:
     external: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,10 +3,10 @@ spring:
     name: jnu-locker
 
   datasource:
-    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}?rewriteBatchedStatements=true
-    username: ${MYSQL_USERNAME}
-    password: ${MYSQL_PASSWORD}
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:postgresql://${PGVECTOR_HOST}:${PGVECTOR_PORT}/${PGVECTOR_DATABASE}
+    username: ${PGVECTOR_USERNAME}
+    password: ${PGVECTOR_PASSWORD}
+    driver-class-name: org.postgresql.Driver
 
   jpa:
     open-in-view: false
@@ -14,7 +14,7 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MySQLDialect
+        dialect: org.hibernate.dialect.PostgreSQLDialect
         jdbc:
           batch_size: 50 # 한 번에 50개의 SQL 문을 배치로 실행
         order_inserts: true # Action Queue 내부 insert 문을 정렬하여 실행
@@ -41,14 +41,9 @@ spring:
         options:
           model: ${OPENAI_MODEL}
     vectorstore:
-      elasticsearch:
+      pgvector:
+        table-name: ${PGVECTOR_TABLE_NAME}
         initialize-schema: true
-        index-name: ${ELASTICSEARCH_INDEX}
-
-  elasticsearch:
-    uris: ${ELASTICSEARCH_URIS}
-    username: ${ELASTICSEARCH_USERNAME}
-    password: ${ELASTICSEARCH_PASSWORD}
 
   servlet:
     multipart:

--- a/src/test/java/com/jnulocker/ai/utils/DocumentTestUtil.java
+++ b/src/test/java/com/jnulocker/ai/utils/DocumentTestUtil.java
@@ -6,6 +6,7 @@ import com.jnulocker.ai.application.service.VectorStoreManager;
 import com.jnulocker.ai.domain.AiDocument;
 import com.jnulocker.member.domain.Member;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.stereotype.Component;
@@ -102,6 +103,10 @@ public class DocumentTestUtil {
 
     /** 테스트용 AiDocument 엔티티 생성 및 저장 */
     public AiDocument createDocument(Member member, String category) {
+        String vectorId1 = UUID.randomUUID().toString();
+        String vectorId2 = UUID.randomUUID().toString();
+        String vectorStoreIds = String.format("[\"%s\", \"%s\"]", vectorId1, vectorId2);
+
         AiDocument document =
                 AiDocument.create(
                         "test-document.pdf",
@@ -111,19 +116,18 @@ public class DocumentTestUtil {
                         category,
                         5,
                         member,
-                        "[\"vector-id-1\", \"vector-id-2\"]");
+                        vectorStoreIds);
 
         return aiDocumentJpaRepository.save(document);
-    }
-
-    /** 카테고리 없이 테스트용 AiDocument 엔티티 생성 및 저장 */
-    public AiDocument createDocumentWithoutCategory(Member member) {
-        return createDocument(member, null);
     }
 
     /** 여러 개의 테스트용 문서 생성 */
     public void createMultipleDocuments(Member member, int count, String category) {
         for (int i = 0; i < count; i++) {
+            String vectorId1 = UUID.randomUUID().toString();
+            String vectorId2 = UUID.randomUUID().toString();
+            String vectorStoreIds = String.format("[\"%s\", \"%s\"]", vectorId1, vectorId2);
+
             AiDocument document =
                     AiDocument.create(
                             "test-document-" + i + ".pdf",
@@ -133,14 +137,9 @@ public class DocumentTestUtil {
                             category,
                             5 + i,
                             member,
-                            "[\"vector-id-" + i + "-1\", \"vector-id-" + i + "-2\"]");
+                            vectorStoreIds);
             aiDocumentJpaRepository.save(document);
         }
-    }
-
-    /** 문서 ID로 문서 조회 */
-    public AiDocument findDocumentById(Long documentId) {
-        return aiDocumentJpaRepository.findById(documentId).orElseThrow();
     }
 
     /** ElasticSearch에서 VectorStore 데이터 삭제 */

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -3,7 +3,7 @@ spring:
     name: jnu-locker
 
   datasource:
-    url: jdbc:tc:mysql:8.0:///test-database
+    url: jdbc:tc:pgvector:pg18:///test-database
     driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
 
   sql:
@@ -12,14 +12,8 @@ spring:
 
   ai:
     vectorstore:
-      elasticsearch:
+      pgvector:
         initialize-schema: true
-        index-name: test-vector-store
-
-  elasticsearch:
-    uris: ${ELASTICSEARCH_URIS:http://localhost:9200}
-    username: ${ELASTICSEARCH_USERNAME:elastic}
-    password: ${ELASTICSEARCH_PASSWORD:}
 
 custom:
   jwt:


### PR DESCRIPTION
### 개요
close #167 

### 작업사항
- Elasticsearch를 Vector Database로 사용 시 리소스 소모가 심해 EC2 인스턴스(t2.small)의 CPU 버스트 발생
- MySQL과 PostgreSQL을 함께 사용할 필요 없이 PostgreSQL로 통합
- PGvector 확장을 통해 PostgreSQL 데이터베이스에서 벡터 검색 지원

### 변경로직

#### 데이터베이스
- MySQL 8.0 → PostgreSQL 18 (pgvetor 확장)
- Docker Compose 서비스 변경
- JDBC 드라이버 및 Hibernate Dialect 변경
- Test Container pgvector 설정
- 데이터베이스 마이그레이션

#### Vector Store
- Elasticsearch 컨테이너 제거
- Spring AI Vector Store: Elasticsearch → PGvector
- 의존성 변경: spring-ai-starter-vector-store-pgvector 적용

### 테스트 결과

문서 업로드 전후로 질의응답 결과
- 전: 정보 확인 불가능 답변
- 후: 정보 확인 후 답변

<img width="355" height="402" alt="image" src="https://github.com/user-attachments/assets/3c223542-f04f-4a46-bf7b-24a56651ab23" />

<img width="359" height="621" alt="image" src="https://github.com/user-attachments/assets/a851c368-bbf6-446b-aa71-953f1dad0836" />


### reference
- [Spring AI PGvector](https://docs.spring.io/spring-ai/reference/api/vectordbs/pgvector.html)
- [pgloader를 이용한 MySQL to PostgreSQL 마이그레이션](https://github.com/dimitri/pgloader/blob/master/docs/tutorial/mysql.rst)
- [MySQL 8.0 버전 마이그레이션 오류 - 5.7 버전 임시 인스턴스에 데이터 복사 후 마이그레이션](https://github.com/dimitri/pgloader/issues/782)

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **기반 시설 개선**
  * 데이터베이스 및 벡터 저장소를 MySQL/Elasticsearch에서 PostgreSQL(pgvector)로 전환했습니다.
  * 컨테이너 및 도커 구성, 포트와 볼륨, 헬스체크가 PostgreSQL 환경에 맞게 업데이트되었습니다.

* **테스트**
  * 통합/테스트 설정이 PostgreSQL 기반으로 변경되어 로컬 및 CI 테스트 환경이 업데이트되었습니다.
  * 테스트 유틸의 벡터 ID 생성 로직이 UUID 기반으로 개선되었습니다.

* **부수 작업**
  * 설정 파일과 JPA/Hibernate 설정이 PostgreSQL에 최적화되도록 조정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->