### PR TITLE
[TEST] 외부 의존성 모킹을 통한 통합 테스트 성능 개선

### DIFF
--- a/src/test/java/com/jnulocker/config/RedisTest.java
+++ b/src/test/java/com/jnulocker/config/RedisTest.java
@@ -1,11 +1,15 @@
 package com.jnulocker.config;
 
+import com.jnulocker.auth.application.port.out.ManagerEmailSender;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
 @ActiveProfiles("test")
 @Import({RedisTestConfig.class, TestVectorStoreConfig.class})
 public abstract class RedisTest extends RedisTestContainer {
+
+    @MockitoBean protected ManagerEmailSender managerEmailSender;
 }

--- a/src/test/java/com/jnulocker/config/RedisTest.java
+++ b/src/test/java/com/jnulocker/config/RedisTest.java
@@ -6,5 +6,6 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("test")
-@Import(RedisTestConfig.class)
-public abstract class RedisTest extends RedisTestContainer {}
+@Import({RedisTestConfig.class, TestVectorStoreConfig.class})
+public abstract class RedisTest extends RedisTestContainer {
+}

--- a/src/test/java/com/jnulocker/config/RedisTestContainer.java
+++ b/src/test/java/com/jnulocker/config/RedisTestContainer.java
@@ -3,10 +3,8 @@ package com.jnulocker.config;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
-@Testcontainers
 public abstract class RedisTestContainer {
 
     private static final int REDIS_PORT = 6379;
@@ -16,8 +14,7 @@ public abstract class RedisTestContainer {
     static {
         REDIS_CONTAINER =
                 new GenericContainer<>(DockerImageName.parse(REDIS_IMAGE))
-                        .withExposedPorts(REDIS_PORT)
-                        .withReuse(true);
+                        .withExposedPorts(REDIS_PORT);
         REDIS_CONTAINER.start();
     }
 

--- a/src/test/java/com/jnulocker/config/TestEmbeddingModel.java
+++ b/src/test/java/com/jnulocker/config/TestEmbeddingModel.java
@@ -1,0 +1,55 @@
+package com.jnulocker.config;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.embedding.AbstractEmbeddingModel;
+import org.springframework.ai.embedding.Embedding;
+import org.springframework.ai.embedding.EmbeddingRequest;
+import org.springframework.ai.embedding.EmbeddingResponse;
+import org.springframework.ai.embedding.EmbeddingResponseMetadata;
+import org.springframework.lang.NonNull;
+
+/** 테스트용 EmbeddingModel */
+public class TestEmbeddingModel extends AbstractEmbeddingModel {
+
+    private final int dimensions;
+
+    public TestEmbeddingModel(int dimensions) {
+        this.dimensions = dimensions;
+    }
+
+    @Override
+    public EmbeddingResponse call(EmbeddingRequest request) {
+        List<String> instructions = request.getInstructions();
+        List<Embedding> embeddings = new ArrayList<>(instructions.size());
+
+        for (int i = 0; i < instructions.size(); i++) {
+            float[] vector = generateDummyVector();
+            embeddings.add(new Embedding(vector, i));
+        }
+
+        return new EmbeddingResponse(embeddings, createMetadata());
+    }
+
+    @Override
+    public float[] embed(@NonNull Document document) {
+        return generateDummyVector();
+    }
+
+    @Override
+    public int dimensions() {
+        return dimensions;
+    }
+
+    private float[] generateDummyVector() {
+        float[] vector = new float[dimensions];
+        Arrays.fill(vector, 0.0f);
+        return vector;
+    }
+
+    private EmbeddingResponseMetadata createMetadata() {
+        return new EmbeddingResponseMetadata("test-model", null);
+    }
+}

--- a/src/test/java/com/jnulocker/config/TestVectorStoreConfig.java
+++ b/src/test/java/com/jnulocker/config/TestVectorStoreConfig.java
@@ -1,21 +1,15 @@
 package com.jnulocker.config;
 
-import com.jnulocker.ai.infrastructure.embedding.HuggingFaceEmbeddingModel;
-import lombok.RequiredArgsConstructor;
+import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.vectorstore.VectorStore;
 import org.springframework.ai.vectorstore.pgvector.PgVectorStore;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.core.JdbcTemplate;
 
-@Configuration
-@Profile("!test")
-@RequiredArgsConstructor
-public class VectorStoreConfig {
-
-    private final HuggingFaceEmbeddingModel embeddingModel;
+@TestConfiguration
+public class TestVectorStoreConfig {
 
     @Value("${spring.ai.vectorstore.pgvector.table-name}")
     private String tableName;
@@ -27,7 +21,12 @@ public class VectorStoreConfig {
     private boolean initializeSchema;
 
     @Bean
-    public VectorStore vectorStore(JdbcTemplate jdbcTemplate) {
+    public EmbeddingModel embeddingModel() {
+        return new TestEmbeddingModel(dimensions);
+    }
+
+    @Bean
+    public VectorStore vectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel) {
         return PgVectorStore.builder(jdbcTemplate, embeddingModel)
                 .vectorTableName(tableName)
                 .dimensions(dimensions)


### PR DESCRIPTION
### 개요
close #177 

### 작업사항
- 통합 테스트 실행 시간을 단축하기 위해 외부 의존성(SMTP, HuggingFace API)을 Mock 처리
- Redis TestContainer가 계속 생성되고 종료되지 않는 이슈가 있어 `reuse` 옵션 제거

### 변경로직

#### 이메일 발송 Mock 처리

- RedisTest에 @MockitoBean ManagerEmailSender 추가
- MANAGER 승인 테스트 4초 → 0.2초

  <img width="288" height="22" alt="image" src="https://github.com/user-attachments/assets/f6baf3ca-7613-428b-91e2-d97da869c4f2" />

  <img width="288" height="22" alt="image" src="https://github.com/user-attachments/assets/fd207dad-718c-4a24-ae48-3e118e3c530e" />


#### 임베딩 생성 Mock 처리

- TestEmbeddingModel: Fake 구현체로 HuggingFace API 호출 제거
- AI 문서 업로드 테스트 13초 → 0.3초

  <img width="288" height="22" alt="image" src="https://github.com/user-attachments/assets/e6696571-d90a-4382-8a1c-de2d3b641ef2" />

  <img width="288" height="22" alt="image" src="https://github.com/user-attachments/assets/2fc4a5b9-f6cc-449c-9a6c-19e62a4297f3" />


#### 프로파일 기반 설정 분리

- VectorStoreConfig: `@Profile("!test")` 추가
- TestVectorStoreConfig: 테스트 전용 설정
- 빈 충돌 방지 및 환경 분리

### 테스트 결과

- 변경 전: **43초** -> 변경 후: **13초**

  <img width="285" height="403" alt="image" src="https://github.com/user-attachments/assets/35394577-5c7f-4e95-94f6-634a9d10062b" />  <img width="285" height="403" alt="image" src="https://github.com/user-attachments/assets/484d8fce-349b-4e1b-9fba-164c60c7563e" />


### reference

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 테스트 환경 격리 및 인프라 개선을 통해 테스트 안정성 강화
  * 테스트 설정 및 구성 업데이트로 개발 환경 최적화

---

**참고**: 이번 업데이트는 내부 테스트 인프라 개선으로, 최종 사용자에게 보이는 기능 변화는 없습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->