### PR TITLE
[CHORE] cAdvisor 컨테이너 모니터링 제거 및 JPA default schema 설정

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,13 @@ docker compose up -d
 # Spring 실행 프로파일
 PROFILE=local
 
-# MySQL 설정 (docker-compose로 실행할 경우 host는 mysql로)
-MYSQL_HOST=mysql
-MYSQL_PORT=3306
-MYSQL_DATABASE=locker
-MYSQL_USERNAME=root
-MYSQL_PASSWORD= # TODO: 비밀번호 입력
-
-# 데이터가 저장될 로컬 경로
-MYSQL_DATA_PATH=./mysql
+# PostgreSQL with pgvector 설정 (docker-compose로 실행할 경우 host는 pgvector로)
+PGVECTOR_HOST=pgvector
+PGVECTOR_PORT=5432
+PGVECTOR_DATABASE=locker
+PGVECTOR_USERNAME=admin
+PGVECTOR_PASSWORD= # TODO: 비밀번호 입력
+PGVECTOR_TABLE_NAME=document_embeddings
 
 # 로그 설정
 LOGGING_LEVEL=INFO
@@ -172,7 +170,7 @@ MAIL_PORT=587
 | Framework    | Spring Boot 3.3.3   | 익숙한 Java 언어로 서버 애플리케이션 개발                               |
 |              | Spring Data JPA     | ORM 기술로 DB를 객체지향적으로 다룸                                     |
 |              | Spring Security     | 인증/인가에 대한 간편한 설정                                            |
-| Database     | MySQL 8.0           | RDB 중 가장 많이 사용되는 MySQL 사용                                    |
+| Database     | PostgreSQL 16 with pgvector | 벡터 검색을 지원하는 고성능 관계형 데이터베이스 (AI 챗봇 기능 지원)  |
 |              | Redis               | RefreshToken 및 캐시 저장소로 인메모리 기반의 DB 사용         |
 | Infra        | Amazon Web Service  | AWS – 클라우드 환경에서 가용성 높은 서비스 가능                         |
 |              | Nginx | Nginx – 리버스 프록시를 통한 SSL/TLS                                 |

--- a/config/prometheus.yml.tmpl
+++ b/config/prometheus.yml.tmpl
@@ -11,8 +11,3 @@ scrape_configs:
     metrics_path: '/metrics'
     static_configs:
       - targets: ['node-exporter:9100']
-
-  - job_name: 'docker-containers'
-    metrics_path: '/metrics'
-    static_configs:
-      - targets: ["cadvisor:8080"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,27 +83,6 @@ services:
     networks:
       - jnu-locker-network
 
-  cadvisor:
-    image: gcr.io/cadvisor/cadvisor:latest
-    container_name: cadvisor-jnu-locker
-    restart: unless-stopped
-    ports:
-      - "8090:8080"
-    volumes:
-      - /:/rootfs:ro
-      - /var/run:/var/run:rw
-      - /sys:/sys:ro
-      - /var/lib/docker/:/var/lib/docker:ro
-    healthcheck:
-      test: [ "CMD", "wget", "-q", "--spider", "http://localhost:8080/healthz" ]
-      start_period: 15s
-      start_interval: 3s
-      interval: 10s
-      timeout: 5s
-      retries: 3
-    networks:
-      - jnu-locker-network
-
   prometheus:
     # user: root # 최초 실행시에만 하기 (컨테이너 접속 후 /data 경로 nobody 권한 주는 용도)
     container_name: prometheus-jnu-locker

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,7 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+        default_schema: locker
         jdbc:
           batch_size: 50 # 한 번에 50개의 SQL 문을 배치로 실행
         order_inserts: true # Action Queue 내부 insert 문을 정렬하여 실행
@@ -123,7 +124,7 @@ spring:
       mode: never
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
 
 ---
 spring:
@@ -142,7 +143,7 @@ spring:
       mode: never
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
 
 ---
 spring:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -160,6 +160,9 @@ spring:
   sql:
     init:
       mode: never
+  jpa:
+    hibernate:
+      ddl-auto: validate
 
 # 프로덕션 환경에서는 p6spy 로깅을 비활성화
 decorator:


### PR DESCRIPTION
### 개요
close #169 

### 작업사항
- cAdvisor가 EC2 인스턴스의 리소스를 많이 잡아먹어 컨테이너 모니터링 메트릭 제거
- JPA가 default schema로 locker를 사용하도록 설정

### 변경로직
- `docker-compose.yml` 에서 cadvisor 서비스 제거
- `prometheus.yml.tmpl`에서 cadvisor 타겟 제거
- `application.yml`에서 default_schema를 locker로 설정

### reference

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 데이터베이스를 MySQL에서 PostgreSQL(벡터 검색 pgvector 포함)로 마이그레이션
  * 예시 환경 설정 및 README의 DB 구성 항목 업데이트
  * 모니터링 구성 간소화(컨테이너 수집기 제거)
  * 배포 구성에서 스키마 자동적용을 검증 모드로 변경하여 스키마 검증 강화
  * 메일(SMTP) 시스템 설정 항목 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->