### PR TITLE
[FEAT] 사물함 & 이메일 unique key 설정 및 회원가입 분산락 적용

### DIFF
--- a/src/main/java/com/jnulocker/auth/application/service/AuthCommandService.java
+++ b/src/main/java/com/jnulocker/auth/application/service/AuthCommandService.java
@@ -19,6 +19,7 @@ import com.jnulocker.auth.exception.UserAlreadyExistException;
 import com.jnulocker.auth.jwt.TokenProvider;
 import com.jnulocker.auth.jwt.exception.JwtException;
 import com.jnulocker.auth.security.SecurityUtils;
+import com.jnulocker.common.util.RedisLockManager;
 import com.jnulocker.common.util.RedisUtil;
 import com.jnulocker.member.application.port.in.MemberCommand;
 import com.jnulocker.member.application.port.in.MemberQuery;
@@ -54,28 +55,34 @@ public class AuthCommandService
     private final TokenRepository tokenRepository;
     private final RegistrationCommand registrationCommand;
     private final ApplicationEventPublisher eventPublisher;
+    private final RedisLockManager redisLockManager;
 
     @Override
-    @Transactional
     public void signupUser(UserSignupRequest request) {
         redisUtil.checkEmailVerified(request.email());
 
-        validateDuplicateEmail(request.email());
+        redisLockManager.lock(
+                request.email(),
+                5L,
+                () -> {
+                    validateDuplicateEmail(request.email());
 
-        String encodedPassword = passwordEncoder.encode(request.password());
+                    String encodedPassword = passwordEncoder.encode(request.password());
 
-        Department department = departmentQuery.getDepartmentByIdOrThrow(request.departmentId());
+                    Department department =
+                            departmentQuery.getDepartmentByIdOrThrow(request.departmentId());
 
-        Member member =
-                Member.createUser(
-                        request.name(),
-                        request.email(),
-                        encodedPassword,
-                        request.phoneNumber(),
-                        request.studentNumber(),
-                        department);
+                    Member member =
+                            Member.createUser(
+                                    request.name(),
+                                    request.email(),
+                                    encodedPassword,
+                                    request.phoneNumber(),
+                                    request.studentNumber(),
+                                    department);
 
-        memberCommand.save(member);
+                    memberCommand.save(member);
+                });
     }
 
     @Override
@@ -83,22 +90,28 @@ public class AuthCommandService
     public void signupManager(ManagerSignupRequest request) {
         redisUtil.checkEmailVerified(request.email());
 
-        validateDuplicateEmail(request.email());
+        redisLockManager.lock(
+                request.email(),
+                5L,
+                () -> {
+                    validateDuplicateEmail(request.email());
 
-        String encodedPassword = passwordEncoder.encode(request.password());
+                    String encodedPassword = passwordEncoder.encode(request.password());
 
-        Department department = departmentQuery.getDepartmentByIdOrThrow(request.departmentId());
+                    Department department =
+                            departmentQuery.getDepartmentByIdOrThrow(request.departmentId());
 
-        Member member =
-                Member.createManager(
-                        request.name(),
-                        request.email(),
-                        encodedPassword,
-                        request.phoneNumber(),
-                        request.studentNumber(),
-                        department);
+                    Member member =
+                            Member.createManager(
+                                    request.name(),
+                                    request.email(),
+                                    encodedPassword,
+                                    request.phoneNumber(),
+                                    request.studentNumber(),
+                                    department);
 
-        memberCommand.save(member);
+                    memberCommand.save(member);
+                });
     }
 
     @Override

--- a/src/main/java/com/jnulocker/auth/application/service/AuthCommandService.java
+++ b/src/main/java/com/jnulocker/auth/application/service/AuthCommandService.java
@@ -63,7 +63,6 @@ public class AuthCommandService
 
         redisLockManager.lock(
                 request.email(),
-                5L,
                 () -> {
                     validateDuplicateEmail(request.email());
 
@@ -91,7 +90,6 @@ public class AuthCommandService
 
         redisLockManager.lock(
                 request.email(),
-                5L,
                 () -> {
                     validateDuplicateEmail(request.email());
 

--- a/src/main/java/com/jnulocker/auth/application/service/AuthCommandService.java
+++ b/src/main/java/com/jnulocker/auth/application/service/AuthCommandService.java
@@ -86,7 +86,6 @@ public class AuthCommandService
     }
 
     @Override
-    @Transactional
     public void signupManager(ManagerSignupRequest request) {
         redisUtil.checkEmailVerified(request.email());
 

--- a/src/main/java/com/jnulocker/common/util/RedisLockManager.java
+++ b/src/main/java/com/jnulocker/common/util/RedisLockManager.java
@@ -3,7 +3,6 @@ package com.jnulocker.common.util;
 import com.jnulocker.common.exception.LockAcquisitionFailedException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
@@ -11,16 +10,25 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
 @Slf4j
 public class RedisLockManager {
 
-    @Value("${custom.lock.default-wait-second:5}")
     private final Long defaultWaitSecond;
 
     private final RedissonClient redissonClient;
     private final TransactionForSupplier transactionForSupplier;
     private final TransactionForRunnable transactionForRunnable;
+
+    public RedisLockManager(
+            @Value("${custom.lock.default-wait-second:5}") Long defaultWaitSecond,
+            RedissonClient redissonClient,
+            TransactionForSupplier transactionForSupplier,
+            TransactionForRunnable transactionForRunnable) {
+        this.defaultWaitSecond = defaultWaitSecond;
+        this.redissonClient = redissonClient;
+        this.transactionForSupplier = transactionForSupplier;
+        this.transactionForRunnable = transactionForRunnable;
+    }
 
     // 반환값이 있는 경우: Supplier<T> 사용
     public <T> T lock(String key, Long waitSecond, Supplier<T> supplier) {

--- a/src/main/java/com/jnulocker/common/util/RedisLockManager.java
+++ b/src/main/java/com/jnulocker/common/util/RedisLockManager.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 public class RedisLockManager {
 
     @Value("${custom.lock.default-wait-second:5}")
-    private Long defaultWaitSecond;
+    private final Long defaultWaitSecond;
 
     private final RedissonClient redissonClient;
     private final TransactionForSupplier transactionForSupplier;

--- a/src/main/java/com/jnulocker/common/util/RedisLockManager.java
+++ b/src/main/java/com/jnulocker/common/util/RedisLockManager.java
@@ -7,12 +7,16 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class RedisLockManager {
+
+    @Value("${custom.lock.default-wait-second:5}")
+    private Long defaultWaitSecond;
 
     private final RedissonClient redissonClient;
     private final TransactionForSupplier transactionForSupplier;
@@ -33,6 +37,10 @@ public class RedisLockManager {
                 lock.unlock();
             }
         }
+    }
+
+    public void lock(String key, Runnable runnable) {
+        lock(key, defaultWaitSecond, runnable);
     }
 
     // 반환값이 없는 경우: Runnable 사용

--- a/src/main/java/com/jnulocker/member/domain/Member.java
+++ b/src/main/java/com/jnulocker/member/domain/Member.java
@@ -36,7 +36,7 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String email;
 
     @Column(nullable = false)

--- a/src/main/java/com/jnulocker/registration/application/service/RegistrationCommandService.java
+++ b/src/main/java/com/jnulocker/registration/application/service/RegistrationCommandService.java
@@ -38,7 +38,6 @@ public class RegistrationCommandService implements RegistrationCommand {
 
         redisLockManager.lock(
                 lockerId.toString(),
-                5L,
                 () -> {
                     Member member = memberQuery.findByIdOrThrow(memberId);
 

--- a/src/main/java/com/jnulocker/registration/application/service/RegistrationCommandService.java
+++ b/src/main/java/com/jnulocker/registration/application/service/RegistrationCommandService.java
@@ -32,7 +32,6 @@ public class RegistrationCommandService implements RegistrationCommand {
     private final RedisLockManager redisLockManager;
 
     @Override
-    @Transactional
     public void registerForEvent(UUID eventId, RegisterForEventRequest request) {
         Long memberId = SecurityUtils.getCurrentMemberId();
         UUID lockerId = request.lockerId();

--- a/src/main/java/com/jnulocker/registration/domain/Registration.java
+++ b/src/main/java/com/jnulocker/registration/domain/Registration.java
@@ -36,7 +36,7 @@ public class Registration extends BaseEntity {
     private Member member;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "locker_id")
+    @JoinColumn(name = "locker_id", unique = true)
     private Locker locker;
 
     public static Registration create(Member member, Locker locker) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -115,6 +115,7 @@ custom:
   lock:
     watchdog:
       timeout: ${LOCK_WATCHDOG_TIMEOUT:30000} # Watchdog 타임아웃 (밀리초, 기본: 30초)
+    default-wait-second: ${LOCK_DEFAULT_WAIT_SECOND:5}
 
 email:
   sender: ${EMAIL_SENDER}

--- a/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
+++ b/src/test/java/com/jnulocker/registration/adapter/in/RegistrationControllerIntegrationTest.java
@@ -127,7 +127,6 @@ public class RegistrationControllerIntegrationTest extends RedisTest {
         assertThat(memberInfo.studentNumber()).isEqualTo("221965");
         assertThat(memberInfo.organization()).isEqualTo("테스트 조직명");
         assertThat(memberInfo.department()).isEqualTo("테스트 학과명");
-        assertThat(memberInfo.email()).isEqualTo("test@email.com");
     }
 
     @Test

--- a/src/testFixtures/java/member/domain/MemberTestDataBuilder.java
+++ b/src/testFixtures/java/member/domain/MemberTestDataBuilder.java
@@ -4,11 +4,12 @@ import static organization.domain.DepartmentTestDataBuilder.departmentBuilder;
 
 import com.jnulocker.member.domain.Member;
 import com.jnulocker.organization.domain.Department;
+import java.util.UUID;
 
 public class MemberTestDataBuilder {
 
     private String name = "테스트 이름";
-    private String email = "test@email.com";
+    private String email = UUID.randomUUID() + "@test.com";
     private String phoneNumber = "010-1234-5678";
     private String password = "password123";
     private String studentNumber = "221965";


### PR DESCRIPTION
### 개요
close #179 

### 작업사항
- `Registration` 엔티티에 Locker에 대하여 unique 설정
- `Member` 엔티티의 email에 대하여 unique 설정
- 회원가입 시 분산락 적용 

### 변경로직
- 태스트코드에서 유저 생성 시 `UUID.randomUUID() + "@test.com"`로 email이 생성되도록 했습니다. 
- 기존에 락 밖에 있던 불필요한 `@Transcational` 제거했습니다.

### 테스트 결과
<img width="300" height="540" alt="image" src="https://github.com/user-attachments/assets/928f02c4-9993-4310-aa5a-815795b567bc" />


### reference
- 머지되면 개발서버 db에 unique 제약 조건 추가하겠습니다. 

### 체크리스트
- [x] assignees 설정
- [x] reviewers 설정
- [x] label 설정
- [x] 브랜치 방향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 분산 잠금을 도입해 동시성으로 인한 중복 가입/등록 문제 방지

* **New Features**
  * 이메일에 대한 DB 유니크 제약 추가로 중복 등록 차단
  * 락 기본 대기시간 설정 옵션 추가 및 락 호출 간소화

* **Behavioral**
  * 가입·이벤트 등록 흐름에 락 적용으로 무결성과 일관성 강화
  * 일부 트랜잭션 경계가 변경되어 처리 방식이 조정됨

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->