### PR TITLE
[FEAT] Tool Calling - 상세 조회 구현

### DIFF
--- a/src/main/java/com/jnulocker/ai/application/advisor/DetailedLoggingAdvisor.java
+++ b/src/main/java/com/jnulocker/ai/application/advisor/DetailedLoggingAdvisor.java
@@ -1,0 +1,154 @@
+package com.jnulocker.ai.application.advisor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.api.CallAdvisor;
+import org.springframework.ai.chat.client.advisor.api.CallAdvisorChain;
+import org.springframework.ai.chat.client.advisor.api.StreamAdvisor;
+import org.springframework.ai.chat.client.advisor.api.StreamAdvisorChain;
+import org.springframework.ai.chat.client.advisor.vectorstore.QuestionAnswerAdvisor;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.Usage;
+import org.springframework.ai.document.Document;
+import org.springframework.core.Ordered;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+
+@Component
+public class DetailedLoggingAdvisor implements CallAdvisor, StreamAdvisor {
+
+    private static final Logger logger = LoggerFactory.getLogger(DetailedLoggingAdvisor.class);
+    private final ObjectMapper objectMapper;
+
+    public DetailedLoggingAdvisor() {
+        this.objectMapper = new ObjectMapper();
+        this.objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+    }
+
+    @Override
+    public String getName() {
+        return "DetailedLoggingAdvisor";
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE - 1;
+    }
+
+    @Override
+    public ChatClientResponse adviseCall(ChatClientRequest request, CallAdvisorChain chain) {
+        logRequest(request);
+        ChatClientResponse response = chain.nextCall(request);
+        logResponse(response);
+        return response;
+    }
+
+    @Override
+    public Flux<ChatClientResponse> adviseStream(
+            ChatClientRequest request, StreamAdvisorChain chain) {
+        logRequest(request);
+        return chain.nextStream(request)
+                .doOnComplete(
+                        () ->
+                                logger.debug(
+                                        "Stream completed for request: {}",
+                                        request.prompt().getUserMessage()));
+    }
+
+    private void logRequest(ChatClientRequest request) {
+        try {
+            Map<String, Object> requestInfo = new HashMap<>();
+
+            // Messages 정보 (System prompt, User prompt 등)
+            List<Map<String, Object>> messages =
+                    request.prompt().getInstructions().stream().map(this::formatMessage).toList();
+
+            requestInfo.put("messages", messages);
+            requestInfo.put("messageCount", messages.size());
+            requestInfo.put("requestToString", request.toString());
+
+            String json = objectMapper.writeValueAsString(requestInfo);
+            logger.debug("\n=== ChatClient Request ===\n{}\n=========================", json);
+        } catch (Exception e) {
+            logger.warn("요청 상세 정보를 로깅하는 데 실패했습니다.", e);
+            logger.debug("요청 내용: {}", request);
+        }
+    }
+
+    private Map<String, Object> formatMessage(Message message) {
+        Map<String, Object> messageInfo = new HashMap<>();
+        messageInfo.put("messageType", message.getMessageType().name());
+        messageInfo.put("text", message.getText());
+        return messageInfo;
+    }
+
+    private void logResponse(ChatClientResponse response) {
+        try {
+            Map<String, Object> responseInfo = new HashMap<>();
+
+            Map<String, Object> metadataInfo = getMetadataInfo(response);
+            responseInfo.put("metadata", metadataInfo);
+
+            // QuestionAnswerAdvisor 검색된 문서 정보
+            addRAGInfo(response, responseInfo);
+
+            responseInfo.put("content", response.chatResponse().getResult().getOutput().getText());
+            responseInfo.put("responseToString", response.toString());
+
+            String json = objectMapper.writeValueAsString(responseInfo);
+            logger.debug("\n=== ChatClient Response ===\n{}\n==========================", json);
+        } catch (Exception e) {
+            logger.warn("응답 상세 정보를 로깅하는 데 실패했습니다.", e);
+            logger.debug("응답 내용: {}", response);
+        }
+    }
+
+    private Map<String, Object> getMetadataInfo(ChatClientResponse response) {
+        ChatResponseMetadata metadata = response.chatResponse().getMetadata();
+
+        Usage usage = metadata.getUsage();
+
+        Map<String, Object> usageInfo = new HashMap<>();
+        usageInfo.put("promptTokens", usage.getPromptTokens());
+        usageInfo.put("completionTokens", usage.getCompletionTokens());
+        usageInfo.put("totalTokens", usage.getTotalTokens());
+
+        Map<String, Object> metadataInfo = new HashMap<>();
+        metadataInfo.put("usage", usageInfo);
+        metadataInfo.put("model", metadata.getModel());
+
+        return metadataInfo;
+    }
+
+    private void addRAGInfo(ChatClientResponse response, Map<String, Object> responseInfo) {
+        Map<String, Object> context = response.context();
+        Object retrievedDocsObj = context.get(QuestionAnswerAdvisor.RETRIEVED_DOCUMENTS);
+        if (retrievedDocsObj instanceof List<?> retrievedDocs) {
+            List<Map<String, Object>> docsInfo =
+                    retrievedDocs.stream()
+                            .filter(Document.class::isInstance)
+                            .map(obj -> getMapFromDocument((Document) obj))
+                            .toList();
+
+            responseInfo.put("retrievedDocuments", docsInfo);
+            responseInfo.put("retrievedDocumentsCount", docsInfo.size());
+        }
+    }
+
+    private Map<String, Object> getMapFromDocument(Document doc) {
+        Map<String, Object> docInfo = new HashMap<>();
+        docInfo.put("id", doc.getId());
+        docInfo.put("text", doc.getText());
+        docInfo.put("metadata", doc.getMetadata());
+        docInfo.put("score", doc.getScore());
+        return docInfo;
+    }
+}

--- a/src/main/java/com/jnulocker/ai/application/tools/AnnounceTools.java
+++ b/src/main/java/com/jnulocker/ai/application/tools/AnnounceTools.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnulocker.announce.application.port.in.AnnounceQuery;
 import com.jnulocker.announce.application.port.in.response.AnnounceCustomPage;
+import com.jnulocker.announce.application.port.in.response.AnnounceDetailResponse;
 import com.jnulocker.announce.application.port.in.response.AnnouncePageable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.tool.annotation.Tool;
@@ -25,6 +26,14 @@ public class AnnounceTools {
             throws JsonProcessingException {
         Pageable pageable = new AnnouncePageable(page, null, "desc", null).toPageable();
         AnnounceCustomPage result = announceQuery.getAnnounces(pageable);
+        return objectMapper.writeValueAsString(result);
+    }
+
+    @Tool(description = "특정 공지사항의 상세 내용을 조회합니다. 제목, 내용, 작성자, 작성/수정 시간, 참여 학과 목록을 확인할 수 있습니다.")
+    @AiToolMethod
+    public String getAnnouncementDetail(@ToolParam(description = "공지사항 ID (숫자)") Long announceId)
+            throws JsonProcessingException {
+        AnnounceDetailResponse result = announceQuery.getAnnounce(announceId);
         return objectMapper.writeValueAsString(result);
     }
 }

--- a/src/main/java/com/jnulocker/ai/application/tools/EventTools.java
+++ b/src/main/java/com/jnulocker/ai/application/tools/EventTools.java
@@ -3,12 +3,18 @@ package com.jnulocker.ai.application.tools;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnulocker.events.application.port.in.EventQuery;
+import com.jnulocker.events.application.port.in.response.AvailableLockersResponse;
 import com.jnulocker.events.application.port.in.response.EventCustomPage;
 import com.jnulocker.events.application.port.in.response.EventPageable;
+import com.jnulocker.events.application.port.in.response.EventResponse;
+import com.jnulocker.events.application.port.in.response.LockerSummaryResponse;
 import com.jnulocker.events.application.port.in.response.MyEventCustomPage;
+import com.jnulocker.events.application.port.in.response.PagedLockersResponse;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
@@ -39,6 +45,55 @@ public class EventTools {
             throws JsonProcessingException {
         Pageable pageable = new EventPageable(page, null, null, null).toPageable();
         MyEventCustomPage result = eventQuery.getMyEvents(pageable);
+        return objectMapper.writeValueAsString(result);
+    }
+
+    @Tool(description = "특정 사물함 신청 이벤트의 상세 정보를 조회합니다. 이벤트 제목, 시작/종료 시간, 참여 학과, 층 정보 등을 확인할 수 있습니다.")
+    @AiToolMethod
+    public String getEventDetails(@ToolParam(description = "이벤트 ID (UUID 형식)") UUID eventId)
+            throws JsonProcessingException {
+        EventResponse result = eventQuery.getEvent(eventId);
+        return objectMapper.writeValueAsString(result);
+    }
+
+    @Tool(
+            description =
+                    "특정 이벤트의 사물함 가용 현황 요약 정보를 조회합니다. 전체 사물함 개수, 사용 가능한 사물함 개수, 층별 집계 정보를 제공합니다.")
+    @AiToolMethod
+    public String getLockerSummary(@ToolParam(description = "이벤트 ID (UUID 형식)") UUID eventId)
+            throws JsonProcessingException {
+        LockerSummaryResponse result = eventQuery.getLockerSummary(eventId);
+        return objectMapper.writeValueAsString(result);
+    }
+
+    @Tool(description = "특정 이벤트의 특정 층에 있는 사물함 목록을 조회합니다. 페이지 단위로 조회 가능")
+    @AiToolMethod
+    public String getLockersByFloor(
+            @ToolParam(description = "이벤트 ID (UUID 형식)") UUID eventId,
+            @ToolParam(description = "조회할 층 번호 (예: 1, 2, 3)") Integer floorNumber,
+            @ToolParam(description = "페이지 번호 (0부터 시작, 기본값 0)", required = false) Integer page,
+            @ToolParam(description = "페이지 크기 (기본값 20, 최대 100)", required = false) Integer size)
+            throws JsonProcessingException {
+        int pageNum = page != null ? page : 0;
+        int pageSize = size != null ? Math.min(size, 100) : 20;
+        Pageable pageable = PageRequest.of(pageNum, pageSize);
+
+        PagedLockersResponse result = eventQuery.getLockersByFloor(eventId, floorNumber, pageable);
+        return objectMapper.writeValueAsString(result);
+    }
+
+    @Tool(description = "특정 이벤트에서 현재 신청 가능한 사물함 목록만 조회합니다. 페이지 단위로 조회할 수 있습니다.")
+    @AiToolMethod
+    public String getAvailableLockers(
+            @ToolParam(description = "이벤트 ID (UUID 형식)") UUID eventId,
+            @ToolParam(description = "페이지 번호 (0부터 시작, 기본값 0)", required = false) Integer page,
+            @ToolParam(description = "페이지 크기 (기본값 20, 최대 100)", required = false) Integer size)
+            throws JsonProcessingException {
+        int pageNum = page != null ? page : 0;
+        int pageSize = size != null ? Math.min(size, 100) : 20;
+        Pageable pageable = PageRequest.of(pageNum, pageSize);
+
+        AvailableLockersResponse result = eventQuery.getAvailableLockers(eventId, pageable);
         return objectMapper.writeValueAsString(result);
     }
 }

--- a/src/main/java/com/jnulocker/ai/application/tools/OrganizationTools.java
+++ b/src/main/java/com/jnulocker/ai/application/tools/OrganizationTools.java
@@ -1,0 +1,42 @@
+package com.jnulocker.ai.application.tools;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jnulocker.organization.application.port.in.DepartmentQuery;
+import com.jnulocker.organization.application.port.in.OrganizationQuery;
+import com.jnulocker.organization.application.port.in.response.DepartmentResponse;
+import com.jnulocker.organization.application.port.in.response.OrganizationResponse;
+import com.jnulocker.organization.domain.OrganizationType;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OrganizationTools {
+
+    private final OrganizationQuery organizationQuery;
+    private final DepartmentQuery departmentQuery;
+    private final ObjectMapper objectMapper;
+
+    @Tool(description = "전남대학교의 조직 목록을 조회합니다. COUNCIL(단과대학), COMMITTEE(위원회) 타입으로 구분하여 조회할 수 있습니다.")
+    @AiToolMethod
+    public String searchOrganizations(
+            @ToolParam(description = "조직 타입: COUNCIL 또는 COMMITTEE")
+                    OrganizationType organizationType)
+            throws JsonProcessingException {
+        List<OrganizationResponse> result = organizationQuery.getOrganizations(organizationType);
+        return objectMapper.writeValueAsString(result);
+    }
+
+    @Tool(description = "특정 조직에 속한 학과/학부 목록을 조회합니다.")
+    @AiToolMethod
+    public String searchDepartments(@ToolParam(description = "조직 ID (숫자)") Long organizationId)
+            throws JsonProcessingException {
+        List<DepartmentResponse> result =
+                departmentQuery.getDepartmentsByOrganizationId(organizationId);
+        return objectMapper.writeValueAsString(result);
+    }
+}

--- a/src/main/java/com/jnulocker/ai/application/tools/RegistrationTools.java
+++ b/src/main/java/com/jnulocker/ai/application/tools/RegistrationTools.java
@@ -1,0 +1,60 @@
+package com.jnulocker.ai.application.tools;
+
+import static com.jnulocker.member.domain.Role.*;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jnulocker.member.application.port.in.MemberQuery;
+import com.jnulocker.member.application.port.in.response.MemberInfoResponse;
+import com.jnulocker.registration.application.port.in.RegistrationQuery;
+import com.jnulocker.registration.application.port.in.response.RegistrationCustomPage;
+import com.jnulocker.registration.application.port.in.response.RegistrationPageable;
+import com.jnulocker.registration.application.port.in.response.RegistrationResponse;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RegistrationTools {
+
+    private final RegistrationQuery registrationQuery;
+    private final MemberQuery memberQuery;
+    private final ObjectMapper objectMapper;
+
+    @Tool(description = "특정 이벤트에 대한 나의 사물함 신청 현황을 조회합니다. 신청한 사물함 번호, 위치(층), 신청 ID를 확인할 수 있습니다.")
+    @AiToolMethod
+    public String checkMyRegistration(@ToolParam(description = "이벤트 ID (UUID 형식)") String eventId)
+            throws JsonProcessingException {
+        UUID uuid = UUID.fromString(eventId);
+        RegistrationResponse result = registrationQuery.getMyRegistration(uuid);
+        return objectMapper.writeValueAsString(result);
+    }
+
+    @Tool(
+            description =
+                    "[관리자 전용] 특정 이벤트의 전체 사물함 신청 현황을 조회합니다. 신청자 정보, 신청 시간, 사물함 배정 상태 등을 확인할 수 있습니다.")
+    @AiToolMethod
+    public String getRegistrationList(
+            @ToolParam(description = "이벤트 ID (UUID 형식)") String eventId,
+            @ToolParam(description = "페이지 번호 (0부터 시작, 기본값 0)", required = false) Integer page)
+            throws JsonProcessingException {
+        MemberInfoResponse currentUser = memberQuery.getMemberInfo();
+
+        if (isNotManager(currentUser)) {
+            return "이 기능은 관리자만 사용할 수 있습니다.";
+        }
+
+        UUID eventUUID = UUID.fromString(eventId);
+        Pageable pageable = new RegistrationPageable(page, null, "desc", null).toPageable();
+        RegistrationCustomPage result = registrationQuery.getRegistrations(eventUUID, pageable);
+        return objectMapper.writeValueAsString(result);
+    }
+
+    private boolean isNotManager(MemberInfoResponse currentUser) {
+        return !MANAGER.equals(currentUser.role()) && !ADMIN.equals(currentUser.role());
+    }
+}

--- a/src/main/java/com/jnulocker/config/AiConfig.java
+++ b/src/main/java/com/jnulocker/config/AiConfig.java
@@ -1,8 +1,12 @@
 package com.jnulocker.config;
 
+import com.jnulocker.ai.application.advisor.DetailedLoggingAdvisor;
 import com.jnulocker.ai.application.tools.AnnounceTools;
 import com.jnulocker.ai.application.tools.EventTools;
 import com.jnulocker.ai.application.tools.MemberTools;
+import com.jnulocker.ai.application.tools.OrganizationTools;
+import com.jnulocker.ai.application.tools.RegistrationTools;
+import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.vectorstore.QuestionAnswerAdvisor;
 import org.springframework.ai.vectorstore.SearchRequest;
@@ -13,7 +17,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
 
 @Configuration
+@RequiredArgsConstructor
 public class AiConfig {
+
+    private final DetailedLoggingAdvisor detailedLoggingAdvisor;
 
     @Value("classpath:/prompts/system-template.st")
     private Resource systemTemplate;
@@ -24,7 +31,9 @@ public class AiConfig {
             VectorStore vectorStore,
             EventTools eventTools,
             AnnounceTools announceTools,
-            MemberTools memberTools) {
+            MemberTools memberTools,
+            RegistrationTools registrationTools,
+            OrganizationTools organizationTools) {
         return builder.defaultSystem(systemTemplate)
                 .defaultAdvisors(
                         QuestionAnswerAdvisor.builder(vectorStore)
@@ -33,8 +42,14 @@ public class AiConfig {
                                                 .topK(5) // 상위 5개 유사 문서 검색
                                                 .similarityThreshold(0.5)
                                                 .build())
-                                .build())
-                .defaultTools(eventTools, announceTools, memberTools)
+                                .build(),
+                        detailedLoggingAdvisor)
+                .defaultTools(
+                        eventTools,
+                        announceTools,
+                        memberTools,
+                        registrationTools,
+                        organizationTools)
                 .build();
     }
 }

--- a/src/main/java/com/jnulocker/config/AiConfig.java
+++ b/src/main/java/com/jnulocker/config/AiConfig.java
@@ -19,6 +19,8 @@ import org.springframework.core.io.Resource;
 @Configuration
 @RequiredArgsConstructor
 public class AiConfig {
+    private static final Integer TOP_K = 5;
+    private static final Double SIMILARITY_THRESHOLD = 0.5;
 
     private final DetailedLoggingAdvisor detailedLoggingAdvisor;
 
@@ -39,8 +41,8 @@ public class AiConfig {
                         QuestionAnswerAdvisor.builder(vectorStore)
                                 .searchRequest(
                                         SearchRequest.builder()
-                                                .topK(5) // 상위 5개 유사 문서 검색
-                                                .similarityThreshold(0.5)
+                                                .topK(TOP_K) // 상위 5개 유사 문서 검색
+                                                .similarityThreshold(SIMILARITY_THRESHOLD)
                                                 .build())
                                 .build(),
                         detailedLoggingAdvisor)

--- a/src/main/java/com/jnulocker/events/application/port/in/EventQuery.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/EventQuery.java
@@ -1,10 +1,13 @@
 package com.jnulocker.events.application.port.in;
 
+import com.jnulocker.events.application.port.in.response.AvailableLockersResponse;
 import com.jnulocker.events.application.port.in.response.EventCustomPage;
 import com.jnulocker.events.application.port.in.response.EventResponse;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
+import com.jnulocker.events.application.port.in.response.LockerSummaryResponse;
 import com.jnulocker.events.application.port.in.response.MyEventCustomPage;
 import com.jnulocker.events.application.port.in.response.MyEventResponse;
+import com.jnulocker.events.application.port.in.response.PagedLockersResponse;
 import com.jnulocker.events.domain.Event;
 import com.jnulocker.events.domain.Locker;
 import java.util.List;
@@ -26,4 +29,10 @@ public interface EventQuery {
     EventResponse getEvent(UUID eventId);
 
     MyEventResponse getMyEvent(UUID eventId);
+
+    LockerSummaryResponse getLockerSummary(UUID eventId);
+
+    PagedLockersResponse getLockersByFloor(UUID eventId, Integer floorNumber, Pageable pageable);
+
+    AvailableLockersResponse getAvailableLockers(UUID eventId, Pageable pageable);
 }

--- a/src/main/java/com/jnulocker/events/application/port/in/response/AvailableLockersResponse.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/response/AvailableLockersResponse.java
@@ -1,0 +1,16 @@
+package com.jnulocker.events.application.port.in.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record AvailableLockersResponse(
+        @Schema(description = "사용 가능한 사물함 목록 (층 정보 포함)") List<LockerWithFloorInfo> lockers,
+        @Schema(description = "현재 페이지 번호", example = "0") int currentPage,
+        @Schema(description = "전체 페이지 수", example = "3") int totalPages,
+        @Schema(description = "전체 사용 가능한 사물함 개수", example = "45") int totalElements) {
+
+    public static AvailableLockersResponse of(
+            List<LockerWithFloorInfo> lockers, int currentPage, int totalPages, int totalElements) {
+        return new AvailableLockersResponse(lockers, currentPage, totalPages, totalElements);
+    }
+}

--- a/src/main/java/com/jnulocker/events/application/port/in/response/FloorSummary.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/response/FloorSummary.java
@@ -1,0 +1,13 @@
+package com.jnulocker.events.application.port.in.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record FloorSummary(
+        @Schema(description = "층 번호", example = "3") int floorNumber,
+        @Schema(description = "해당 층의 전체 사물함 개수", example = "50") int totalLockers,
+        @Schema(description = "해당 층의 사용 가능한 사물함 개수", example = "15") int availableLockers) {
+
+    public static FloorSummary of(int floorNumber, int totalLockers, int availableLockers) {
+        return new FloorSummary(floorNumber, totalLockers, availableLockers);
+    }
+}

--- a/src/main/java/com/jnulocker/events/application/port/in/response/LockerSummaryResponse.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/response/LockerSummaryResponse.java
@@ -1,0 +1,15 @@
+package com.jnulocker.events.application.port.in.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record LockerSummaryResponse(
+        @Schema(description = "전체 사물함 개수", example = "150") int totalLockers,
+        @Schema(description = "사용 가능한 사물함 개수", example = "45") int availableLockers,
+        @Schema(description = "층별 사물함 집계 정보") List<FloorSummary> floors) {
+
+    public static LockerSummaryResponse of(
+            int totalLockers, int availableLockers, List<FloorSummary> floors) {
+        return new LockerSummaryResponse(totalLockers, availableLockers, floors);
+    }
+}

--- a/src/main/java/com/jnulocker/events/application/port/in/response/LockerWithFloorInfo.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/response/LockerWithFloorInfo.java
@@ -1,0 +1,15 @@
+package com.jnulocker.events.application.port.in.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+
+public record LockerWithFloorInfo(
+        @Schema(description = "사물함 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+                UUID lockerId,
+        @Schema(description = "사물함 코드", example = "A301") String code,
+        @Schema(description = "층 번호", example = "3") Integer floorNumber) {
+
+    public static LockerWithFloorInfo of(UUID lockerId, String code, Integer floorNumber) {
+        return new LockerWithFloorInfo(lockerId, code, floorNumber);
+    }
+}

--- a/src/main/java/com/jnulocker/events/application/port/in/response/PagedLockersResponse.java
+++ b/src/main/java/com/jnulocker/events/application/port/in/response/PagedLockersResponse.java
@@ -1,0 +1,21 @@
+package com.jnulocker.events.application.port.in.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record PagedLockersResponse(
+        @Schema(description = "사물함 목록") List<LockerResponse> lockers,
+        @Schema(description = "현재 페이지 번호", example = "0") int currentPage,
+        @Schema(description = "전체 페이지 수", example = "5") int totalPages,
+        @Schema(description = "전체 사물함 개수", example = "100") int totalElements,
+        @Schema(description = "층 정보", example = "3층") String floorInfo) {
+
+    public static PagedLockersResponse of(
+            List<LockerResponse> lockers,
+            int currentPage,
+            int totalPages,
+            int totalElements,
+            String floorInfo) {
+        return new PagedLockersResponse(lockers, currentPage, totalPages, totalElements, floorInfo);
+    }
+}

--- a/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
+++ b/src/main/java/com/jnulocker/events/application/service/EventQueryService.java
@@ -5,11 +5,17 @@ import static com.jnulocker.events.infrastructure.mapper.LockerMapper.*;
 import com.jnulocker.auth.security.SecurityUtils;
 import com.jnulocker.events.application.port.in.EventQuery;
 import com.jnulocker.events.application.port.in.request.FloorInfo;
+import com.jnulocker.events.application.port.in.response.AvailableLockersResponse;
 import com.jnulocker.events.application.port.in.response.EventCustomPage;
 import com.jnulocker.events.application.port.in.response.EventResponse;
+import com.jnulocker.events.application.port.in.response.FloorSummary;
 import com.jnulocker.events.application.port.in.response.FloorWithLockersResponse;
+import com.jnulocker.events.application.port.in.response.LockerResponse;
+import com.jnulocker.events.application.port.in.response.LockerSummaryResponse;
+import com.jnulocker.events.application.port.in.response.LockerWithFloorInfo;
 import com.jnulocker.events.application.port.in.response.MyEventCustomPage;
 import com.jnulocker.events.application.port.in.response.MyEventResponse;
+import com.jnulocker.events.application.port.in.response.PagedLockersResponse;
 import com.jnulocker.events.application.port.out.EventLoadPort;
 import com.jnulocker.events.application.port.out.FloorLoadPort;
 import com.jnulocker.events.application.port.out.LockerLoadPort;
@@ -139,5 +145,91 @@ public class EventQueryService implements EventQuery {
         List<Locker> lockersForFloor =
                 lockersByFloorId.getOrDefault(floor.getId(), List.of()).stream().sorted().toList();
         return FloorWithLockersResponse.of(floor, lockersForFloor);
+    }
+
+    @Override
+    public LockerSummaryResponse getLockerSummary(UUID eventId) {
+        List<FloorWithLockersResponse> floors = getLockersByEventId(eventId);
+
+        int totalLockers = 0;
+        int availableLockers = 0;
+        List<FloorSummary> floorSummaries = new ArrayList<>();
+
+        for (FloorWithLockersResponse floor : floors) {
+            int floorTotal = floor.lockers().size();
+            long floorAvailable =
+                    floor.lockers().stream().filter(LockerResponse::available).count();
+
+            totalLockers += floorTotal;
+            availableLockers += (int) floorAvailable;
+
+            floorSummaries.add(
+                    FloorSummary.of(floor.floorNumber(), floorTotal, (int) floorAvailable));
+        }
+
+        return LockerSummaryResponse.of(totalLockers, availableLockers, floorSummaries);
+    }
+
+    @Override
+    public PagedLockersResponse getLockersByFloor(
+            UUID eventId, Integer floorNumber, Pageable pageable) {
+        List<FloorWithLockersResponse> floors = getLockersByEventId(eventId);
+
+        FloorWithLockersResponse targetFloor =
+                floors.stream()
+                        .filter(f -> f.floorNumber().equals(floorNumber))
+                        .findFirst()
+                        .orElse(null);
+
+        if (targetFloor == null) {
+            return PagedLockersResponse.of(List.of(), 0, 0, 0, "해당 층을 찾을 수 없습니다: " + floorNumber);
+        }
+
+        List<LockerResponse> allLockers = targetFloor.lockers();
+        int pageNum = pageable.getPageNumber();
+        int pageSize = pageable.getPageSize();
+
+        int totalElements = allLockers.size();
+        int totalPages = (int) Math.ceil((double) totalElements / pageSize);
+        int start = pageNum * pageSize;
+        int end = Math.min(start + pageSize, totalElements);
+
+        List<LockerResponse> pagedLockers =
+                start < totalElements ? allLockers.subList(start, end) : List.of();
+
+        return PagedLockersResponse.of(
+                pagedLockers, pageNum, totalPages, totalElements, floorNumber + "층");
+    }
+
+    @Override
+    public AvailableLockersResponse getAvailableLockers(UUID eventId, Pageable pageable) {
+        List<FloorWithLockersResponse> floors = getLockersByEventId(eventId);
+
+        List<LockerWithFloorInfo> availableLockers =
+                floors.stream()
+                        .flatMap(
+                                floor ->
+                                        floor.lockers().stream()
+                                                .filter(LockerResponse::available)
+                                                .map(
+                                                        locker ->
+                                                                LockerWithFloorInfo.of(
+                                                                        locker.lockerId(),
+                                                                        locker.code(),
+                                                                        floor.floorNumber())))
+                        .toList();
+
+        int pageNum = pageable.getPageNumber();
+        int pageSize = pageable.getPageSize();
+
+        int totalElements = availableLockers.size();
+        int totalPages = (int) Math.ceil((double) totalElements / pageSize);
+        int start = pageNum * pageSize;
+        int end = Math.min(start + pageSize, totalElements);
+
+        List<LockerWithFloorInfo> pagedLockers =
+                start < totalElements ? availableLockers.subList(start, end) : List.of();
+
+        return AvailableLockersResponse.of(pagedLockers, pageNum, totalPages, totalElements);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,10 +41,12 @@ spring:
       chat:
         options:
           model: ${OPENAI_MODEL}
+          temperature: ${OPENAI_TEMPERATURE:0.2}
     vectorstore:
       pgvector:
         table-name: ${PGVECTOR_TABLE_NAME}
         initialize-schema: true
+        dimensions: ${PGVECTOR_DIMENSIONS:1536}
 
   servlet:
     multipart:
@@ -69,7 +71,8 @@ management:
 
 logging:
   level:
-    root: ${LOGGING_LEVEL}  # TRACE < DEBUG < INFO < WARN < ERROR < FATAL < OFF
+    root: ${LOGGING_LEVEL:WARN}  # TRACE < DEBUG < INFO < WARN < ERROR < FATAL < OFF
+    com.jnulocker.ai.application.advisor: ${LOGGING_LEVEL_ADVISOR:INFO}
 
   file:
     name: ${LOGGING_DIR}/${LOGGING_FILE}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -6,6 +6,11 @@ spring:
     url: jdbc:tc:pgvector:pg18:///test-database
     driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
 
+  jpa:
+    properties:
+      hibernate:
+        default_schema: public # Testcontainers의 임시 DB를 사용하므로 스키마를 public으로 설정
+
   sql:
     init:
       mode: never


### PR DESCRIPTION
### 개요
close #171 

### 작업사항

[Event]
- 이벤트 상세 정보 조회
- 신청 가능한 사물함 조회

[Registration]
- 내 신청 현황 조회
- 전체 신청 현황 조회 [관리자]

[Organization]
- 조직(단과대, 위원회) 목록 조회
- 학과 목록 조회

[Announce]
- 공지사항 상세 정보 조회

[로깅 설정]
- ChatClient 요청 및 응답 로깅
  - 요청: system 및 user 메시지
  - 응답: 토큰 사용량, RAG 문서 검색 결과 등

### 변경로직
- [x] 상세 조회 Tools 구현
- [x] 로깅 Advisor 구현
- [x] ChatClient에 Tool, Advisor 등록

### 테스트 결과
<img width="315" height="400" alt="image" src="https://github.com/user-attachments/assets/ce7c7b89-a5fe-4a95-9193-b2d6b62eba6d" />

### reference
- [Spring AI Advisors](https://docs.spring.io/spring-ai/reference/api/advisors.html)

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * AI 챗봇의 상세 디버그 로깅 활성화
  * 공지사항 상세 조회, 조직/부서 검색, 등록자 조회 도구 추가
  * 이벤트 라커 정보 조회 기능 확장(전체 요약, 층별 페이징, 이용 가능 라커)

* **설정 개선**
  * AI 모델 온도 기본값 추가(기본 0.2)
  * 벡터 저장소 차원 기본값 추가(기본 1536)
  * 로깅 기본 레벨 및 어드바이저 로깅 설정 추가

* **테스트 설정**
  * 테스트 DB 스키마 기본 설정 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->